### PR TITLE
[READY] Vimspector: Allow running nose tests under vimspector

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,0 +1,52 @@
+{
+  "configurations": {
+    "python - launch nosetests": {
+      "adapter": "vscode-python",
+      "variables": [
+        {
+          "python": {
+            "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which python); else echo \"${dollar}VIRTUAL_ENV/bin/python\"; fi'"
+          },
+          "nosetests": {
+            "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which nosetests); else echo \"${dollar}VIRTUAL_ENV/bin/nosetests\"; fi'"
+          }
+        },
+        {
+          "python_path": {
+            "shell": [
+              "${python}",
+              "${workspaceRoot}/run_tests.py",
+              "--dump-path"
+            ]
+          }
+        }
+      ],
+      "configuration": {
+        "name": "Python nosetests",
+        "type": "vscode-python",
+        "request": "launch",
+
+        "cwd": "${workspaceRoot}",
+        "stopOnEntry": true,
+        "console": "integratedTerminal",
+        "justMyCode": false,
+
+        "debugOptions": [],
+
+        "program": "${nosetests}",
+        "pythonPath": "${python}",
+        "args": [
+          "-v",
+          "--with-id",
+          "--ignore-files=(^\\.|^setup\\.py$$)",
+          "${Test}"
+        ],
+        "env": {
+          "PYTHONPATH": "${python_path}",
+          "LD_LIBRARY_PATH": "${workspaceRoot}/third_party/ycmd/this_party/clang/lib",
+          "YCM_TEST_NO_RETRY": "1"
+        }
+      }
+    }
+  }
+}

--- a/run_tests.py
+++ b/run_tests.py
@@ -52,6 +52,9 @@ def ParseArguments():
                        help = 'Enable coverage report' )
   parser.add_argument( '--no-flake8', action = 'store_true',
                        help = 'Do not run flake8' )
+  parser.add_argument( '--dump-path', action = 'store_true',
+                       help = 'Dump the PYTHONPATH required to run tests '
+                              'manually, then exit.' )
 
   parsed_args, nosetests_args = parser.parse_known_args()
 
@@ -90,8 +93,13 @@ def NoseTests( parsed_args, extra_nosetests_args ):
 
 def Main():
   ( parsed_args, nosetests_args ) = ParseArguments()
+  if parsed_args.dump_path:
+    print( os.environ[ 'PYTHONPATH' ] )
+    sys.exit()
+
   if not parsed_args.no_flake8:
     RunFlake8()
+
   BuildYcmdLibs( parsed_args )
   NoseTests( parsed_args, nosetests_args )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Allows running our python tests under vimspector. 

I use this with these:

* [compiler plugin](https://github.com/puremourning/.vim-mac/blob/master/compiler/ycmd_test.vim)
* [ftplugin mappings](https://github.com/puremourning/.vim-mac/blob/5fb39207e3c0369a09509e2ec17d62dcee6ec9d4/ftplugin/python.vim#L122-L128)

Ultimately I just hit `<C-S-T>` to run the test under cursor in vimspector.

But in practice you can just press F5 and enter the full path to the file (or other nosetest arguments) when prompted.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3554)
<!-- Reviewable:end -->
