### PR TITLE
[READY] Use noselect

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -495,6 +495,10 @@ function! s:SetUpCompleteopt()
   set completeopt-=menu
   set completeopt+=menuone
 
+  " Instead of making vim deselect the first completion item with <C-p>, we
+  " `noselect` makes vim do that on its own.
+  set completeopt+=noselect
+
   " This is unnecessary with our features. People use this option to insert
   " the common prefix of all the matches and then add more differentiating chars
   " so that they can select a more specific match. With our features, they
@@ -872,13 +876,8 @@ function! s:Complete()
     call s:CloseCompletionMenu()
   else
     " <c-x><c-u> invokes the user's completion function (which we have set to
-    " youcompleteme#CompleteFunc), and <c-p> tells Vim to select the previous
-    " completion candidate. This is necessary because by default, Vim selects
-    " the first candidate when completion is invoked, and selecting a candidate
-    " automatically replaces the current text with it. Calling <c-p> forces Vim
-    " to deselect the first candidate and in turn preserve the user's current
-    " text until he explicitly chooses to replace it with a completion.
-    call s:SendKeys( "\<C-X>\<C-U>\<C-P>" )
+    " youcompleteme#CompleteFunc).
+    call s:SendKeys( "\<C-X>\<C-U>" )
   endif
 endfunction
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Instead of manually deselecting the first candidate, we can make vim do that on its own.
Fixes #3430 

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3433)
<!-- Reviewable:end -->
