### PR TITLE
[WIP] Introduce mods= argument to YcmCompleter command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,6 +1505,16 @@ This command gives access to a number of additional [IDE-like
 features](#quick-feature-summary) in YCM, for things like semantic GoTo, type
 information, FixIt and refactoring.
 
+Command modifiers are supported (see `:h mods`). They currently only affect how
+the new window is split when using [the `GoTo` commands](#goto-commands). These
+modifiers can also be specified through the `mods=` argument as a
+comma-separated list e.g.:
+```viml
+:YcmCompleter mods=rightbelow,vertical GoTo
+```
+This is useful for versions of Vim that don't support command modifiers (older
+than 7.4.1898).
+
 This command accepts a range that can either be specified through a selection in
 one of Vim's visual modes (see `:h visual-use`) or on the command line. For
 instance, `:2,5YcmCompleter` will apply the command from line 2 to line 5. This
@@ -2805,20 +2815,21 @@ let g:ycm_use_ultisnips_completer = 1
 
 ### The `g:ycm_goto_buffer_command` option
 
-Defines where `GoTo*` commands result should be opened. Can take one of the
-following values: `'same-buffer'`, `'split'`, or `'split-or-existing-window'`.
-If this option is set to the `'same-buffer'` but current buffer can not be
-switched (when buffer is modified and `nohidden` option is set), then result
-will be opened in a split. When the option is set to
+Defines where [the `GoTo` commands](#goto-commands) result should be opened. Can
+take one of the following values: `'same-buffer'`, `'split'`, or
+`'split-or-existing-window'`.  If this option is set to the `'same-buffer'` but
+current buffer can not be switched (when buffer is modified and `nohidden`
+option is set), then result will be opened in a split. When the option is set to
 `'split-or-existing-window'`, if the result is already open in a window of the
 current tab page (or any tab pages with the `:tab` modifier; see below), it will
 jump to that window. Otherwise, the result will be opened in a split as if the
 option was set to `'split'`.
 
-To customize the way a new window is split, prefix the `GoTo*` command with one
-of the following modifiers: `:aboveleft`, `:belowright`, `:botright`,
-`:leftabove`, `:rightbelow`, `:topleft`, and `:vertical`. For instance, to
-split vertically to the right of the current window, run the command:
+To customize the way a new window is split, prefix [the `GoTo`
+command](#goto-commands) with one of the following modifiers: `:aboveleft`,
+`:belowright`, `:botright`, `:leftabove`, `:rightbelow`, `:topleft`, and
+`:vertical`. For instance, to split vertically to the right of the current
+window, run the command:
 ```viml
 :rightbelow vertical YcmCompleter GoTo
 ```
@@ -2829,9 +2840,13 @@ To open in a new tab page, use the `:tab` modifier with the `'split'` or
 :tab YcmCompleter GoTo
 ```
 
-**NOTE:** command modifiers were added in Vim 7.4.1898. If you are using an
-older version, you can still configure this by setting the option to one of the
-deprecated values: `'vertical-split'`, `'new-tab'`, or `'new-or-existing-tab'`.
+These modifiers can also be specified through the `mods=` arguments as a
+comma-separated list. For instance:
+```viml
+:YcmCompleter mods=rightbelow,vertical GoTo
+```
+This is useful for versions of Vim that don't support command modifiers (older
+than 7.4.1898).
 
 Default: `'same-buffer'`
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1744,6 +1744,15 @@ The *:YcmCompleter* command
 This command gives access to a number of additional IDE-like features in YCM,
 for things like semantic GoTo, type information, FixIt and refactoring.
 
+Command modifiers are supported (see ':h mods'). They currently only affect how
+the new window is split when using the |GoTo| commands. These modifiers can
+also be specified through the 'mods=' argument as a comma-separated list e.g.:
+>
+  :YcmCompleter mods=rightbelow,vertical GoTo
+<
+This is useful for versions of Vim that don't support command modifiers (older
+than 7.4.1898).
+
 This command accepts a range that can either be specified through a selection
 in one of Vim's visual modes (see ':h visual-use') or on the command line. For
 instance, ':2,5YcmCompleter' will apply the command from line 2 to line 5. This
@@ -3020,7 +3029,7 @@ Default: '1'
 -------------------------------------------------------------------------------
 The *g:ycm_goto_buffer_command* option
 
-Defines where 'GoTo*' commands result should be opened. Can take one of the
+Defines where the |GoTo| commands result should be opened. Can take one of the
 following values: "'same-buffer'", "'split'", or "'split-or-existing-window'".
 If this option is set to the "'same-buffer'" but current buffer can not be
 switched (when buffer is modified and 'nohidden' option is set), then result
@@ -3030,7 +3039,7 @@ any tab pages with the ':tab' modifier; see below), it will jump to that
 window. Otherwise, the result will be opened in a split as if the option was
 set to "'split'".
 
-To customize the way a new window is split, prefix the 'GoTo*' command with one
+To customize the way a new window is split, prefix the |GoTo| command with one
 of the following modifiers: ':aboveleft', ':belowright', ':botright',
 ':leftabove', ':rightbelow', ':topleft', and ':vertical'. For instance, to
 split vertically to the right of the current window, run the command:
@@ -3042,9 +3051,13 @@ To open in a new tab page, use the ':tab' modifier with the "'split'" or
 >
   :tab YcmCompleter GoTo
 <
-**NOTE:** command modifiers were added in Vim 7.4.1898. If you are using an
-older version, you can still configure this by setting the option to one of the
-deprecated values: "'vertical-split'", "'new-tab'", or "'new-or-existing-tab'".
+These modifiers can also be specified through the 'mods=' arguments as a comma-
+separated list. For instance:
+>
+  :YcmCompleter mods=rightbelow,vertical GoTo
+<
+This is useful for versions of Vim that don't support command modifiers (older
+than 7.4.1898).
 
 Default: "'same-buffer'"
 >

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -42,7 +42,7 @@ def SendCommandRequest_ExtraConfVimData_Works_test( ycm ):
         send_request.call_args[ 0 ],
         contains(
           contains( 'GoTo' ),
-          'aboveleft',
+          contains( 'aboveleft' ),
           has_entries( {
             'options': has_entries( {
               'tab_size': 2,
@@ -67,7 +67,7 @@ def SendCommandRequest_ExtraConfData_UndefinedValue_test( ycm ):
         send_request.call_args[ 0 ],
         contains(
           contains( 'GoTo' ),
-          'belowright',
+          contains( 'belowright' ),
           has_entries( {
             'options': has_entries( {
               'tab_size': 2,
@@ -87,7 +87,7 @@ def SendCommandRequest_BuildRange_NoVisualMarks_test( ycm, *args ):
       ycm.SendCommandRequest( [ 'GoTo' ], '', True, 1, 2 )
       send_request.assert_called_once_with(
         [ 'GoTo' ],
-        '',
+        [],
         {
           'options': {
             'tab_size': 2,
@@ -119,7 +119,7 @@ def SendCommandRequest_BuildRange_VisualMarks_test( ycm, *args ):
       ycm.SendCommandRequest( [ 'GoTo' ], 'tab', True, 1, 2 )
       send_request.assert_called_once_with(
         [ 'GoTo' ],
-        'tab',
+        [ 'tab' ],
         {
           'options': {
             'tab_size': 2,
@@ -145,7 +145,7 @@ def SendCommandRequest_IgnoreFileTypeOption_test( ycm, *args ):
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     expected_args = (
       [ 'GoTo' ],
-      '',
+      [],
       {
         'options': {
           'tab_size': 2,
@@ -161,3 +161,28 @@ def SendCommandRequest_IgnoreFileTypeOption_test( ycm, *args ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
       ycm.SendCommandRequest( [ 'GoTo', 'ft=python' ], '', False, 1, 1 )
       send_request.assert_called_once_with( *expected_args )
+
+
+@YouCompleteMeInstance()
+def SendCommandRequest_SupportModsOption_test( ycm, *args ):
+  current_buffer = VimBuffer( 'buffer' )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
+    with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
+      ycm.SendCommandRequest( [ 'mods=rightbelow', 'GoTo' ],
+                              'vertical',
+                              False,
+                              1,
+                              1 )
+      send_request.assert_called_once_with(
+        [ 'GoTo' ],
+        [ 'vertical', 'rightbelow' ],
+        { 'options': { 'tab_size': 2, 'insert_spaces': True } }
+      )
+
+    with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
+      ycm.SendCommandRequest( [ 'GoTo', 'mods=tab' ], 'tab', False, 1, 1 )
+      send_request.assert_called_once_with(
+        [ 'GoTo' ],
+        [ 'tab' ],
+        { 'options': { 'tab_size': 2, 'insert_spaces': True } }
+      )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1691,7 +1691,7 @@ def JumpToLocation_SameFile_SameBuffer_NoSwapFile_test( vim_command ):
     vimsupport.JumpToLocation( os.path.realpath( u'uni¢𐍈d€' ),
                                2,
                                5,
-                               'aboveleft' )
+                               [ 'aboveleft' ] )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1708,7 +1708,7 @@ def JumpToLocation_DifferentFile_SameBuffer_Unmodified_test( vim_command ):
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'belowright' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'belowright' ] )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1728,7 +1728,7 @@ def JumpToLocation_DifferentFile_SameBuffer_Modified_CannotHide_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'botright' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'botright' ] )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1748,7 +1748,7 @@ def JumpToLocation_DifferentFile_SameBuffer_Modified_CanHide_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'leftabove' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'leftabove' ] )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1769,7 +1769,7 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Unexpected_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     assert_that(
       calling( vimsupport.JumpToLocation ).with_args(
-          os.path.realpath( u'different_uni¢𐍈d€' ), 2, 5, 'rightbelow' ),
+          os.path.realpath( u'different_uni¢𐍈d€' ), 2, 5, [ 'rightbelow' ] ),
       raises( VimError, 'Unknown code' )
     )
 
@@ -1784,7 +1784,7 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Quit_test( vim_command ):
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'topleft' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'topleft' ] )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1802,7 +1802,7 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Abort_test( vim_command ):
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'vertical' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'vertical' ] )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1824,7 +1824,7 @@ def JumpToLocation_DifferentFile_Split_CurrentTab_NotAlreadyOpened_test(
 
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'aboveleft' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'aboveleft' ] )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1849,7 +1849,7 @@ def JumpToLocation_DifferentFile_Split_CurrentTab_AlreadyOpened_test(
     vim.current.tabpage = current_tab
 
     vimsupport.JumpToLocation( os.path.realpath( u'different_uni¢𐍈d€' ),
-                               2, 5, 'belowright' )
+                               2, 5, [ 'belowright' ] )
 
     assert_that( vim.current.tabpage, equal_to( current_tab ) )
     assert_that( vim.current.window, equal_to( different_window ) )
@@ -1870,7 +1870,7 @@ def JumpToLocation_DifferentFile_Split_AllTabs_NotAlreadyOpened_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'tab' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'tab' ] )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1894,7 +1894,7 @@ def JumpToLocation_DifferentFile_Split_AllTabs_AlreadyOpened_test(
     with MockVimBuffers( [ current_buffer, different_buffer ],
                          [ current_buffer ] ) as vim:
       vimsupport.JumpToLocation( os.path.realpath( u'different_uni¢𐍈d€' ),
-                                 2, 5, 'tab' )
+                                 2, 5, [ 'tab' ] )
 
       assert_that( vim.current.tabpage, equal_to( current_tab ) )
       assert_that( vim.current.window, equal_to( different_window ) )
@@ -1915,7 +1915,7 @@ def JumpToLocation_DifferentFile_NewOrExistingTab_NotAlreadyOpened_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'aboveleft vertical' )
+    vimsupport.JumpToLocation( target_name, 2, 5, [ 'aboveleft', 'vertical' ] )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1939,7 +1939,7 @@ def JumpToLocation_DifferentFile_NewOrExistingTab_AlreadyOpened_test(
     with MockVimBuffers( [ current_buffer, different_buffer ],
                          [ current_buffer ] ) as vim:
       vimsupport.JumpToLocation( os.path.realpath( u'different_uni¢𐍈d€' ),
-                                 2, 5, 'belowright tab' )
+                                 2, 5, [ 'belowright', 'tab' ] )
 
       assert_that( vim.current.tabpage, equal_to( current_tab ) )
       assert_that( vim.current.window, equal_to( different_window ) )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -485,7 +485,7 @@ def JumpToFile( filename, command, modifiers ):
   vim_command = GetVimCommand( command )
   try:
     escaped_filename = EscapeFilepathForVimCommand( filename )
-    vim.command( 'keepjumps {} {} {}'.format( modifiers,
+    vim.command( 'keepjumps {} {} {}'.format( ' '.join( modifiers ),
                                               vim_command,
                                               escaped_filename ) )
   # When the file we are trying to jump to has a swap file

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -325,12 +325,18 @@ class YouCompleteMe( object ):
                           has_range,
                           start_line,
                           end_line ):
+    modifiers = modifiers.split( ' ' ) if modifiers else []
     final_arguments = []
     for argument in arguments:
       # The ft= option which specifies the completer when running a command is
       # ignored because it has not been working for a long time. The option is
       # still parsed to not break users that rely on it.
       if argument.startswith( 'ft=' ):
+        continue
+      if argument.startswith( 'mods=' ):
+        for modifier in argument[ 5: ].split( ',' ):
+          if modifier not in modifiers:
+            modifiers.append( modifier )
         continue
       final_arguments.append( argument )
 


### PR DESCRIPTION
Introduce a new argument to the `YcmCompleter` command that takes a comma-separated list of command modifiers. This argument allows the use of command modifiers in versions of Vim older than 7.4.1898. It also gives the possibility to add modifiers that are not built into Vim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3177)
<!-- Reviewable:end -->
