### PR TITLE
[READY] Stop async diagnostics from updating at inopportune times

### DIFF
--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -145,6 +145,7 @@ def YouCompleteMeInstance( custom_options = {} ):
         WaitUntilReady()
         ycm.CheckIfServerIsReady()
         try:
+          test_utils.VIM_MATCHES_FOR_WINDOW.clear()
           test( ycm, *args, **kwargs )
         finally:
           StopServer( ycm )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -451,6 +451,9 @@ class YouCompleteMe( object ):
 
 
   def UpdateWithNewDiagnosticsForFile( self, filepath, diagnostics ):
+    if not self.ShouldDisplayDiagnostics():
+      return
+
     bufnr = vimsupport.GetBufferNumberForFilename( filepath )
     if bufnr in self._buffers and vimsupport.BufferIsVisible( bufnr ):
       # Note: We only update location lists, etc. for visible buffers, because


### PR DESCRIPTION
Currently `g:ycm_show_diagnostics_ui` doesn't prevent async diagnostics
from popping up.

This PR fixes that and also prevents diagnostics from changing in any
mode except normal, as I think it can be very distracting.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md


Like mentioned on gitter, our async diagnostics doesn't listen to `ycm_show_diagnostic_ui`. Besides that diagnostics changing in insert mode is distracting in my opinion.
RFC for two reasons. First because of containing diagnostics to change only in normal mode. Second because no tests, because I wasn't sure how to test this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3509)
<!-- Reviewable:end -->
