### PR TITLE
RFC: WIP - Hover support

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -554,6 +554,17 @@ function s:StopPoller( poller ) abort
 endfunction
 
 
+function! s:SetUpHover()
+  if !s:AllowedToCompleteInCurrentBuffer() || get( g:, 'ycm_disable_hover', 0 )
+    return
+  endif
+
+
+  if exists( '*popup_beval' )
+  endif
+endfunction
+
+
 function! s:OnVimLeave()
   " Workaround a NeoVim issue - not shutting down timers correctly
   " https://github.com/neovim/neovim/issues/6840
@@ -598,6 +609,7 @@ function! s:OnFileTypeSet()
   call s:SetUpCompleteopt()
   call s:SetCompleteFunc()
   call s:StartMessagePoll()
+  call s:SetUpHover()
 
   exec s:python_command "ycm_state.OnFileTypeSet()"
   call s:OnFileReadyToParse( 1 )
@@ -612,6 +624,7 @@ function! s:OnBufferEnter()
 
   call s:SetUpCompleteopt()
   call s:SetCompleteFunc()
+  call s:SetUpHover()
 
   exec s:python_command "ycm_state.OnBufferVisit()"
   " Last parse may be outdated because of changes from other buffers. Force a

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -559,13 +559,15 @@ endfunction
 
 
 function! s:SetUpHover()
-  if !s:AllowedToCompleteInCurrentBuffer() || get( g:, 'ycm_disable_hover', 0 )
+  if !s:AllowedToCompleteInCurrentBuffer() || !get( g:, 'ycm_enable_hover', 0 )
     return
   endif
 
+  " TODO: Set this only for semantically-supported filetypes ?
 
-  if exists( '*popup_beval' )
-  endif
+  setlocal balloonexpr=YCMHover()
+  setlocal ballooneval
+  setlocal balloonevalterm
 endfunction
 
 
@@ -613,7 +615,6 @@ function! s:OnFileTypeSet()
   call s:SetUpCompleteopt()
   call s:SetCompleteFunc()
   call s:StartMessagePoll()
-  call s:SetUpHover()
 
   exec s:python_command "ycm_state.OnFileTypeSet()"
   call s:OnFileReadyToParse( 1 )
@@ -628,7 +629,6 @@ function! s:OnBufferEnter()
 
   call s:SetUpCompleteopt()
   call s:SetCompleteFunc()
-  call s:SetUpHover()
 
   exec s:python_command "ycm_state.OnBufferVisit()"
   " Last parse may be outdated because of changes from other buffers. Force a
@@ -705,6 +705,10 @@ function! s:PollFileParseResponse( ... )
   exec s:python_command "ycm_state.HandleFileParseRequest()"
   if s:Pyeval( "ycm_state.ShouldResendFileParseRequest()" )
     call s:OnFileReadyToParse( 1 )
+  endif
+
+  if s:Pyeval( "ycm_state.NativeFiletypeCompletionUsable()" )
+    call s:SetUpHover()
   endif
 endfunction
 

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -94,7 +94,7 @@ class CommandRequest( BaseRequest ):
     if 'detailed_info' in self._response:
       return self._response[ 'detailed_info' ]
 
-    return '[No data]'
+    return None
 
 
   def RunPostCommandActionsIfNeeded( self,

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -73,6 +73,30 @@ class CommandRequest( BaseRequest ):
     return self._response
 
 
+  def GetResponseTextOnly( self ):
+    if self._response is None and self._response_future is not None:
+      # This is a blocking call if not Done()
+      self.Response()
+
+    if self._response is None:
+      # An exception was raised and handled.
+      return
+
+    # If not a dictionary or a list, the response is necessarily a
+    # scalar: boolean, number, string, etc. In this case, we print
+    # it to the user.
+    if not isinstance( self._response, ( dict, list ) ):
+      return self._response
+
+    if 'message' in self._response:
+      return self._response[ 'message' ]
+
+    if 'detailed_info' in self._response:
+      return self._response[ 'detailed_info' ]
+
+    return '[No data]'
+
+
   def RunPostCommandActionsIfNeeded( self,
                                      buffer_command,
                                      modifiers ):
@@ -165,13 +189,6 @@ class CommandRequest( BaseRequest ):
 
   def _HandleDetailedInfoResponse( self ):
     vimsupport.WriteToPreviewWindow( self._response[ 'detailed_info' ] )
-
-
-def SendCommandRequestAsync( arguments, extra_data = None ):
-  request = CommandRequest( arguments, extra_data )
-  request.Start()
-  # Don't block
-  return request
 
 
 def SendCommandRequest( arguments,

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -133,11 +133,15 @@ class CommandRequest( BaseRequest ):
 
 
   def _HandleBasicResponse( self ):
-    vimsupport.PostVimMessage( self._response, warning = False )
+    vimsupport.PostVimMessage( self._response,
+                               warning = False,
+                               popup = True )
 
 
   def _HandleMessageResponse( self ):
-    vimsupport.PostVimMessage( self._response[ 'message' ], warning = False )
+    vimsupport.PostVimMessage( self._response[ 'message' ],
+                               warning = False,
+                               popup = True )
 
 
   def _HandleDetailedInfoResponse( self ):

--- a/python/ycm/tests/postcomplete_test.py
+++ b/python/ycm/tests/postcomplete_test.py
@@ -134,6 +134,7 @@ def _SetUpCompleteDone( completions ):
     yield request
 
 
+# TODO/FIXME: REplace these (essentially pointless) tets with vim-layer tests
 @patch( 'ycm.vimsupport.CurrentFiletypes', return_value = [ 'ycmtest' ] )
 def OnCompleteDone_DefaultFixIt_test( *args ):
   request = CompletionRequest( None )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -591,10 +591,41 @@ def NumLinesInBuffer( buffer_object ):
   return len( buffer_object )
 
 
+def VimSupportsPopupWindows():
+  return vim.eval( 'exists( "*popup_notification" )' )
+
+
 # Calling this function from the non-GUI thread will sometimes crash Vim. At
 # the time of writing, YCM only uses the GUI thread inside Vim (this used to
 # not be the case).
-def PostVimMessage( message, warning = True, truncate = False ):
+def PostVimMessage( message,
+                    warning = True,
+                    truncate = False,
+                    popup = False ):
+  if popup and VimSupportsPopupWindows():
+    return _PostVimMessageAsPopup( message, warning )
+
+  return _PostVimMessageToCommandLine( message, warning, truncate )
+
+
+def _PostVimMessageAsPopup( message, warning ):
+  if not isinstance( message, list ):
+    message = message.splitlines()
+  # FIXME: The deafult positioning is _terrible_
+  # Let's put it near to the status line
+
+  options = {
+    'highlight': 'WarningMsg' if warning else 'PMenu',
+    'line': vim.options[ 'lines' ] - vim.options[ 'cmdheight' ],
+    'col': 1,
+    'pos': 'botleft'
+  }
+  vim.eval( "popup_notification( {}, {} )".format( json.dumps( message ),
+                                                   json.dumps( options ) ) )
+
+
+
+def _PostVimMessageToCommandLine( message, warning, truncate ):
   """Display a message on the Vim status line. By default, the message is
   highlighted and logged to Vim command-line history (see :h history).
   Unset the |warning| parameter to disable this behavior. Set the |truncate|

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -591,10 +591,6 @@ def NumLinesInBuffer( buffer_object ):
   return len( buffer_object )
 
 
-def VimSupportsPopupWindows():
-  return vim.eval( 'exists( "*popup_notification" )' )
-
-
 # Calling this function from the non-GUI thread will sometimes crash Vim. At
 # the time of writing, YCM only uses the GUI thread inside Vim (this used to
 # not be the case).

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -438,7 +438,7 @@ class YouCompleteMe( object ):
     self._latest_async_command_request = None
 
     if text is None:
-      return [ '[No data]' ]
+      return ''
 
     return text.splitlines()
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -406,9 +406,17 @@ class YouCompleteMe( object ):
                                extra_data )
 
 
+  def GetDefinedSubcommandsAsync( self ):
+    request = BaseRequest()
+    future = request.PostDataToHandlerAsync( BuildRequestData(),
+                                             'defined_subcommands' )
+
+    return request, future
+
+
   def GetDefinedSubcommands( self ):
-    subcommands = BaseRequest().PostDataToHandler( BuildRequestData(),
-                                                   'defined_subcommands' )
+    request, future = self.GetDefinedSubcommandsAsync()
+    subcommands = request.HandleFuture( future )
     return subcommands if subcommands else []
 
 


### PR DESCRIPTION
Opening this for discussion/demo.

this does 2 things:

* Makes the Command responses display in a popup above the command line (I realise this is contentious)
* Supports _hover_ (using GetType for now)

To enable hover add this to `vimrc`, or write it to a file and run `vim -S that_file.vim`:

```viml
set balloonexpr=YCMHover()
set ballooneval
set balloonevalterm
```

Demos:

![YCM-hover](https://user-images.githubusercontent.com/10584846/71314473-eb281180-2440-11ea-8167-a0dd821fc071.gif)

<img width="579" alt="Screenshot 2019-12-21 at 22 27 13" src="https://user-images.githubusercontent.com/10584846/71314479-0d219400-2441-11ea-9d20-4e4861b75494.png">

All WIP, all up for discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3564)
<!-- Reviewable:end -->
