### PR TITLE
[READY] Don't poll forever if signature help request isn't sent

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,8 @@ jobs:
   steps:
   - checkout: self
     submodules: recursive
+  - bash: sudo -H $(PIP) install --upgrade pip setuptools wheel
+    displayName: Upgrade pip
   - bash: sudo -H $(PIP) install -r python/test_requirements.txt
     displayName: Install dependencies
   - bash: python3 ./install.py --clangd-completer --java-completer

--- a/python/ycm/signature_help.py
+++ b/python/ycm/signature_help.py
@@ -25,7 +25,7 @@ from builtins import *  # noqa
 import vim
 import json
 from ycm import vimsupport
-from ycm.vimsupport import GetIntValue
+from ycm.vimsupport import memoize, GetIntValue
 
 
 class SignatureHelpState( object ):
@@ -84,6 +84,7 @@ def _MakeSignatureHelpBuffer( signature_info ):
   return lines
 
 
+@memoize
 def ShouldUseSignatureHelp():
   return ( vimsupport.VimHasFunctions( 'screenpos', 'pum_getpos' ) and
            vimsupport.VimSupportsPopupWindows() )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -33,7 +33,7 @@ MockVimModule()
 from ycm import vimsupport
 from nose.tools import eq_
 from hamcrest import ( assert_that, calling, contains, empty, equal_to,
-                       has_entry, raises )
+                       has_entry, is_not, raises )
 from mock import MagicMock, call, patch
 from ycmd.utils import ToBytes
 import os
@@ -2009,3 +2009,36 @@ def VimVersionAtLeast_test():
   assert_that( not vimsupport.VimVersionAtLeast( '7.4.1579' ) )
   assert_that( not vimsupport.VimVersionAtLeast( '7.4.1898' ) )
   assert_that( not vimsupport.VimVersionAtLeast( '8.1.278' ) )
+
+
+@patch( 'ycm.vimsupport.GetIntValue', return_value = 1 )
+def VimSupportsPopupWindows_Memo_test( *args ):
+  vimsupport.MEMO = {}
+
+  try:
+    assert_that( vimsupport.VimSupportsPopupWindows() )
+    assert_that( vimsupport.MEMO, is_not( empty() ) )
+
+    # If the momizer did not step in, we would throw an error in the following
+    # call to VimVersionAtLeast
+    with patch( 'ycm.vimsupport.VimHasFunctions', side_effect = RuntimeError ):
+      assert_that( vimsupport.VimSupportsPopupWindows() )
+  finally:
+    vimsupport.MEMO = {}
+
+
+@patch( 'ycm.vimsupport.GetIntValue', return_value = 1 )
+def VimHasFunction_Memo_test( GetIntValue ):
+  vimsupport.MEMO = {}
+
+  try:
+    assert_that( vimsupport.VimHasFunction( 'test' ) )
+    assert_that( vimsupport.MEMO, is_not( empty() ) )
+
+    GetIntValue.return_value = 0
+
+    # If the memoizer didn't kick in, the following call would return False
+    assert_that( vimsupport.VimHasFunction( 'test' ) )
+
+  finally:
+    vimsupport.MEMO = {}

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -79,6 +79,10 @@ NO_COMPLETIONS = {
   'completions': []
 }
 
+# checking for existence of funcitons is a little slow and can't change at
+# tuntime, so we cache the results
+_VIM_SUPPORTS_POPUP_WINDOWS = None
+
 
 def CurrentLineAndColumn():
   """Returns the 0-based current line and 0-based current column."""
@@ -1261,14 +1265,18 @@ def AutoCloseOnCurrentBuffer( name ):
 
 
 def VimSupportsPopupWindows():
-  return VimHasFunctions( 'popup_create',
-                          'popup_move',
-                          'popup_hide',
-                          'popup_settext',
-                          'popup_show',
-                          'popup_close',
-                          'prop_add',
-                          'prop_type_add' )
+  global _VIM_SUPPORTS_POPUP_WINDOWS
+  if _VIM_SUPPORTS_POPUP_WINDOWS is None:
+    _VIM_SUPPORTS_POPUP_WINDOWS =  VimHasFunctions( 'popup_create',
+                                                    'popup_move',
+                                                    'popup_hide',
+                                                    'popup_settext',
+                                                    'popup_show',
+                                                    'popup_close',
+                                                    'prop_add',
+                                                    'prop_type_add' )
+
+  return _VIM_SUPPORTS_POPUP_WINDOWS
 
 
 def VimHasFunctions( *functions ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -322,11 +322,13 @@ class YouCompleteMe( object ):
 
 
   def SendSignatureHelpRequest( self ):
+    """Send a signature help request, if we're ready to. Return whether or not a
+    request was sent (and should be checked later)"""
     if not self.NativeFiletypeCompletionUsable():
-      return
+      return False
 
     if not self._latest_completion_request:
-      return
+      return False
 
     for filetype in vimsupport.CurrentFiletypes():
       if not self._signature_help_available_requests[ filetype ].Done():
@@ -340,7 +342,7 @@ class YouCompleteMe( object ):
       if sig_help_available == 'PENDING':
         # Send another /signature_help_available request
         self._signature_help_available_requests[ filetype ].Start( filetype )
-        return
+        return False
 
       request_data = self._latest_completion_request.request_data.copy()
       request_data[ 'signature_help_state' ] = self._signature_help_state.state
@@ -349,6 +351,7 @@ class YouCompleteMe( object ):
 
       self._latest_signature_help_request = SignatureHelpRequest( request_data )
       self._latest_signature_help_request.Start()
+      return True
 
 
   def SignatureHelpRequestReady( self ):

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -132,7 +132,7 @@ function! Test_Signatures_After_Trigger()
           \     pyxeval(
           \       'ycm_state.SignatureHelpRequestReady()'
           \     ),
-          \     'sig help request reqdy'
+          \     'sig help request ready'
           \   )
           \ } )
     call WaitForAssert( {->
@@ -140,7 +140,7 @@ function! Test_Signatures_After_Trigger()
           \     pyxeval(
           \       "bool( ycm_state.GetSignatureHelpResponse()[ 'signatures' ] )"
           \     ),
-          \     'sig help request reqdy'
+          \     'sig help request has signatures'
           \   )
           \ } )
     call WaitForAssert( {->


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fixes #3549 

See comment : https://github.com/ycm-core/YouCompleteMe/issues/3549#issuecomment-559936332

Previously, when we called `RequestSignatureHelp` there were a number of reasons why we wouldn't send the request. In these cases, `SignatureHelpRequstReady` would always be false, so we'd poll it every 10ms forever, or until the timer was cancelled. Meanwhile, a separate bug meant that if the timer was already running and you keep typing, we would start more timers, without waiting for (or killing) the existing poll timer.

To solve the former: we return `False` from `SendSignatureHelpRequest` if we didn't send a request, and we make sure to only send one request.
To solve the latter: we stop calling `timer_stop` directly and make sure that we use `s:StopPoller` which both stops the poller and resets the timer id. This means we can always check for -1 to mean no poller is running. We then check this in `s:RequestSignatureHelp` to prevent starting multiple polls.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3550)
<!-- Reviewable:end -->
