### PR TITLE
[READY] Add mods and size to :YcmToggleLogs

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,14 +1,11 @@
 {
   "configurations": {
-    "python - launch nosetests": {
-      "adapter": "vscode-python",
+    "python - launch pytest": {
+      "adapter": "debugpy",
       "variables": [
         {
           "python": {
             "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which python); else echo \"${dollar}VIRTUAL_ENV/bin/python\"; fi'"
-          },
-          "nosetests": {
-            "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which nosetests); else echo \"${dollar}VIRTUAL_ENV/bin/nosetests\"; fi'"
           }
         },
         {
@@ -22,28 +19,27 @@
         }
       ],
       "configuration": {
-        "name": "Python nosetests",
-        "type": "vscode-python",
+        "name": "Python run test",
+        "type": "debugpy",
         "request": "launch",
 
-        "cwd": "${workspaceRoot}",
-        "stopOnEntry": true,
+        "cwd": "${workspaceRoot}/python",
+        "stopOnEntry": false,
         "console": "integratedTerminal",
-        "justMyCode": false,
+        "justMyCode": true,
 
         "debugOptions": [],
 
-        "program": "${nosetests}",
-        "pythonPath": "${python}",
+        "module": "pytest",
+        "python": "${python}",
         "args": [
           "-v",
-          "--with-id",
-          "--ignore-files=(^\\.|^setup\\.py$$)",
+          "--tb=native",
           "${Test}"
         ],
         "env": {
           "PYTHONPATH": "${python_path}",
-          "LD_LIBRARY_PATH": "${workspaceRoot}/third_party/ycmd/this_party/clang/lib",
+          "LD_LIBRARY_PATH": "${workspaceRoot}/third_party/ycmd/third_party/clang/lib",
           "YCM_TEST_NO_RETRY": "1"
         }
       }

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1096,8 +1096,10 @@ endfunction
 function! s:SetUpCommands()
   command! YcmRestartServer call s:RestartServer()
   command! YcmDebugInfo call s:DebugInfo()
-  command! -nargs=* -complete=custom,youcompleteme#LogsComplete
-        \ YcmToggleLogs call s:ToggleLogs(<f-args>)
+  command! -nargs=* -complete=custom,youcompleteme#LogsComplete -count=0
+        \ YcmToggleLogs call s:ToggleLogs( <f-count>,
+                                         \ <f-mods>,
+                                         \ <f-args>)
   if py3eval( 'vimsupport.VimVersionAtLeast( "7.4.1898" )' )
     command! -nargs=* -complete=custom,youcompleteme#SubCommandsComplete -range
           \ YcmCompleter call s:CompleterCommand(<q-mods>,
@@ -1144,8 +1146,9 @@ function! s:DebugInfo()
 endfunction
 
 
-function! s:ToggleLogs(...)
-  py3 ycm_state.ToggleLogs( *vim.eval( 'a:000' ) )
+function! s:ToggleLogs( count, ... )
+  py3 ycm_state.ToggleLogs( vimsupport.GetIntValue( 'a:count' ),
+                          \ *vim.eval( 'a:000' ) )
 endfunction
 
 

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -253,16 +253,19 @@ def YouCompleteMe_ToggleLogs_WithParameters_test( open_filename,
                                                   ycm ):
   logfile_buffer = VimBuffer( ycm._client_logfile )
   with MockVimBuffers( [ logfile_buffer ], [ logfile_buffer ] ):
-    ycm.ToggleLogs( os.path.basename( ycm._client_logfile ),
+    ycm.ToggleLogs( 90,
+                    'botright vertical',
+                    os.path.basename( ycm._client_logfile ),
                     'nonexisting_logfile',
                     os.path.basename( ycm._server_stdout ) )
 
     open_filename.assert_has_exact_calls( [
-      call( ycm._server_stdout, { 'size': 12,
+      call( ycm._server_stdout, { 'size': 90,
                                   'watch': True,
                                   'fix': True,
                                   'focus': False,
-                                  'position': 'end' } )
+                                  'position': 'end',
+                                  'mods': 'botright vertical' } )
     ] )
     close_buffers_for_filename.assert_has_exact_calls( [
       call( ycm._client_logfile )
@@ -278,14 +281,15 @@ def YouCompleteMe_ToggleLogs_WithoutParameters_SelectLogfileNotAlreadyOpen_test(
 
   current_buffer = VimBuffer( 'current_buffer' )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
-    ycm.ToggleLogs()
+    ycm.ToggleLogs( 0, '' )
 
   open_filename.assert_has_exact_calls( [
     call( ycm._server_stderr, { 'size': 12,
                                 'watch': True,
                                 'fix': True,
                                 'focus': False,
-                                'position': 'end' } )
+                                'position': 'end',
+                                'mods': '' } )
   ] )
 
 
@@ -298,7 +302,7 @@ def YouCompleteMe_ToggleLogs_WithoutParameters_SelectLogfileAlreadyOpen_test(
 
   logfile_buffer = VimBuffer( ycm._server_stdout )
   with MockVimBuffers( [ logfile_buffer ], [ logfile_buffer ] ):
-    ycm.ToggleLogs()
+    ycm.ToggleLogs( 0, '' )
 
   close_buffers_for_filename.assert_has_exact_calls( [
     call( ycm._server_stdout )
@@ -314,7 +318,7 @@ def YouCompleteMe_ToggleLogs_WithoutParameters_NoSelection_test(
 
   current_buffer = VimBuffer( 'current_buffer' )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
-    ycm.ToggleLogs()
+    ycm.ToggleLogs( 0, '' )
 
   assert_that(
     # Argument passed to PostVimMessage.

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1152,7 +1152,8 @@ def OpenFilename( filename, options = {} ):
   - watch: automatically watch for changes (default: False). This is useful
   for logs;
   - position: set the position where the file is opened (default: start).
-  Choices are start and end."""
+  Choices are start and end.
+  - mods: The vim <mods> for the command, such as :vertical"""
 
   # Set the options.
   command = GetVimCommand( options.get( 'command', 'horizontal-split' ),
@@ -1170,7 +1171,10 @@ def OpenFilename( filename, options = {} ):
 
   # Open the file.
   try:
-    vim.command( '{0}{1} {2}'.format( size, command, filename ) )
+    vim.command( '{mods}{0}{1} {2}'.format( size,
+                                            command,
+                                            filename,
+                                            mods=options.get( 'mods', '' ) ) )
   # When the file we are trying to jump to has a swap file,
   # Vim opens swap-exists-choices dialog and throws vim.error with E325 error,
   # or KeyboardInterrupt after user selects one of the options which actually

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -674,16 +674,20 @@ class YouCompleteMe:
     return logfiles
 
 
-  def _OpenLogfile( self, logfile ):
+  def _OpenLogfile( self, size, mods, logfile ):
     # Open log files in a horizontal window with the same behavior as the
     # preview window (same height and winfixheight enabled). Automatically
     # watch for changes. Set the cursor position at the end of the file.
+    if not size:
+      size = vimsupport.GetIntValue( '&previewheight' )
+
     options = {
-      'size': vimsupport.GetIntValue( '&previewheight' ),
+      'size': size,
       'fix': True,
       'focus': False,
       'watch': True,
-      'position': 'end'
+      'position': 'end',
+      'mods': mods
     }
 
     vimsupport.OpenFilename( logfile, options )
@@ -693,7 +697,7 @@ class YouCompleteMe:
     vimsupport.CloseBuffersForFilename( logfile )
 
 
-  def ToggleLogs( self, *filenames ):
+  def ToggleLogs( self, size, mods, *filenames ):
     logfiles = self.GetLogfiles()
     if not filenames:
       sorted_logfiles = sorted( logfiles )
@@ -707,7 +711,7 @@ class YouCompleteMe:
 
       logfile = logfiles[ sorted_logfiles[ logfile_index ] ]
       if not vimsupport.BufferIsVisibleForFilename( logfile ):
-        self._OpenLogfile( logfile )
+        self._OpenLogfile( size, mods, logfile )
       else:
         self._CloseLogfile( logfile )
       return
@@ -719,7 +723,7 @@ class YouCompleteMe:
       logfile = logfiles[ filename ]
 
       if not vimsupport.BufferIsVisibleForFilename( logfile ):
-        self._OpenLogfile( logfile )
+        self._OpenLogfile( size, mods, logfile )
         continue
 
       self._CloseLogfile( logfile )

--- a/test/commands.test.vim
+++ b/test/commands.test.vim
@@ -1,0 +1,47 @@
+function! SetUp()
+  let g:ycm_use_clangd = 1
+  let g:ycm_keep_logfiles = 1
+  let g:ycm_log_level = 'DEBUG'
+  call youcompleteme#test#setup#SetUp()
+endfunction
+
+function! Test_ToggleLogs()
+  let log_files = pyxeval( 'ycm_state.GetLogfiles()' )
+  let bcount = len( getbufinfo() )
+
+  " default - show
+  exe 'YcmToggleLogs' keys( log_files )[ 0 ]
+  call assert_equal( bcount + 1, len( getbufinfo() ) )
+  let win = getbufinfo( keys( log_files )[ 0 ] )[ 0 ].windows[ 0 ]
+  call assert_equal( &previewheight, winheight( win_id2win( win ) ) )
+
+  " default - hide
+  exe 'YcmToggleLogs' keys( log_files )[ 0 ]
+  " buffer is wiped out
+  call assert_equal( bcount, len( getbufinfo() ) )
+  call assert_equal( [], getbufinfo( keys( log_files )[ 0 ] ) )
+
+  " show - 10 lines
+  exe '10YcmToggleLogs' keys( log_files )[ 0 ]
+  call assert_equal( bcount + 1, len( getbufinfo() ) )
+  let win = getbufinfo( keys( log_files )[ 0 ] )[ 0 ].windows[ 0 ]
+  call assert_equal( 10, winheight( win_id2win( win ) ) )
+
+  " hide
+  exe '10YcmToggleLogs' keys( log_files )[ 0 ]
+  call assert_equal( bcount, len( getbufinfo() ) )
+  call assert_equal( [], getbufinfo( keys( log_files )[ 0 ] ) )
+
+  " show - 15 cols
+  exe 'vertical 15YcmToggleLogs' keys( log_files )[ 0 ]
+  call assert_equal( bcount + 1, len( getbufinfo() ) )
+  let win = getbufinfo( keys( log_files )[ 0 ] )[ 0 ].windows[ 0 ]
+  call assert_equal( 15, winwidth( win_id2win( win ) ) )
+
+  " hide
+  exe 'YcmToggleLogs' keys( log_files )[ 0 ]
+  call assert_equal( bcount, len( getbufinfo() ) )
+  call assert_equal( [], getbufinfo( keys( log_files )[ 0 ] ) )
+
+  %bwipeout!
+endfunction


### PR DESCRIPTION
    Add range and mods to YcmToggleLogs
    
    Range allows a custom height to be specified.
    
    Mods allows things like :vertical YcmToggleLogs. This is most useful
    when used with a range, like :vertical 90YcmToggleLogs. This simply
    allows to open the logs in a vertical split which is useful for large
    logs.
    
    You can also :botright etc. See :help <mods>.


This is mostly useful with a user command: `command! YcmLogErr :botright vertical 75YcmToggleLogs ycmd*stderr*`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3647)
<!-- Reviewable:end -->
