### PR TITLE
Reduced latency by using timer to dispatch request

### DIFF
--- a/README.md
+++ b/README.md
@@ -2994,6 +2994,26 @@ Default: 1000
 let g:ycm_disable_for_files_larger_than_kb = 1000
 ```
 
+### The `g:ycm_async_completionrequest_dispatch` option
+
+Defines if requests are dispatched asynchronously. **experimental**
+Handling completion requests is done asynchronously by ycmd, but dispatching the
+request is not. This is done on every keystroke and thus increases input latency
+in most cases. With this option enabled the dispatching of the request is off-
+loaded into a callback triggered by a timer (without delay) to run asynchronous.
+Using an asynchronous dispatch improves input latency a lot but it is currently
+unknown if it introduces subtile errors in completion, due to dispatching not
+in the "right" state. Therefore this is **experimental**.
+
+- `1`: YCM will use a timer to dispatch request asynchronously.
+- `0`: YCM will dispatch the right when handling the TextChange-trigger
+
+Default: 0
+
+```viml
+let g:ycm_async_completionrequest_dispatch = 0
+```
+
 ### The `g:ycm_use_clangd` option
 
 This option controls whether **clangd** should be used as completion engine for

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -709,6 +709,10 @@ endfunction
 
 
 function! s:OnTextChangedInsertMode()
+  call timer_start(0, function('s:OnTextChangedInsertModeCB'))
+endfunction
+
+function! s:OnTextChangedInsertModeCB(...)
   if !s:AllowedToCompleteInCurrentBuffer()
     return
   endif

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -709,6 +709,9 @@ endfunction
 
 
 function! s:OnTextChangedInsertMode()
+  if !g:ycm_async_completionrequest_dispatch
+    return s:OnTextChangedInsertModeCB()
+  endif
   call timer_start(0, function('s:OnTextChangedInsertModeCB'))
 endfunction
 

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -195,6 +195,8 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
+let g:ycm_async_completionrequest_dispatch =
+      \ get( g:, 'ycm_async_completionrequest_dispatch', 0 )
 "
 " List of ycmd options.
 "


### PR DESCRIPTION
First: Thanks for YCM! You really complete me!

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Lately I concerned myself with input latency (https://lwn.net/Articles/751763/, https://pavelfatin.com/typometer/) and found that in my setup YCM adds quite some latency onto the stack.
But a fix was easily found and I wanted to share this with you. I attached the benchmark results done with Fatin's tool. At least for neovim users this option does really help pushing down input latency. Classic vim is not that much influenced.

Handling of completions is already asynchronous but dispatching the
request is not. As this is done on every key stroke it does influence
input latency for most vim flavors. Using timers dispatching can be
offloaded to a callback which improves latency.

![benchmark](https://user-images.githubusercontent.com/7195718/54516533-74b12d00-495f-11e9-8246-94d88f55b4d7.jpg)

Sorry closed closed #3346 accidentally and could not reopen because of --amend. 

With low battery I saw higher latency with gvim, but I revisited with enough power and gvim seems to behave.
It does only slightly influence latency with gvim (well within std deviation boundaries).
I guess the effect I saw can be ignored as the group of users with gvim on very low battery is execptionally small.

So I changed the code to use timer_start.
I removed the variable and made it normal behavior.
Thus no additional documentation is required.

Any other second thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3347)
<!-- Reviewable:end -->
