### PR TITLE
[READY] Use inverse video for current argument

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -168,10 +168,11 @@ function! youcompleteme#Enable()
   let s:completion = s:default_completion
 
   if exists( '*prop_type_add' ) && exists( '*prop_type_delete' )
+    hi default YCMInverse term=reverse cterm=reverse gui=reverse
     call prop_type_delete( 'YCM-signature-help-current-argument' )
     call prop_type_add( 'YCM-signature-help-current-argument', {
-          \   'highlight': 'PMenuSel',
-          \   'combine':   0,
+          \   'highlight': 'YCMInverse',
+          \   'combine':   1,
           \   'priority':  50,
           \ } )
   endif

--- a/test/docker/ci/image/Dockerfile
+++ b/test/docker/ci/image/Dockerfile
@@ -56,6 +56,9 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew &&\
     echo "eval \$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" \
         > /etc/bash.bashrc
 
+# Python
+RUN ${YCM_VIM_PYTHON} -m pip install --upgrade pip setuptools wheel
+
 # clean up
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
     /home/linuxbrew/.linuxbrew/bin/brew cleanup && \


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

In some colour schemes, it's not appropriate to layer the syntax highlighting on the PMenu colours.

So in order to provide a highlight of the current argument that's guaranteed to have the right contrast, we just use inverse colours instead.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3589)
<!-- Reviewable:end -->
