### PR TITLE
LLVM update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,10 +1147,10 @@ of the two completer engines:
 -   **Performance**: Clangd has faster reparse and code completion times
     compared to libclang.
 
-Note that for clangd to have some of the above mentioned functionality, you need
+Note that for older versions of clangd to have some of the above mentioned functionality, you need
 to enable clangd indexing by adding `-background-index` to
-[g:ycm_clangd_args](#the-gycm_clangd_args-option). Clangd will automatically
-enable indexing in version 9.
+[g:ycm_clangd_args](#the-gycm_clangd_args-option). Clangd automatically
+enabled indexing by default in clangd version 9.
 
 To enable:
 


### PR DESCRIPTION
LLVM and clangd 9.0 have since been released, and this is enabled by default: source https://clang.llvm.org/extra/clangd/Installation.html#background-indexing

EDIT: was doing further investigation and found that the bundled clangd (`YouCompleteMe/third_party/ycmd/third_party/clangd/output/bin/clangd`) is actually version 8.0.0 and not version 9.0.0 even though LLVM and clangd 9.0.0 have been released 

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]
Because the current documentation was out of date


[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3508)
<!-- Reviewable:end -->
