### PR TITLE
[READY] Add typescriptreact to diagnostics enabled filetypes

### DIFF
--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -20,7 +20,7 @@ from ycm.client.event_notification import EventNotification
 from ycm.diagnostic_interface import DiagnosticInterface
 
 DIAGNOSTIC_UI_FILETYPES = { 'cpp', 'cs', 'c', 'objc', 'objcpp', 'cuda',
-                            'javascript', 'typescript' }
+                            'javascript', 'typescript', 'typescriptreact' }
 
 
 # Emulates Vim buffer


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

For `foo.tsx` file, currently the diagnostics only arrive after `:YcmForceCompileAndDIagnostics`, because `typescriptreact` is missing from the `DIAGNOSTIC_UI_FILETYPES` set.

The vim level test is missing, mostly because I didn't feel like writing one. If you think I should write that test, I will. 

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3638)
<!-- Reviewable:end -->
