### PR TITLE
[READY] Blacklist leaderf filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -2375,6 +2375,7 @@ let g:ycm_filetype_blacklist = {
       \ 'vimwiki': 1,
       \ 'pandoc': 1,
       \ 'infolog': 1,
+      \ 'leaderf': 1,
       \ 'mail': 1
       \}
 ```

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -109,6 +109,7 @@ let g:ycm_filetype_blacklist =
       \   'vimwiki': 1,
       \   'pandoc': 1,
       \   'infolog': 1,
+      \   'leaderf': 1,
       \   'mail': 1
       \ } )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Fixes #3544 

When leaderf spawns its window as a popup (like YCM's signature help) it calls `execute()`. If a user also has `g:ycm_seed_identifiers_with_syntax == 1` then YCM calls [`:redir`](https://github.com/ycm-core/YouCompleteMe/blob/master/python/ycm/vimsupport.py#L201)  to collect [the keywords](https://github.com/ycm-core/YouCompleteMe/blob/master/python/ycm/syntax_parse.py#L72).

Vim apparently doesn't like executing `redir` within `execute()`.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3545)
<!-- Reviewable:end -->
