### PR TITLE
Revert sign_define() as it's in a later version of vim

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -325,12 +325,11 @@ function! s:SetUpSigns()
     highlight link YcmWarningLine SyntasticWarningLine
   endif
 
-  call sign_define( 'YcmError', { 'text': g:ycm_error_symbol,
-                                \ 'texthl': 'YcmErrorSign',
-                                \ 'linehl': 'YcmErrorLine' } )
-  call sign_define( 'YcmWarning', { 'text': g:ycm_error_symbol,
-                                  \ 'texthl': 'YcmWarningSign',
-                                  \ 'linehl': 'YcmWarningLine' } )
+  exe 'sign define YcmError text=' . g:ycm_error_symbol .
+        \ ' texthl=YcmErrorSign linehl=YcmErrorLine'
+  exe 'sign define YcmWarning text=' . g:ycm_warning_symbol .
+        \ ' texthl=YcmWarningSign linehl=YcmWarningLine'
+
 endfunction
 
 


### PR DESCRIPTION
Fixes #3593

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3594)
<!-- Reviewable:end -->
