### PR TITLE
Signature Help: Enable syntax highlighting in the popup

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -169,23 +169,10 @@ function! youcompleteme#Enable()
 
   if exists( '*prop_type_add' ) && exists( '*prop_type_delete' )
     call prop_type_delete( 'YCM-signature-help-current-argument' )
-    call prop_type_delete( 'YCM-signature-help-current-signature' )
-    call prop_type_delete( 'YCM-signature-help-signature' )
-
     call prop_type_add( 'YCM-signature-help-current-argument', {
           \   'highlight': 'PMenuSel',
           \   'combine':   0,
           \   'priority':  50,
-          \ } )
-    call prop_type_add( 'YCM-signature-help-current-signature', {
-          \   'highlight': 'PMenu',
-          \   'combine':   0,
-          \   'priority':  40,
-          \ } )
-    call prop_type_add( 'YCM-signature-help-signature', {
-          \   'highlight': 'PMenuSbar',
-          \   'combine':   0,
-          \   'priority':  40,
           \ } )
   endif
 endfunction

--- a/python/ycm/signature_help.py
+++ b/python/ycm/signature_help.py
@@ -125,7 +125,7 @@ def UpdateSignatureHelp( state, signature_info ): # noqa
 
   # Don't allow the popup to overlap the pum
   if line > 0 and GetIntValue( 'pumvisible()' ):
-    pum_line = GetIntValue( vim.eval( 'pum_getpos().row' ) ) + 1
+    pum_line = GetIntValue( 'pum_getpos().row' ) + 1
     if pos == 'botleft' and pum_line <= line:
       line = 0
     elif ( pos == 'topleft' and
@@ -167,9 +167,9 @@ def UpdateSignatureHelp( state, signature_info ): # noqa
   }
 
   if not state.popup_win_id:
-    state.popup_win_id = GetIntValue( vim.eval( "popup_create( {}, {} )".format(
+    state.popup_win_id = GetIntValue( "popup_create( {}, {} )".format(
       json.dumps( buf_lines ),
-      json.dumps( options ) ) ) )
+      json.dumps( options ) ) )
   else:
     vim.eval( 'popup_settext( {}, {} )'.format(
       state.popup_win_id,


### PR DESCRIPTION
We *don't* want to enable 'filetype' in the popup - this actually leads
to YCM trying to parse the signature help buffer and various other
autocommands the we don't want. Just enabling the syntax allows for
Syntax autocommnds to even customise the display (I guess), but doesn't
have lots of lag like filetype setting.

In order to differentiate the current signature, we used to use
some text properties to mimic the completion popup. This doesn't work
with syntax highlighting (it overrides it), so we remove that and use
the syntax file's 'CursorLine' highlighting. This works nicely.

Note: There's a "cursorline" option to popup_open, but we don't want to
use that, as it actually uses 'PMenuSel', and is essentially designed
for poup menu-like things. We actually use PMenuSel for the current
_argument_ highlighting anyway.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Highlighting the popup might be more visually pleasing.

Demo:

![YCM-sig-help-syntax-cursorline](https://user-images.githubusercontent.com/10584846/70850053-26917180-1e7e-11ea-8ae8-1fb891270cf3.gif)


[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3555)
<!-- Reviewable:end -->
