### PR TITLE
[READY] Signature help for mixed filetypes

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -322,34 +322,33 @@ class YouCompleteMe( object ):
 
 
   def SendSignatureHelpRequest( self ):
-    filetype = vimsupport.CurrentFiletypes()[ 0 ]
-    if not self._signature_help_available_requests[ filetype ].Done():
-      return
-
-    sig_help_available = self._signature_help_available_requests[
-        filetype ].Response()
-    if sig_help_available == 'NO':
-      return
-
-    if sig_help_available == 'PENDING':
-      # Send another /signature_help_available request
-      self._signature_help_available_requests[ filetype ].Start( filetype )
-      return
-
     if not self.NativeFiletypeCompletionUsable():
       return
 
     if not self._latest_completion_request:
       return
 
-    request_data = self._latest_completion_request.request_data.copy()
-    request_data[ 'signature_help_state' ] = self._signature_help_state.state
+    for filetype in vimsupport.CurrentFiletypes():
+      if not self._signature_help_available_requests[ filetype ].Done():
+        continue
 
-    self._AddExtraConfDataIfNeeded( request_data )
+      sig_help_available = self._signature_help_available_requests[
+          filetype ].Response()
+      if sig_help_available == 'NO':
+        continue
 
-    self._latest_signature_help_request = SignatureHelpRequest(
-      request_data )
-    self._latest_signature_help_request.Start()
+      if sig_help_available == 'PENDING':
+        # Send another /signature_help_available request
+        self._signature_help_available_requests[ filetype ].Start( filetype )
+        return
+
+      request_data = self._latest_completion_request.request_data.copy()
+      request_data[ 'signature_help_state' ] = self._signature_help_state.state
+
+      self._AddExtraConfDataIfNeeded( request_data )
+
+      self._latest_signature_help_request = SignatureHelpRequest( request_data )
+      self._latest_signature_help_request.Start()
 
 
   def SignatureHelpRequestReady( self ):

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -113,10 +113,11 @@ endfunction
 
 function! Test_Signatures_After_Trigger()
   call youcompleteme#test#setup#OpenFile(
-        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/general_fallback'
-        \ . '/make_drink.cc', {} )
+        \ '/test/testdata/vim/mixed_filetype.vim',
+        \ { 'native_ft': 0 } )
 
-  call setpos( '.', [ 0, 7, 13 ] )
+  setf vim.python
+  call setpos( '.', [ 0, 3, 17 ] )
 
   " Required to trigger TextChangedI
   " https://github.com/vim/vim/issues/4665#event-2480928194

--- a/test/testdata/vim/mixed_filetype.vim
+++ b/test/testdata/vim/mixed_filetype.vim
@@ -1,0 +1,4 @@
+pyx << EOF
+import os
+os.path.abspath(
+EOF


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

This PR enables signature help in mixed filetypes, like `vim.python`. The idea is, if `filetypes[i]` doesn't support `/signature_help`, see if the next one does. 

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3541)
<!-- Reviewable:end -->
