### PR TITLE
[READY] Stabilise CI

### DIFF
--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -2,8 +2,8 @@ flake8                >= 3.0.0
 flake8-comprehensions >= 1.4.1
 flake8-ycm            >= 0.1.0
 PyHamcrest            >= 1.10.1
-coverage              >= 4.2
 codecov               >= 2.0.5
+coverage              <5.0
 covimerage            >= 0.2.0
 pytest
 pytest-cov

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -70,9 +70,7 @@ class BaseRequest:
     from this message."""
     try:
       try:
-        result = _JsonFromFuture( future )
-        _logger.debug( 'RX: %s', result )
-        return result
+        return _JsonFromFuture( future )
       except UnknownExtraConf as e:
         if vimsupport.Confirm( str( e ) ):
           _LoadExtraConfFile( e.extra_conf_file )
@@ -168,7 +166,7 @@ class BaseRequest:
 
     headers = BaseRequest._ExtraHeaders( method, request_uri )
 
-    _logger.debug( 'GET %s\n%s', request_uri, headers )
+    _logger.debug( 'GET %s (%s)\n%s', request_uri, payload, headers )
 
     return BaseRequest.Session().get(
       request_uri,
@@ -252,6 +250,7 @@ def BuildRequestData( buffer_number = None ):
 
 def _JsonFromFuture( future ):
   response = future.result()
+  _logger.debug( 'RX: %s\n%s', response, response.text )
   _ValidateResponseObject( response )
   if response.status_code == BaseRequest.Requests().codes.server_error:
     raise MakeServerException( response.json() )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -34,8 +34,8 @@ from ycm.client.base_request import BaseRequest, BuildRequestData
 from ycm.client.completer_available_request import SendCompleterAvailableRequest
 from ycm.client.command_request import SendCommandRequest
 from ycm.client.completion_request import CompletionRequest
-from ycm.client.signature_help_request import SignatureHelpRequest
-from ycm.client.signature_help_request import SigHelpAvailableByFileType
+from ycm.client.signature_help_request import ( SignatureHelpRequest,
+                                                SigHelpAvailableByFileType )
 from ycm.client.debug_info_request import ( SendDebugInfoRequest,
                                             FormatDebugInfoResponse )
 from ycm.client.omni_completion_request import OmniCompletionRequest
@@ -328,7 +328,7 @@ class YouCompleteMe:
       if sig_help_available == 'PENDING':
         # Send another /signature_help_available request
         self._signature_help_available_requests[ filetype ].Start( filetype )
-        return False
+        continue
 
       request_data = self._latest_completion_request.request_data.copy()
       request_data[ 'signature_help_state' ] = self._signature_help_state.state
@@ -338,6 +338,8 @@ class YouCompleteMe:
       self._latest_signature_help_request = SignatureHelpRequest( request_data )
       self._latest_signature_help_request.Start()
       return True
+
+    return False
 
 
   def SignatureHelpRequestReady( self ):
@@ -523,11 +525,12 @@ class YouCompleteMe:
 
 
   def OnBufferVisit( self ):
-    filetype = vimsupport.CurrentFiletypes()[ 0 ]
-    # The constructor of dictionary values starts the request,
-    # so the line below fires a new request only if the dictionary
-    # value is accessed for the first time.
-    self._signature_help_available_requests[ filetype ].Done()
+    for filetype in vimsupport.CurrentFiletypes():
+      # The constructor of dictionary values starts the request,
+      # so the line below fires a new request only if the dictionary
+      # value is accessed for the first time.
+      self._signature_help_available_requests[ filetype ].Done()
+
     extra_data = {}
     self._AddUltiSnipsDataIfNeeded( extra_data )
     SendEventNotificationAsync( 'BufferVisit', extra_data = extra_data )

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -38,8 +38,11 @@ function! Test_MessagePoll_After_LocationList()
   call assert_equal( 'cpp', &ft )
   call WaitForAssert( {-> assert_equal( 1, len( sign_getplaced() ) ) } )
   call setline( 1, '' )
+  " Wait for the parse request to be complete otherwise we won't send another
+  " one when the TextChanged event fires
+  call WaitFor( {-> pyxeval( 'ycm_state.FileParseRequestReady()' ) } )
   doautocmd TextChanged
-  call WaitForAssert( {-> assert_true( empty( sign_getplaced() ) ) }, 10000 )
+  call WaitForAssert( {-> assert_true( empty( sign_getplaced() ) ) } )
   call assert_true( empty( getloclist( 0 ) ) )
   %bwipeout!
 endfunction

--- a/test/lib/autoload/youcompleteme/test/setup.vim
+++ b/test/lib/autoload/youcompleteme/test/setup.vim
@@ -35,13 +35,13 @@ function! youcompleteme#test#setup#OpenFile( f, kwargs ) abort
 
   if get( a:kwargs, 'native_ft', 1 )
     call WaitForAssert( {->
-  	\ assert_true( pyxeval( 'ycm_state.NativeFiletypeCompletionUsable()' ) )
-  	\ } )
-  
+        \ assert_true( pyxeval( 'ycm_state.NativeFiletypeCompletionUsable()' ) )
+        \ } )
+
     " Need to wait for the server to be ready. The best way to do this is to
     " force compile and diagnostics, though this only works for the c-based
-    " completers. For python and others, we actually need to parse the debug info
-    " to check the server state.
+    " completers. For python and others, we actually need to parse the debug
+    " info to check the server state.
     YcmForceCompileAndDiagnostics
   endif
 

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -7,6 +7,12 @@ function! s:_ClearSigHelp()
   unlet! s:popup_win_id
 endfunction
 
+function! s:_CheckSignatureHelpAvailable( filetype )
+  return pyxeval(
+        \ 'ycm_state.SignatureHelpAvailableRequestComplete('
+        \ . ' vim.eval( "a:filetype" ), False )' )
+endfunction
+
 function s:_GetSigHelpWinID()
   call WaitForAssert( {->
         \   assert_true(
@@ -116,7 +122,9 @@ function! Test_Signatures_After_Trigger()
         \ '/test/testdata/vim/mixed_filetype.vim',
         \ { 'native_ft': 0 } )
 
-  setf vim.python
+  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'vim' ) } )
+  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'python' ) } )
+
   call setpos( '.', [ 0, 3, 17 ] )
 
   " Required to trigger TextChangedI
@@ -184,6 +192,8 @@ function! Test_Signatures_With_PUM_NoSigns()
   call youcompleteme#test#setup#OpenFile(
         \ '/third_party/ycmd/ycmd/tests/clangd/testdata/general_fallback'
         \ . '/make_drink.cc', {} )
+
+  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'cpp' ) } )
 
   " Make sure that error signs don't shift the window
   setlocal signcolumn=no
@@ -257,6 +267,8 @@ function! Test_Signatures_With_PUM_Signs()
   call youcompleteme#test#setup#OpenFile(
         \ '/third_party/ycmd/ycmd/tests/clangd/testdata/general_fallback'
         \ . '/make_drink.cc', {} )
+
+  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'cpp' ) } )
 
   " Make sure that sign causes the popup to shift
   setlocal signcolumn=auto
@@ -496,6 +508,7 @@ endfunction
 
 function! Test_Signatures_TopLine()
   call youcompleteme#test#setup#OpenFile( 'test/testdata/python/test.py', {} )
+  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'python' ) } )
   call setpos( '.', [ 0, 1, 24 ] )
   call test_override( 'char_avail', 1 )
 
@@ -515,6 +528,7 @@ endfunction
 
 function! Test_Signatures_TopLineWithPUM()
   call youcompleteme#test#setup#OpenFile( 'test/testdata/python/test.py', {} )
+  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'python' ) } )
   call setpos( '.', [ 0, 1, 24 ] )
   call test_override( 'char_avail', 1 )
 

--- a/test/testdata/vim/mixed_filetype.vim
+++ b/test/testdata/vim/mixed_filetype.vim
@@ -2,3 +2,5 @@ pyx << EOF
 import os
 os.path.abspath(
 EOF
+
+" vim: ft=vim.python


### PR DESCRIPTION
The version of coverage required by covimerage is not compatible with
the current coverage version, so rather than downgrading it for our
python tests, we just use a different requirements file for vimscript
tests.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fixes this error in CI:

> ERROR: covimerage 0.2.1 has requirement coverage<5.0a6, but you'll have coverage 5.0.3 which is incompatible.

Should also fix coverage data for vimscript

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3592)
<!-- Reviewable:end -->
