### PR TITLE
[WIP] Only echo diagnostic for the current buffer

### DIFF
--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -87,9 +87,10 @@ class DiagnosticInterface( object ):
 
 
   def _EchoDiagnostic( self ):
-    line, _ = vimsupport.CurrentLineAndColumn()
-    line += 1  # Convert to 1-based
-    self._EchoDiagnosticForLine( line )
+    if self._bufnr == vimsupport.GetCurrentBufferNumber():
+      line, _ = vimsupport.CurrentLineAndColumn()
+      line += 1  # Convert to 1-based
+      self._EchoDiagnosticForLine( line )
 
 
   def _EchoDiagnosticForLine( self, line_num ):

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -913,18 +913,18 @@ def YouCompleteMe_AsyncDiagnosticUpdate_PerFile_test( ycm,
         'text': 'error text in a buffer open in a separate window',
         'location': {
           'filepath': '/separate_window',
-          'line_num': 3,
+          'line_num': 1,
           'column_num': 3
         },
         'location_extent': {
           'start': {
             'filepath': '/separate_window',
-            'line_num': 3,
+            'line_num': 1,
             'column_num': 3,
           },
           'end': {
             'filepath': '/separate_window',
-            'line_num': 3,
+            'line_num': 1,
             'column_num': 3,
           }
         },
@@ -1035,7 +1035,7 @@ def YouCompleteMe_AsyncDiagnosticUpdate_PerFile_test( ycm,
 
     call( 3, [
       {
-        'lnum': 3,
+        'lnum': 1,
         'col': 3,
         'bufnr': 3,
         'valid': 1,
@@ -1052,7 +1052,7 @@ def YouCompleteMe_AsyncDiagnosticUpdate_PerFile_test( ycm,
         VimMatch( 'YcmErrorSection', '\%1l\%1c\_.\{-}\%1l\%1c' )
       ),
       3: contains(
-        VimMatch( 'YcmErrorSection', '\%3l\%3c\_.\{-}\%3l\%3c' )
+        VimMatch( 'YcmErrorSection', '\%1l\%3c\_.\{-}\%1l\%3c' )
       )
     } )
   )


### PR DESCRIPTION
Since diagnostics can be updated for any buffer (through [the `UpdateWithNewDiagnosticsForFile` method](https://github.com/Valloric/YouCompleteMe/blob/e1ead995c13fe20989ee3d69fd76b20c5fff5d5b/python/ycm/youcompleteme.py#L384)), we need to check that the buffer is the current one when echoing a diagnostic for the current line.

Updated the `YouCompleteMe_AsyncDiagnosticUpdate_PerFile` test to make it fail without the change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3058)
<!-- Reviewable:end -->
