### PR TITLE
Suggestion to track a certain submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,7 @@
 [submodule "third_party/requests_deps/chardet"]
 	path = third_party/requests_deps/chardet
 	url = https://github.com/chardet/chardet
+	branch = stable
 [submodule "third_party/requests_deps/urllib3"]
 	path = third_party/requests_deps/urllib3
 	url = https://github.com/urllib3/urllib3


### PR DESCRIPTION
- PR Prelude: done.

## Motivation
After updating YCM and running install.py, it does not work any more and gives me this error message when starting Vim:
```
Error detected while processing function <SNR>94_PollServerReady[7]..<SNR>94_Pyeval:
line    2:
/home/***/.vim/pack/vim/opt/YouCompleteMe/third_party/requests_deps/requests/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.25.6) or chardet (4.0.0) doesn't match a supported version!
```

A bit debugging revealed the reason: That the master of chardet has been updated. There is however a stable branch in the chardet repository, which still points to a version below 4.0.0. Tracking that will buy some time to test against 4.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3501)
<!-- Reviewable:end -->
