### PR TITLE
deal with long wrapped lines in preview windows

### DIFF
--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -193,16 +193,15 @@ def _GetCompletionInfoField( completion_data ):
   info = info.replace( '\x00', '' )
 
 
-  vf_strdisplaywidth = vimsupport.vim.Function( 'strdisplaywidth' )
-  vf_winwidth = vimsupport.vim.Function( 'winwidth' )
-
   # Get the width of the current window
-  winwidth = vf_winwidth( 0 )
+  winwidth = vimsupport.vim.current.window.width
 
   num_additional_line = 0
   for line in info.splitlines():
-    if vf_strdisplaywidth( line ) > winwidth:
-      num_additional_line += vf_strdisplaywidth( line ) // winwidth
+    vimsupport.vim.current.buffer.vars["ycm_tmp_var"] = line
+    strdisplaywidth = int( vimsupport.vim.eval( 'strdisplaywidth(b:ycm_tmp_var)' ) )
+    if strdisplaywidth > winwidth:
+      num_additional_line += strdisplaywidth // winwidth
 
   footer = ''
   if num_additional_line > 0:

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -193,22 +193,22 @@ def _GetCompletionInfoField( completion_data ):
   info = info.replace( '\x00', '' )
 
 
-  vf_strdisplaywidth = vimsupport.vim.Function('strdisplaywidth')
-  vf_winwidth = vimsupport.vim.Function('winwidth')
+  vf_strdisplaywidth = vimsupport.vim.Function( 'strdisplaywidth' )
+  vf_winwidth = vimsupport.vim.Function( 'winwidth' )
 
   # Get the width of the current window
-  winwidth = vf_winwidth(0)
+  winwidth = vf_winwidth( 0 )
 
   num_additional_line = 0
   for line in info.splitlines():
-    if vf_strdisplaywidth(line) > winwidth:
-      num_additional_line += vf_strdisplaywidth(line) // winwidth
+    if vf_strdisplaywidth( line ) > winwidth:
+      num_additional_line += vf_strdisplaywidth( line ) // winwidth
 
   footer = ''
   if num_additional_line > 0:
     # The empty line at the end is ignored, so this one is not effective.
     footer = '\n'
-    for i in range(num_additional_line):
+    for i in range( num_additional_line ):
       footer += '\n'
   return info + footer
 

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -190,7 +190,27 @@ def _GetCompletionInfoField( completion_data ):
 
   # This field may contain null characters e.g. \x00 in Python docstrings. Vim
   # cannot evaluate such characters so they are removed.
-  return info.replace( '\x00', '' )
+  info = info.replace( '\x00', '' )
+
+
+  vf_strdisplaywidth = vimsupport.vim.Function('strdisplaywidth')
+  vf_winwidth = vimsupport.vim.Function('winwidth')
+
+  # Get the width of the current window
+  winwidth = vf_winwidth(0)
+
+  num_additional_line = 0
+  for line in info.splitlines():
+    if vf_strdisplaywidth(line) > winwidth:
+      num_additional_line += vf_strdisplaywidth(line) // winwidth
+
+  footer = ''
+  if num_additional_line > 0:
+    # The empty line at the end is ignored, so this one is not effective.
+    footer = '\n'
+    for i in range(num_additional_line):
+      footer += '\n'
+  return info + footer
 
 
 def _ConvertCompletionDataToVimData( completion_identifier, completion_data ):


### PR DESCRIPTION
Signed-off-by: Gunwoo Gim (The obtuse) <wind8702@gmail.com>

Deal with long wrapped lines in preview windows by adjusting the height
of the preview window.

I'm sorry but it's not tested in vim sessions with 'wrap' feature off.
I think I should turn it off when the wrap feature is turned off.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
In the project of libhwloc they generate docstring untrimmed, in such a way that the docstring would be wrapped in 2 or more lines. I couldn't even see the description of a struct member without "set display+=lastline" in my vim session -was able to read the variable type at least though..-, could read just the first chunk of the text otherwise.

I know that this "quickfix" is hackish, it just deceives vim by simply adding empty lines in the end, and vim might possibly prevent it from working in a future version. but I have no expertise in Vim so am just providing the very quickfix.


[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3480)
<!-- Reviewable:end -->
