### PR TITLE
[READY] Wipe instead of closing quickfix after a multi-choice GoTo command

### DIFF
--- a/python/ycm/tests/client/command_request_test.py
+++ b/python/ycm/tests/client/command_request_test.py
@@ -110,7 +110,7 @@ class GoToResponse_QuickFix_test( object ):
       call( 'augroup ycmquickfix' ),
       call( 'autocmd! * <buffer>' ),
       call( 'autocmd WinLeave <buffer> '
-            'if bufnr( "%" ) == expand( "<abuf>" ) | q | endif' ),
+            'if bufnr( "%" ) == expand( "<abuf>" ) | bw! | endif' ),
       call( 'augroup END' ),
       call( 'doautocmd User YcmQuickFixOpened' )
     ] )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -168,7 +168,7 @@ def OpenLocationList_test( vim_command, fitting_height, variable_exists ):
     call( 'augroup ycmlocation' ),
     call( 'autocmd! * <buffer>' ),
     call( 'autocmd WinLeave <buffer> '
-          'if bufnr( "%" ) == expand( "<abuf>" ) | q | endif' ),
+          'if bufnr( "%" ) == expand( "<abuf>" ) | bw! | endif' ),
     call( 'augroup END' ),
     call( 'doautocmd User YcmLocationOpened' ),
     call( 'silent! wincmd p' )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1253,5 +1253,5 @@ def AutoCloseOnCurrentBuffer( name ):
   vim.command( 'augroup {}'.format( name ) )
   vim.command( 'autocmd! * <buffer>' )
   vim.command( 'autocmd WinLeave <buffer> '
-               'if bufnr( "%" ) == expand( "<abuf>" ) | q | endif' )
+               'if bufnr( "%" ) == expand( "<abuf>" ) | bw! | endif' )
   vim.command( 'augroup END' )


### PR DESCRIPTION
YCM automatically closes the quickfix/location list buffer after leaving
it by triggering an autocmd on `WinLeave`.

However, just `q`uitting the buffer doesn't remove it from the buffer
list and so YCM leaves behind its `WinLeave` autocmd. By calling `bw!`
instead, YCM completely wipes the buffer and makes sure that the
`WinLeave` autocmd doesn't get in the way of `:make`, `:grep` etc, for
which users might want to leave the list open even after leaving the
buffer.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3494)
<!-- Reviewable:end -->
