### PR TITLE
Restore neovim compatibility

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -54,7 +54,8 @@ elseif !has( 'timers' )
         \ echohl None
   call s:restore_cpo()
   finish
-elseif ( v:version > 800 || ( v:version == 800 && has( 'patch1436' ) ) ) &&
+elseif !has( 'nvim' ) &&
+     \ ( v:version > 800 || ( v:version == 800 && has( 'patch1436' ) ) ) &&
      \ !has( 'python_compiled' ) && !has( 'python3_compiled' )
   echohl WarningMsg |
         \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .


### PR DESCRIPTION
Upstream neovim included vim patch 1436 (of vim version 8.0) but does
not have `python_compiled` or `python3_compiled`. For this reason this
patch adds a general neovim check.

This PR is related to #3306.