### PR TITLE
[READY] Poll messages for all visible filetypes

### DIFF
--- a/python/ycm/client/messages_request.py
+++ b/python/ycm/client/messages_request.py
@@ -34,9 +34,9 @@ TIMEOUT_SECONDS = 60
 
 
 class MessagesPoll( BaseRequest ):
-  def __init__( self ):
+  def __init__( self, buff ):
     super( MessagesPoll, self ).__init__()
-    self._request_data = BuildRequestData()
+    self._request_data = BuildRequestData( buff.number )
     self._response_future = None
 
 

--- a/python/ycm/tests/mock_utils.py
+++ b/python/ycm/tests/mock_utils.py
@@ -68,18 +68,18 @@ class FakeFuture( object ):
 
 
 def MockAsyncServerResponseDone( response ):
-  """Return a fake future object that is complete with the supplied response
-  message. Suitable for mocking a response future within a client request. For
-  example:
+  """Return a MessagePoll containing a fake future object that is complete with
+  the supplied response message. Suitable for mocking a response future within
+  a client request. For example:
 
-    server_message = {
-      'message': 'this message came from the server'
-    }
-
-    with patch.object( ycm._message_poll_request,
-                       '_response_future',
-                       new = MockAsyncServerResponseDone( [] ) ) as mock_future:
-      ycm.OnPeriodicTick() # Uses ycm._message_poll_request ...
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 1 ) ) as v:
+    mock_response = MockAsyncServerResponseDone( response )
+    with patch.dict( ycm._message_poll_requests, {} ):
+      ycm._message_poll_requests[ filetype ] = MessagesPoll( v.current.buffer )
+      ycm._message_poll_requests[ filetype ]._response_future = mock_response
+      # Needed to keep a reference to the mocked dictionary
+      mock_future = ycm._message_poll_requests[ filetype ]._response_future
+      ycm.OnPeriodicTick() # Uses ycm._message_poll_requests[ filetype ] ...
   """
   return mock.MagicMock( wraps = FakeFuture( True, response ) )
 
@@ -88,10 +88,14 @@ def MockAsyncServerResponseInProgress():
   """Return a fake future object that is incomplete. Suitable for mocking a
   response future within a client request. For example:
 
-    with patch.object( ycm._message_poll_request,
-                       '_response_future',
-                       new = MockAsyncServerResponseInProgress() ):
-      ycm.OnPeriodicTick() # Uses ycm._message_poll_request ...
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 1 ) ) as v:
+    mock_response = MockAsyncServerResponseInProgress()
+    with patch.dict( ycm._message_poll_requests, {} ):
+      ycm._message_poll_requests[ filetype ] = MessagesPoll( v.current.buffer )
+      ycm._message_poll_requests[ filetype ]._response_future = mock_response
+      # Needed to keep a reference to the mocked dictionary
+      mock_future = ycm._message_poll_requests[ filetype ]._response_future
+      ycm.OnPeriodicTick() # Uses ycm._message_poll_requests[ filetype ] ...
   """
   return mock.MagicMock( wraps = FakeFuture( False ) )
 
@@ -100,11 +104,14 @@ def MockAsyncServerResponseException( exception ):
   """Return a fake future object that is complete, but raises an exception.
   Suitable for mocking a response future within a client request. For example:
 
-    exception = RuntimeError( 'Check client handles exception' )
-    with patch.object( ycm._message_poll_request,
-                       '_response_future',
-                       new = MockAsyncServerResponseException( exception ) ):
-      ycm.OnPeriodicTick() # Uses ycm._message_poll_request ...
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 1 ) ) as v:
+    mock_response = MockAsyncServerResponseException( exception )
+    with patch.dict( ycm._message_poll_requests, {} ):
+      ycm._message_poll_requests[ filetype ] = MessagesPoll( v.current.buffer )
+      ycm._message_poll_requests[ filetype ]._response_future = mock_response
+      # Needed to keep a reference to the mocked dictionary
+      mock_future = ycm._message_poll_requests[ filetype ]._response_future
+      ycm.OnPeriodicTick() # Uses ycm._message_poll_requests[ filetype ] ...
   """
   return mock.MagicMock( wraps = FakeFuture( True, None, exception ) )
 

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -43,3 +43,18 @@ function! Test_MessagePoll_After_LocationList()
   call assert_true( empty( getloclist( 0 ) ) )
   %bwipeout!
 endfunction
+
+function! Test_MessagePoll_Multiple_Filetypes()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/third_party/ycmd/ycmd/tests/java/testdata/simple_eclipse_project' .
+        \ '/src/com/test/TestLauncher.java', {} )
+  call WaitForAssert( {-> assert_true( len( sign_getplaced( '%' )[ 0 ][ 'signs' ] ) ) } )
+  let java_signs = sign_getplaced( '%' )[ 0 ][ 'signs' ]
+  vsplit testdata/diagnostics/foo.cpp
+  " Make sure we've left the java buffer
+  call assert_equal( java_signs, sign_getplaced( '#' )[ 0 ][ 'signs' ] )
+  " Clangd emits two diagnostics for foo.cpp.
+  call WaitForAssert( {-> assert_equal( 2, len( sign_getplaced( '%' )[ 0 ][ 'signs' ] ) ) } )
+  let cpp_signs = sign_getplaced( '%' )[ 0 ][ 'signs' ]
+  call assert_false( java_signs == cpp_signs )
+endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

This fixes a long standing bug that makes the message poll available only for a single filetype.

RFC because of the two `FIXME:` comments that should be discussed.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3551)
<!-- Reviewable:end -->
