### PR TITLE
[READY] Close the completion menu when there are no candidates

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -19,6 +19,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:DEBUG = 0
+
 " This needs to be called outside of a function
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
 let s:force_semantic = 0
@@ -535,6 +537,14 @@ function! s:OnCompleteDone()
     return
   endif
 
+  if s:DEBUG
+    call ch_log( 'ycm: s:OnCompleteDone()' .
+               \ ' - last_char_inserted_by_user=' .
+               \ s:last_char_inserted_by_user .
+               \ ' - v:completed_item=' .
+               \ string( v:completed_item ) )
+  endif
+
   let s:last_char_inserted_by_user = v:false
 
   py3 ycm_state.OnCompleteDone()
@@ -545,6 +555,14 @@ endfunction
 function! s:OnCompleteChanged()
   if !s:AllowedToCompleteInCurrentBuffer()
     return
+  endif
+
+  if s:DEBUG
+    call ch_log( 'ycm: s:OnCompleteChanged()' .
+               \ ' - last_char_inserted_by_user=' .
+               \ s:last_char_inserted_by_user .
+               \ ' - v:event=' .
+               \ string( v:event ) )
   endif
 
   if ! empty( v:event.completed_item )
@@ -688,6 +706,14 @@ function! s:OnInsertChar()
     return
   endif
 
+  if s:DEBUG
+    call ch_log( 'ycm: s:OnInsertChar()' .
+               \ ' - last_char_inserted_by_user=' .
+               \ s:last_char_inserted_by_user .
+               \ ' - v:char = ' .
+               \ v:char )
+  endif
+
   let s:last_char_inserted_by_user = v:true
 
   if s:completion_api == s:COMPLETION_COMPLETEFUNC
@@ -748,6 +774,12 @@ endfunction
 function! s:OnTextChangedInsertMode( popup_is_visible )
   if !s:AllowedToCompleteInCurrentBuffer()
     return
+  endif
+
+  if s:DEBUG
+    call ch_log( 'ycm: s:OnTextChangedInsertMode( ' . a:popup_is_visible . ')' .
+               \ ' - last_char_inserted_by_user=' .
+               \ s:last_char_inserted_by_user )
   endif
 
   if a:popup_is_visible && !s:last_char_inserted_by_user

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -72,8 +72,11 @@ let s:completion_api = get( g:,
                           \ 'ycm_use_completion_api',
                           \ s:COMPLETION_TEXTCHANGEDP )
 
-" Fall back to using completefunc if the TextChangedP API isn't available
-if !exists( '##TextChangedP' ) || s:completion_api != s:COMPLETION_TEXTCHANGEDP
+" Fall back to using completefunc if the TextChangedP/CompleteChanged API
+" isn't available. Both are needed to ensure correct behaviour with the 'new'
+" complete() api
+if !exists( '##TextChangedP' ) || !exists( '##CompleteChanged' )
+      \ || s:completion_api != s:COMPLETION_TEXTCHANGEDP
   let s:completion_api = s:COMPLETION_COMPLETEFUNC
 endif
 
@@ -544,6 +547,10 @@ function! s:OnCompleteChanged()
     return
   endif
 
+  if ! empty( v:event.completed_item )
+    let s:last_char_inserted_by_user = v:false
+  endif
+
   call s:UpdateSignatureHelp()
 endfunction
 
@@ -657,25 +664,23 @@ function! s:PollFileParseResponse( ... )
 endfunction
 
 
-if s:completion_api == s:COMPLETION_COMPLETEFUNC
-  function! s:SendKeys( keys )
-    " By default keys are added to the end of the typeahead buffer. If there are
-    " already keys in the buffer, they will be processed first and may change
-    " the state that our keys combination was sent for (e.g. <C-X><C-U><C-P> in
-    " normal mode instead of insert mode or <C-e> outside of completion mode).
-    " We avoid that by inserting the keys at the start of the typeahead buffer
-    " with the 'i' option. Also, we don't want the keys to be remapped to
-    " something else so we add the 'n' option.
-    call feedkeys( a:keys, 'in' )
-  endfunction
+function! s:SendKeys( keys )
+  " By default keys are added to the end of the typeahead buffer. If there are
+  " already keys in the buffer, they will be processed first and may change
+  " the state that our keys combination was sent for (e.g. <C-X><C-U><C-P> in
+  " normal mode instead of insert mode or <C-e> outside of completion mode).
+  " We avoid that by inserting the keys at the start of the typeahead buffer
+  " with the 'i' option. Also, we don't want the keys to be remapped to
+  " something else so we add the 'n' option.
+  call feedkeys( a:keys, 'in' )
+endfunction
 
 
-  function! s:CloseCompletionMenu()
-    if pumvisible()
-      call s:SendKeys( "\<C-e>" )
-    endif
-  endfunction
-endif
+function! s:CloseCompletionMenu()
+  if pumvisible()
+    call s:SendKeys( "\<C-e>" )
+  endif
+endfunction
 
 
 function! s:OnInsertChar()
@@ -768,13 +773,19 @@ function! s:OnTextChangedInsertMode( popup_is_visible )
     let s:force_semantic = 0
   endif
 
-  if exists( 'b:ycm_completing' ) &&
+  if get( b:, 'ycm_completing' ) &&
         \ ( g:ycm_auto_trigger || s:force_semantic ) &&
         \ !s:InsideCommentOrStringAndShouldStop() &&
         \ !s:OnBlankLine()
-    " The call to s:Complete here is absolutely necessary, to both prevent
-    " flicker and to ensure that tabbing throught the list does not continually
-    " filter the list to the selected element.
+    " The call to s:Complete here is necessary, to minimize flicker when we
+    " close the pum on every keypress. In that case, we try to quickly show it
+    " again with whatver the latest completion result is. When using complete(),
+    " we don't need to do this, as we only close the pum when there are no
+    " completions. However, it's still useful as we don't want Vim's filtering
+    " to _ever_ apply. Examples of when this is problematic is when typing some
+    " keys to filter (that are not a prefix of the completion), then deleting a
+    " character. Normally Vim would re-filter based on the new "query", but we
+    " don't want that.
     call s:Complete()
     call s:RequestCompletion()
 
@@ -907,7 +918,7 @@ function! s:RequestSemanticCompletion()
     return ''
   endif
 
-  if exists( 'b:ycm_completing' )
+  if get( b:, 'ycm_completing' )
     let s:force_semantic = 1
     if s:completion_api == s:COMPLETION_TEXTCHANGEDP
       call s:StopPoller( s:pollers.completion )
@@ -1014,11 +1025,15 @@ if s:completion_api == s:COMPLETION_TEXTCHANGEDP
       let s:completion.completion_start_column +=
             \ col( '.' ) - s:completion.column
     endif
-    let old_completeopt = &completeopt
-    set completeopt+=noselect
-    call complete( s:completion.completion_start_column,
-                 \ s:completion.completions )
-    let &completeopt = old_completeopt
+    if len( s:completion.completions )
+      let old_completeopt = &completeopt
+      set completeopt+=noselect
+      call complete( s:completion.completion_start_column,
+                   \ s:completion.completions )
+      let &completeopt = old_completeopt
+    elseif pumvisible()
+      call s:CloseCompletionMenu()
+    endif
   endfunction
 else
   function! s:Complete()
@@ -1162,7 +1177,7 @@ function! youcompleteme#GetCommandResponse( ... )
     return ''
   endif
 
-  if !exists( 'b:ycm_completing' )
+  if !get( b:, 'ycm_completing' )
     return ''
   endif
 


### PR DESCRIPTION
    Close the completion menu (get out of ctrl-x mode) when the set of
    completions we generate is empty. This gets the user out of ctrl-x mode
    and allows insert-mode mappings to work again.

    Fixing this caused a regression in the completedone handing, which
    highlighted another issue: we were not correctly identifying
    non-user-entered insert-mode changes during TextChangedP. We were
    relying on CompleteDone, but this is triggered too late or not at all.
    The only reliable way when tabbing though elements of the pum is the
    CompleteChanged event, which when combined with the
    v:event.completed_item key tells us that the change was due to a user
    changing the pum selection.

    Fixing the above resolved the regression in handling completion fixits
    and allows us to close the pum at the right time, but doing only one
    leaves one or other broken, so we have to guard the new API only to
    users with the CompleteChanged event available.

    It was initially thought that this meant we could skip calling
    s:Complete in the TextChangeInsertMode handler, but we actually want to
    call it anyway to ensure that it's _our_ completions that are shown, not
    any vim-based filtering.

Fixes #3651 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3656)
<!-- Reviewable:end -->
