### PR TITLE
Improve behavior when whitelist is set

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -625,7 +625,11 @@ function! s:PollServerReady( timer_id )
     return
   endif
 
-  call s:OnFileTypeSet()
+  if g:ycm_global_settings
+    call s:OnFileTypeSet()
+  else
+    doautoall youcompleteme FileType
+  endif
 endfunction
 
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -338,7 +338,7 @@ function! s:SetUpKeyMappings()
       exe 'imap' . s:mapping_pattern . ' <Nul> <C-Space>'
     endif
 
-    silent! exe 'inoremap <unique> <silent> ' . invoke_key .
+    silent! exe 'inoremap <unique> <silent>' . s:mapping_pattern . ' '. invoke_key .
           \ ' <C-R>=<SID>InvokeSemanticCompletion()<CR>'
   endif
 
@@ -351,7 +351,7 @@ function! s:SetUpKeyMappings()
   " completion menu is open. We handle this by closing the completion menu on
   " the keys that delete a character in insert mode.
   for key in [ "<BS>", "<C-h>" ]
-    silent! exe 'inoremap <unique> <expr> ' . key .
+    silent! exe 'inoremap <unique> <expr>' . s:mapping_pattern . ' ' . key .
           \ ' <SID>OnDeleteChar( "\' . key . '" )'
   endfor
 endfunction

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -69,8 +69,10 @@ let s:using_python3 = s:UsingPython3()
 let s:python_until_eof = s:using_python3 ? "python3 << EOF" : "python << EOF"
 let s:python_command = s:using_python3 ? "py3 " : "py "
 let s:autocmd_pattern = ' *'
+let s:mapping_pattern = ''
 if !g:ycm_global_settings
   let s:autocmd_pattern = ' <buffer>'
+  let s:mapping_pattern = ' <buffer>'
 endif
 
 
@@ -309,13 +311,13 @@ function! s:SetUpKeyMappings()
     " With this command, when the completion window is visible, the tab key
     " (default) will select the next candidate in the window. In vim, this also
     " changes the typed-in text to that of the candidate completion.
-    exe 'inoremap <expr>' . key .
+    exe 'inoremap <expr>' . s:mapping_pattern . key .
           \ ' pumvisible() ? "\<C-n>" : "\' . key .'"'
   endfor
 
   for key in g:ycm_key_list_previous_completion
     " This selects the previous candidate for shift-tab (default)
-    exe 'inoremap <expr>' . key .
+    exe 'inoremap <expr>' . s:mapping_pattern . key .
           \ ' pumvisible() ? "\<C-p>" : "\' . key .'"'
   endfor
 
@@ -323,7 +325,7 @@ function! s:SetUpKeyMappings()
     " When selecting a candidate and closing the completion menu with the <C-y>
     " key, the menu will automatically be reopened because of the TextChangedI
     " event. We define a command to prevent that.
-    exe 'inoremap <expr>' . key . ' <SID>StopCompletion( "\' . key . '" )'
+    exe 'inoremap <expr>' . s:mapping_pattern . key . ' <SID>StopCompletion( "\' . key . '" )'
   endfor
 
   if !empty( g:ycm_key_invoke_completion )
@@ -331,7 +333,7 @@ function! s:SetUpKeyMappings()
 
     " Inside the console, <C-Space> is passed as <Nul> to Vim
     if invoke_key ==# '<C-Space>'
-      imap <Nul> <C-Space>
+      exe 'imap' . s:mapping_pattern . ' <Nul> <C-Space>'
     endif
 
     silent! exe 'inoremap <unique> <silent> ' . invoke_key .
@@ -339,7 +341,7 @@ function! s:SetUpKeyMappings()
   endif
 
   if !empty( g:ycm_key_detailed_diagnostics )
-    silent! exe 'nnoremap <unique> ' . g:ycm_key_detailed_diagnostics .
+    silent! exe 'nnoremap <unique>' . s:mapping_pattern . ' ' . g:ycm_key_detailed_diagnostics .
           \ ' :YcmShowDetailedDiagnostic<CR>'
   endif
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -70,9 +70,11 @@ let s:python_until_eof = s:using_python3 ? "python3 << EOF" : "python << EOF"
 let s:python_command = s:using_python3 ? "py3 " : "py "
 let s:autocmd_pattern = ' *'
 let s:mapping_pattern = ''
+let s:command_pattern = ''
 if !g:ycm_global_settings
   let s:autocmd_pattern = ' <buffer>'
   let s:mapping_pattern = ' <buffer>'
+  let s:command_pattern = ' -buffer'
 endif
 
 
@@ -936,28 +938,28 @@ endfunction
 
 
 function! s:SetUpCommands()
-  command! YcmRestartServer call s:RestartServer()
-  command! YcmDebugInfo call s:DebugInfo()
-  command! -nargs=* -complete=custom,youcompleteme#LogsComplete
-        \ YcmToggleLogs call s:ToggleLogs(<f-args>)
+  exe 'command!'.s:command_pattern.' YcmRestartServer call s:RestartServer()'
+  exe 'command!'.s:command_pattern.' YcmDebugInfo call s:DebugInfo()'
+  exe 'command!'.s:command_pattern.' -nargs=* -complete=custom,youcompleteme#LogsComplete '.
+        \ 'YcmToggleLogs call s:ToggleLogs(<f-args>)'
   if s:Pyeval( 'vimsupport.VimVersionAtLeast( "7.4.1898" )' )
-    command! -nargs=* -complete=custom,youcompleteme#SubCommandsComplete -range
-          \ YcmCompleter call s:CompleterCommand(<q-mods>,
-          \                                      <count>,
-          \                                      <line1>,
-          \                                      <line2>,
-          \                                      <f-args>)
+    exe 'command!'.s:command_pattern.' -nargs=* -complete=custom,youcompleteme#SubCommandsComplete -range '.
+          \ 'YcmCompleter call s:CompleterCommand(<q-mods>,'.
+          \                                      '<count>,'.
+          \                                      '<line1>,'.
+          \                                      '<line2>,'.
+          \                                      '<f-args>)'
   else
-    command! -nargs=* -complete=custom,youcompleteme#SubCommandsComplete -range
-          \ YcmCompleter call s:CompleterCommand('',
-          \                                      <count>,
-          \                                      <line1>,
-          \                                      <line2>,
-          \                                      <f-args>)
+    exe 'command!'.s:command_pattern.' -nargs=* -complete=custom,youcompleteme#SubCommandsComplete -range '.
+          \ 'YcmCompleter call s:CompleterCommand("",'.
+          \                                      '<count>,'.
+          \                                      '<line1>,'.
+          \                                      '<line2>,'.
+          \                                      '<f-args>)'
   endif
-  command! YcmDiags call s:ShowDiagnostics()
-  command! YcmShowDetailedDiagnostic call s:ShowDetailedDiagnostic()
-  command! YcmForceCompileAndDiagnostics call s:ForceCompileAndDiagnostics()
+  exe 'command!'.s:command_pattern.' YcmDiags call s:ShowDiagnostics()'
+  exe 'command!'.s:command_pattern.' YcmShowDetailedDiagnostic call s:ShowDetailedDiagnostic()'
+  exe 'command!'.s:command_pattern.' YcmForceCompileAndDiagnostics call s:ForceCompileAndDiagnostics()'
 endfunction
 
 

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -102,6 +102,8 @@ let g:ycm_filetype_blacklist =
       \   'mail': 1
       \ } )
 
+let g:ycm_global_settings = type( g:ycm_filetype_whitelist ) != type( {} ) ||
+        \ has_key( g:ycm_filetype_whitelist, '*' )
 let g:ycm_open_loclist_on_ycm_diags =
       \ get( g:, 'ycm_open_loclist_on_ycm_diags', 1 )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

I've been using/enjoying this plugin for a few weeks now.
But one thing that bothers me is that despite I've set `g:ycm_filetype_whitelist` to few specific filetypes the plugin still affects all filetypes (e.g.: mappings, autocmds). I believe it should add little overhead if no buffer with filetype in whitelist is open.

Restricting the plugin actions to fewer filetypes should increase the editor performance and reduce the issues when interacting with other unrelated plugins (such as the ones in the default blacklist option).

When/if the changes proposed here are used for some time and tested for a large number of people it may be possible to simplify all the code by removing the support for global configurations.
The default value for `g:ycm_filetype_whitelist` could be all supported filetypes (mentioned in `:h youcompleteme-quick-feature-summary`), and the blacklist option would be unnecessary.

The changes made proposed here attempt to:

* leave the behavior unchanged if the whitelist has the default value
* if the whitelist is provided, make most of the autocmds/mappings/commands/options buffer local
* base on the whitelist and ignore the g:ycm_filetype_blacklist, as it'd be necessary to convert the '*' to all possible filetypes and then subtract the ones in the blacklist


## Tests
No automated tests were included as the changes are only on VimScript (as per [CONTRIBUTING][cont]).

To manually test the change:
    
    :au youcompleteme
    :au ycmcompletemecursormove
    :Y<c-d>
    :imap <tab>

Expected results:
* without setting `g:ycm_filetype_whitelist`: exactly the same output as in current master branch
* setting `g:ycm_filetype_whitelist`: 
  - after opening plugin without arguments: only FileType for specified types on youcompleteme augroup, empty for all other commands
  - open a buffer whose filetype is present on the whitelist: output similar to the current master branch
  - open an empty buffer or one buffer whose filetype is *not* present on the whitelist: output similar to the current master branch, and no autocmds for the current buffer other than VimLeave.

## Approach

The more direct approach for autocmds would be to replace `*` with a list of file extensions. But unfortunately there is no direct mapping between filetypes and file extensions -- for example, cpp filetype is set for both `.cc` and `.cpp` file extensions. In addition, some filetypes are set based on the file contents (as can be seem in `$VIMRUNTIME/filetype.vim`).
So the approach chosen was to use the `FileType` autocmd to set all the options for the buffer (again, nothing is supposed to change if the whitelist has the default value).

The options affected by this pluing are global, so it is necessary to save the previous value before updating them, and restore when switching buffers/windows. This work was left to the future, to avoid making this PR too big.


[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3409)
<!-- Reviewable:end -->
