### PR TITLE
fix "no such variable" error

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -297,6 +297,7 @@ let g:ycm_python_binary_path =
 " Populate any other (undocumented) options set in the ycmd
 " default_settings.json. This ensures that any part of ycm that uses ycmd code
 " will have the default set. I'm looking at you, Omni-completer.
+let key = 0
 for key in keys( s:default_options )
   if ! has_key( g:, 'ycm_' . key )
     let g:[ 'ycm_' . key ] = s:default_options[ key ]


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

commit abb9d078 merged in october 2019 appears to introduce an error generated when starting vim w/ YCM installed

line  306:
E108: No such variable: "key"

(merged in: 12c4710d 2019-10-22 | Merge pull request #3412 from puremourning/signature-help [mergify[bot]] )

I'm not familiar w/ vimscript so i'm not sure if the normal looping idiom involves pre-initializing vars, but manually initializing the key var before the loop appears to resolve the issue.

No tests included because I can't see a simple way to test this.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3599)
<!-- Reviewable:end -->
