### PR TITLE
Update README to reflect features available for the C-family languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,9 @@ Quick Feature Summary
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
 * Automatically fix certain errors (`FixIt`)
+* Reference finding (`GoToReferences`)
+* Renaming symbols (`RefactorRename <new name>`)
+* Code formatting (`Format`)
 
 ### C♯
 
@@ -1882,7 +1885,7 @@ This command attempts to find all of the references within the project to the
 identifier under the cursor and populates the quickfix list with those
 locations.
 
-Supported in filetypes: `java, javascript, python, typescript, rust`
+Supported in filetypes: `c, cpp, objc, objcpp, cuda, java, javascript, python, typescript, rust`
 
 #### The `GoToImplementation` subcommand
 
@@ -2048,7 +2051,7 @@ files. Rename operations may involve changes to multiple files, which may or may
 not be open in Vim buffers at the time. YouCompleteMe handles all of this for
 you. The behavior is described in [the following section](#multi-file-refactor).
 
-Supported in filetypes: `java, javascript, typescript, rust`
+Supported in filetypes: `c, cpp, objc, objcpp, cuda, java, javascript, typescript, rust`
 
 #### Multi-file Refactor
 
@@ -2089,7 +2092,7 @@ it in one of Vim's visual modes (see `:h visual-use`) and run the command or
 directly enter the range on the command line, e.g. `:2,5YcmCompleter Format` to
 format it from line 2 to line 5.
 
-Supported in filetypes: `java, javascript, go, typescript, rust`
+Supported in filetypes: `c, cpp, objc, objcpp, cuda, java, javascript, go, typescript, rust`
 
 #### The `OrganizeImports` subcommand
 
@@ -2120,7 +2123,7 @@ The support for `ExecuteCommand` was implemented to support plugins like
 Restarts the semantic-engine-as-localhost-server for those semantic engines that
 work as separate servers that YCM talks to.
 
-Supported in filetypes: `cs, go, java, javascript, rust, typescript`
+Supported in filetypes: `c, cpp, objc, objcpp, cuda, cs, go, java, javascript, rust, typescript`
 
 #### The `ClearCompilationFlagCache` subcommand
 


### PR DESCRIPTION


# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
Using clangd as the C-family completion engine, the following
YcmCompleter subcommands are available:
Supported commands are:
ExecuteCommand
FixIt
Format
GetDoc
GetDocImprecise
GetType
GetTypeImprecise
GoTo
GoToDeclaration
GoToDefinition
GoToImprecise
GoToInclude
GoToReferences
RefactorRename
RestartServer

I've included the C-family languages in the list of supported languages
for each of these subcommands (where they were missing).
This change is needed to accurately reflect the features available for the C-family completion engine.
There are no tests because this PR only modifies the README.md file.


[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3537)
<!-- Reviewable:end -->
