### PR TITLE
[READY] Use openssl 1.1 and newer python 2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,9 +21,9 @@ jobs:
       'Python 2.7':
         # Tests are failing on Python 2.7.0 with the exception
         # "TypeError: argument can't be <type 'unicode'>"
-        YCM_PYTHON_VERSION: '2.7.1'
+        YCM_PYTHON_VERSION: '2.7.13'
       'Python 3.5':
-        YCM_PYTHON_VERSION: '3.5.1'
+        YCM_PYTHON_VERSION: '3.5.3'
     maxParallel: 2
   variables:
     COVERAGE: true

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -5,15 +5,15 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/i
 
 eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 
-brew install openssl@1.0 pyenv
+brew install pyenv
 
 eval "$(pyenv init -)"
 
 # In order to work with ycmd, python *must* be built as a shared library. This
 # is set via the PYTHON_CONFIGURE_OPTS option.
 PYTHON_CONFIGURE_OPTS="--enable-shared" \
-CFLAGS="-I$(brew --prefix openssl@1.0)/include" \
-LDFLAGS="-L$(brew --prefix openssl@1.0)/lib" \
+CFLAGS="-I$(brew --prefix openssl)/include" \
+LDFLAGS="-L$(brew --prefix openssl)/lib" \
   pyenv install ${YCM_PYTHON_VERSION}
 pyenv global ${YCM_PYTHON_VERSION}
 pip install -r python/test_requirements.txt


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Linuxbrew removed openssl 1.0. We have no choice but to use a newer python to link against openssl 1.1.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3543)
<!-- Reviewable:end -->
