### PR TITLE
[READY] Do not hardcode async diagnostic filetype support

### DIFF
--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -26,10 +26,8 @@ from ycm import vimsupport
 from ycm.client.event_notification import EventNotification
 from ycm.diagnostic_interface import DiagnosticInterface
 
-
 DIAGNOSTIC_UI_FILETYPES = { 'cpp', 'cs', 'c', 'objc', 'objcpp', 'cuda',
                             'javascript', 'typescript' }
-DIAGNOSTIC_UI_ASYNC_FILETYPES = { 'java' }
 
 
 # Emulates Vim buffer
@@ -39,7 +37,7 @@ DIAGNOSTIC_UI_ASYNC_FILETYPES = { 'java' }
 class Buffer( object ):
 
   def __init__( self, bufnr, user_options, async_diags ):
-    self.number = bufnr
+    self._number = bufnr
     self._parse_tick = 0
     self._handled_tick = 0
     self._parse_request = None
@@ -70,7 +68,7 @@ class Buffer( object ):
     return bool( self._parse_request and self._parse_request.ShouldResend() )
 
 
-  def UpdateDiagnostics( self, force=False ):
+  def UpdateDiagnostics( self, force = False ):
     if force or not self._async_diags:
       self.UpdateWithNewDiagnostics( self._parse_request.Response() )
     else:
@@ -117,7 +115,7 @@ class Buffer( object ):
 
 
   def _ChangedTick( self ):
-    return vimsupport.GetBufferChangedTick( self.number )
+    return vimsupport.GetBufferChangedTick( self._number )
 
 
 class BufferDict( dict ):
@@ -131,7 +129,7 @@ class BufferDict( dict ):
     new_value = self[ key ] = Buffer(
       key,
       self._user_options,
-      any( x in DIAGNOSTIC_UI_ASYNC_FILETYPES
-           for x in vimsupport.GetBufferFiletypes( key ) ) )
+      not any( x in DIAGNOSTIC_UI_FILETYPES
+               for x in vimsupport.GetBufferFiletypes( key ) ) )
 
     return new_value

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -54,9 +54,6 @@ from ycm.tests.mock_utils import ( MockAsyncServerResponseDone,
                                    MockAsyncServerResponseException )
 
 
-import ycm.youcompleteme as ycm_module
-
-
 @YouCompleteMeInstance()
 def YouCompleteMe_YcmCoreNotImported_test( ycm ):
   assert_that( 'ycm_core', is_not( is_in( sys.modules ) ) )
@@ -722,68 +719,8 @@ def YouCompleteMe_UpdateMatches_ClearDiagnosticMatchesInNewBuffer_test( ycm ):
 
 @YouCompleteMeInstance( { 'g:ycm_echo_current_diagnostic': 1,
                           'g:ycm_always_populate_location_list': 1,
-                          'g:ycm_enable_diagnostic_highlighting': 1 } )
-@patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
-        return_value = True )
-@patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
-def YouCompleteMe_AsyncDiagnosticUpdate_NotAvailableForFIletype_test(
-    ycm, post_vim_message, *args ):
-  diagnostics = [
-    {
-      'kind': 'ERROR',
-      'text': 'error text in current buffer',
-      'location': {
-        'filepath': '/current',
-        'line_num': 1,
-        'column_num': 1
-      },
-      'location_extent': {
-        'start': {
-          'filepath': '/current',
-          'line_num': 1,
-          'column_num': 1,
-        },
-        'end': {
-          'filepath': '/current',
-          'line_num': 1,
-          'column_num': 1,
-        }
-      },
-      'ranges': []
-    },
-  ]
-  current_buffer = VimBuffer( '/current',
-                              filetype = 'ycmtest',
-                              contents = [ 'current' ] * 10,
-                              number = 1 )
-  buffers = [ current_buffer ]
-  windows = [ current_buffer ]
-
-  # Register each buffer internally with YCM
-  for current in buffers:
-    with MockVimBuffers( buffers, [ current ] ):
-      ycm.OnFileReadyToParse()
-  with patch( 'ycm.vimsupport.SetLocationListForWindow',
-              new_callable = ExtendedMock ) as set_location_list_for_window:
-    with MockVimBuffers( buffers, windows ):
-      ycm.UpdateWithNewDiagnosticsForFile( '/current', diagnostics )
-
-  post_vim_message.assert_has_exact_calls( [] )
-  set_location_list_for_window.assert_has_exact_calls( [] )
-
-  assert_that(
-    test_utils.VIM_MATCHES_FOR_WINDOW,
-    empty()
-  )
-
-
-@YouCompleteMeInstance( { 'g:ycm_echo_current_diagnostic': 1,
-                          'g:ycm_always_populate_location_list': 1,
                           'g:ycm_show_diagnostics_ui': 0,
                           'g:ycm_enable_diagnostic_highlighting': 1 } )
-@patch.object( ycm_module,
-               'DIAGNOSTIC_UI_ASYNC_FILETYPES',
-               [ 'ycmtest' ] )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
@@ -841,71 +778,7 @@ def YouCompleteMe_AsyncDiagnosticUpdate_UserDisabled_test( ycm,
 
 @YouCompleteMeInstance( { 'g:ycm_echo_current_diagnostic': 1,
                           'g:ycm_always_populate_location_list': 1,
-                          'g:ycm_show_diagnostics_ui': 0,
                           'g:ycm_enable_diagnostic_highlighting': 1 } )
-@patch.object( ycm_module,
-               'DIAGNOSTIC_UI_ASYNC_FILETYPES',
-               [ 'ycmtest' ] )
-@patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
-        return_value = True )
-@patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
-def YouCompleteMe_AsyncDiagnosticUpdate_UserDisabledAndNoFiletypeSupport_test(
-    ycm, post_vim_message, *args ):
-  diagnostics = [
-    {
-      'kind': 'ERROR',
-      'text': 'error text in current buffer',
-      'location': {
-        'filepath': '/current',
-        'line_num': 1,
-        'column_num': 1
-      },
-      'location_extent': {
-        'start': {
-          'filepath': '/current',
-          'line_num': 1,
-          'column_num': 1,
-        },
-        'end': {
-          'filepath': '/current',
-          'line_num': 1,
-          'column_num': 1,
-        }
-      },
-      'ranges': []
-    },
-  ]
-  current_buffer = VimBuffer( '/current',
-                              filetype = 'ycmtest',
-                              contents = [ 'current' ] * 10,
-                              number = 1 )
-  buffers = [ current_buffer ]
-  windows = [ current_buffer ]
-
-  # Register each buffer internally with YCM
-  for current in buffers:
-    with MockVimBuffers( buffers, [ current ] ):
-      ycm.OnFileReadyToParse()
-  with patch( 'ycm.vimsupport.SetLocationListForWindow',
-              new_callable = ExtendedMock ) as set_location_list_for_window:
-    with MockVimBuffers( buffers, windows ):
-      ycm.UpdateWithNewDiagnosticsForFile( '/current', diagnostics )
-
-  post_vim_message.assert_has_exact_calls( [] )
-  set_location_list_for_window.assert_has_exact_calls( [] )
-
-  assert_that(
-    test_utils.VIM_MATCHES_FOR_WINDOW,
-    empty()
-  )
-
-
-@YouCompleteMeInstance( { 'g:ycm_echo_current_diagnostic': 1,
-                          'g:ycm_always_populate_location_list': 1,
-                          'g:ycm_enable_diagnostic_highlighting': 1 } )
-@patch.object( ycm_module,
-               'DIAGNOSTIC_UI_ASYNC_FILETYPES',
-               [ 'ycmtest' ] )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
@@ -1067,13 +940,7 @@ def YouCompleteMe_AsyncDiagnosticUpdate_SingleFile_test( ycm,
 @YouCompleteMeInstance( { 'g:ycm_echo_current_diagnostic': 1,
                           'g:ycm_always_populate_location_list': 1,
                           'g:ycm_enable_diagnostic_highlighting': 1 } )
-@patch.object( ycm_module,
-               'DIAGNOSTIC_UI_ASYNC_FILETYPES',
-               [ 'ycmtest' ] )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
-        return_value = True )
-@patch( 'ycm.youcompleteme.YouCompleteMe.'
-        'DiagnosticUiSupportedForCurrentFiletype',
         return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
 def YouCompleteMe_AsyncDiagnosticUpdate_PerFile_test( ycm,
@@ -1270,9 +1137,6 @@ def YouCompleteMe_OnPeriodicTick_ServerNotReady_test( ycm, *args ):
 
 
 @YouCompleteMeInstance()
-@patch.object( ycm_module,
-               'DIAGNOSTIC_UI_ASYNC_FILETYPES',
-               [ 'ycmtest' ] )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
 @patch( 'ycm.client.base_request._ValidateResponseObject', return_value = True )
@@ -1319,9 +1183,6 @@ def YouCompleteMe_OnPeriodicTick_DontRetry_test( ycm,
 
 
 @YouCompleteMeInstance()
-@patch.object( ycm_module,
-               'DIAGNOSTIC_UI_ASYNC_FILETYPES',
-               [ 'ycmtest' ] )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
 @patch( 'ycm.client.base_request._ValidateResponseObject', return_value = True )
@@ -1355,9 +1216,6 @@ def YouCompleteMe_OnPeriodicTick_Exception_test( ycm,
 
 
 @YouCompleteMeInstance()
-@patch.object( ycm_module,
-               'DIAGNOSTIC_UI_ASYNC_FILETYPES',
-               [ 'ycmtest' ] )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
 @patch( 'ycm.client.base_request._ValidateResponseObject', return_value = True )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Hardcoding supported filetypes prooved to be error prone, as we have
forgot to add `go`, `rust` and in my fork `swift` to the set. Another
problem with hardcoded filetypes is the `GenericLSPCompleter` which can
provide diagnostics for arbitrary filetypes.

This PR does away with `DIAGNOSTIC_UI_ASYNC_FILETYPES`.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3524)
<!-- Reviewable:end -->
