### PR TITLE
Add RLS config and usage information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1504,7 +1504,26 @@ In case you are running Python 2.7.8 and older, you will need to manually
 install [rustup][].
 
 To [configure RLS](#lsp-configuration) look up [rls configuration options][
-rls-preferences]
+rls-preferences]. The value of the `ls` key must be structured as in the
+following example:
+
+```python
+def Settings( **kwargs ):
+  if kwargs[ 'language' ] == 'rust':
+    return {
+        'ls': {
+            'rust': {
+                'features': ['http2','spnego'],
+                'all_targets': False,
+                'wait_to_build': 1500,
+            }
+        }
+    }
+```
+
+That is to say, `ls` should be paired with a dictionary containing a key `rust`,
+which should be paired with another dictionary in which the keys are RLS
+options.
 
 ### Go Semantic Completion
 

--- a/README.md
+++ b/README.md
@@ -1525,6 +1525,10 @@ That is to say, `ls` should be paired with a dictionary containing a key `rust`,
 which should be paired with another dictionary in which the keys are RLS
 options.
 
+Also, for the time being, if you make changes to your `Cargo.toml` that RLS
+doesn't seem to recognize, you may need to restart it manually with
+`:YcmCompleter RestartServer`.
+
 ### Go Semantic Completion
 
 Completions and GoTo commands should work out of the box (provided that you


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

The proper way to structure the `ls` dictionary for RLS is somewhat obscure, so this PR adds a brief passage in the README explaining it. It also makes mention of needing to restart RLS in order for it to register changes to `Cargo.toml`, since having it register those changes automatically would require didChangeWatchedFiles support (see [ycm-core/ycmd#1296](https://github.com/ycm-core/ycmd/pull/1296)).

This doc change is motivated by a [Gitter conversation](https://gitter.im/Valloric/YouCompleteMe?at=5e29630801914e3e0432eb30) in which @bstaletic and I were briefly puzzled over the right way to pass options to RLS. Even after we figured it out, I was still having trouble getting the right behavior from RLS+Cargo; @bstaletic suggested restarting RLS due to the above-mentioned issue, which worked, hence the tip about that.

I believe these changes will help other people who encounter these issues to solve them on their own.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3578)
<!-- Reviewable:end -->
