### PR TITLE
valloric.github.io -> ycm-core.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3647,7 +3647,7 @@ tracker][tracker]. Before you do, please carefully read
 the team will use to help get you going.
 
 The latest version of the plugin is available at
-<http://valloric.github.io/YouCompleteMe/>.
+<http://ycm-core.github.io/YouCompleteMe/>.
 
 The author's homepage is <http://val.markovic.io>.
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3903,7 +3903,7 @@ If you have bug reports or feature suggestions, please use the issue tracker
 for important diagnostics which the team will use to help get you going.
 
 The latest version of the plugin is available at
-http://valloric.github.io/YouCompleteMe/.
+http://ycm-core.github.io/YouCompleteMe/.
 
 The author's homepage is http://val.markovic.io.
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

I was installing ycm on a new machine and looking at docs and found broken links to valloric.github.io. It looks like the repos moved from the valloric github account to ycm-core and github automatically redirects links in the repos but not to github pages sites. I'm also opening a PR in https://github.com/ycm-core/ycmd for the same thing. 

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3462)
<!-- Reviewable:end -->
