### PR TITLE
[READY] Add auto-hover behaviour (on by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,17 @@ YCM also provides [semantic IDE-like features](#quick-feature-summary) in a
 number of languages, including:
 
 - displaying signature help (argument hints) when entering the arguments to a
-  function call
-- finding declarations, definitions, usages, etc. of identifiers,
-- displaying type information for classes, variables, functions etc.,
-- displaying documentation for methods, members, etc. in the preview window,
-- fixing common coding errors, like missing semi-colons, typos, etc.,
-- semantic renaming of variables across files,
+  function call (Vim only)
+- [finding declarations, definitions, usages](#goto-commands), etc.
+  of identifiers,
+- [displaying type information](#the-gettype-subcommand) for classes,
+  variables, functions etc.,
+- displaying documentation for methods, members, etc. in the [preview
+  window](#the-getdoc-subcommand), or in a
+  [popup next to the cursor](#the-gycm_auto_hover-option) (Vim only)
+- [fixing common coding errors](#the-fixit-subcommand), like missing
+  semi-colons, typos, etc.,
+- [semantic renaming](#the-refactorrename-subcommand) of variables across files,
 - formatting code,
 - removing unused imports, sorting imports, etc.
 
@@ -199,6 +204,11 @@ Below we can see YCM being able to do a few things:
   for servers that support it.
 
 ![YouCompleteMe GIF subcommands demo](https://i.imgur.com/nmUUbdl.gif)
+
+And here's some documentation being shown in a hover popup, automatically and
+manually:
+
+![hover demo](https://user-images.githubusercontent.com/10584846/80312146-91af6500-87db-11ea-996b-7396f3134d1f.gif)
 
 Features vary by file type, so make sure to check out the [file type feature
 summary](#quick-feature-summary) and the
@@ -1980,8 +1990,11 @@ endfunction
 " CursorHold triggers in normal mode after a delay
 autocmd CursorHold * call s:Hover()
 " Or, if you prefer, a mapping:
-nnoremap <leader>D :call <SID>Hover()<CR>
+nnoremap <silent> <leader>D :call <SID>Hover()<CR>
 ```
+
+**NOTE**: This is only an example, for real hover support, see
+[`g:ycm_auto_hover`](#the-gycm_auto_hover-option).
 
 If the completer subcommand result is not a string (for example, it's a FixIt or
 a Location), or if the completer subcommand raises an error, an empty string is
@@ -2353,6 +2366,29 @@ Default: `1`
 ```viml
 let g:ycm_echo_current_diagnostic = 1
 ```
+
+### The `g:ycm_auto_hover` option
+
+This option controls whether or not YCM shows documentation in a popup at the
+cursor location after a short delay. Only supported in Vim.
+
+The displayed documentation depends on what the completer for the current
+language supports. It's selected in this order of preference: `GetHover`
+`GetDoc`, `GetType`.
+
+When this option is set to `'CursorHold'`, the popup is displayed on the
+`CursorHold` autocommand. See `:help CursorHold` for the deatils, but this means
+that it is displayed after `updatetime` milliseconds.  When set to an empty
+string, the popup is not automatically displayed.
+
+In addition to this setting, there is the `<plug>(YCMHover)` mapping, which can
+be used to manually trigger the popup. For example:
+
+```viml
+nmap <leader>D <plug>(YCMHover)
+```
+
+Default: `'CursorHold'`
 
 ### The `g:ycm_filter_diagnostics` option
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -38,7 +38,7 @@ Contents ~
   4. Signature Help                              |youcompleteme-signature-help|
   5. General Semantic Completion    |youcompleteme-general-semantic-completion|
   6. C-family Semantic Completion  |youcompleteme-c-family-semantic-completion|
-   1. Option 1: Use a compilation database [45] |youcompleteme-option-1-use-compilation-database-45|
+   1. Option 1: Use a compilation database [46] |youcompleteme-option-1-use-compilation-database-46|
    2. Option 2: Provide the flags manually |youcompleteme-option-2-provide-flags-manually|
    3. Errors during compilation       |youcompleteme-errors-during-compilation|
   7. Java Semantic Completion          |youcompleteme-java-semantic-completion|
@@ -105,6 +105,7 @@ Contents ~
  11. Functions                                        |youcompleteme-functions|
   1. The |youcompleteme#GetErrorCount| function
   2. The |youcompleteme#GetWarningCount| function
+  3. The 'youcompleteme#GetCommandResponse( ... )' function |youcompleteme#GetCommandResponse()|
  12. Autocommands                                  |youcompleteme-autocommands|
   1. The |YcmLocationOpened| autocommand
   2. The |YcmQuickFixOpened| autocommand
@@ -124,51 +125,52 @@ Contents ~
   13. The |g:ycm_enable_diagnostic_signs| option
   14. The |g:ycm_enable_diagnostic_highlighting| option
   15. The |g:ycm_echo_current_diagnostic| option
-  16. The |g:ycm_filter_diagnostics| option
-  17. The |g:ycm_always_populate_location_list| option
-  18. The |g:ycm_open_loclist_on_ycm_diags| option
-  19. The |g:ycm_complete_in_comments| option
-  20. The |g:ycm_complete_in_strings| option
-  21. The |g:ycm_collect_identifiers_from_comments_and_strings| option
-  22. The |g:ycm_collect_identifiers_from_tags_files| option
-  23. The |g:ycm_seed_identifiers_with_syntax| option
-  24. The |g:ycm_extra_conf_vim_data| option
-  25. The |g:ycm_server_python_interpreter| option
-  26. The |g:ycm_keep_logfiles| option
-  27. The |g:ycm_log_level| option
-  28. The |g:ycm_auto_start_csharp_server| option
-  29. The |g:ycm_auto_stop_csharp_server| option
-  30. The |g:ycm_csharp_server_port| option
-  31. The |g:ycm_csharp_insert_namespace_expr| option
-  32. The |g:ycm_add_preview_to_completeopt| option
-  33. The |g:ycm_autoclose_preview_window_after_completion| option
-  34. The |g:ycm_autoclose_preview_window_after_insertion| option
-  35. The |g:ycm_max_diagnostics_to_display| option
-  36. The |g:ycm_key_list_select_completion| option
-  37. The |g:ycm_key_list_previous_completion| option
-  38. The |g:ycm_key_list_stop_completion| option
-  39. The |g:ycm_key_invoke_completion| option
-  40. The |g:ycm_key_detailed_diagnostics| option
-  41. The |g:ycm_global_ycm_extra_conf| option
-  42. The |g:ycm_confirm_extra_conf| option
-  43. The |g:ycm_extra_conf_globlist| option
-  44. The |g:ycm_filepath_completion_use_working_dir| option
-  45. The |g:ycm_semantic_triggers| option
-  46. The |g:ycm_cache_omnifunc| option
-  47. The |g:ycm_use_ultisnips_completer| option
-  48. The |g:ycm_goto_buffer_command| option
-  49. The |g:ycm_disable_for_files_larger_than_kb| option
-  50. The |g:ycm_use_clangd| option
-  51. The |g:ycm_clangd_binary_path| option
-  52. The |g:ycm_clangd_args| option
-  53. The |g:ycm_clangd_uses_ycmd_caching| option
-  54. The |g:ycm_language_server| option
-  55. The |g:ycm_disable_signature_help| option
-  56. The |g:ycm_gopls_binary_path| option
-  57. The |g:ycm_gopls_args| option
-  58. The |g:ycm_rls_binary_path| and |g:ycm_rustc_binary_path| options
-  59. The |g:ycm_tsserver_binary_path| option
-  60. The |g:ycm_roslyn_binary_path| option
+  16. The |g:ycm_auto_hover| option
+  17. The |g:ycm_filter_diagnostics| option
+  18. The |g:ycm_always_populate_location_list| option
+  19. The |g:ycm_open_loclist_on_ycm_diags| option
+  20. The |g:ycm_complete_in_comments| option
+  21. The |g:ycm_complete_in_strings| option
+  22. The |g:ycm_collect_identifiers_from_comments_and_strings| option
+  23. The |g:ycm_collect_identifiers_from_tags_files| option
+  24. The |g:ycm_seed_identifiers_with_syntax| option
+  25. The |g:ycm_extra_conf_vim_data| option
+  26. The |g:ycm_server_python_interpreter| option
+  27. The |g:ycm_keep_logfiles| option
+  28. The |g:ycm_log_level| option
+  29. The |g:ycm_auto_start_csharp_server| option
+  30. The |g:ycm_auto_stop_csharp_server| option
+  31. The |g:ycm_csharp_server_port| option
+  32. The |g:ycm_csharp_insert_namespace_expr| option
+  33. The |g:ycm_add_preview_to_completeopt| option
+  34. The |g:ycm_autoclose_preview_window_after_completion| option
+  35. The |g:ycm_autoclose_preview_window_after_insertion| option
+  36. The |g:ycm_max_diagnostics_to_display| option
+  37. The |g:ycm_key_list_select_completion| option
+  38. The |g:ycm_key_list_previous_completion| option
+  39. The |g:ycm_key_list_stop_completion| option
+  40. The |g:ycm_key_invoke_completion| option
+  41. The |g:ycm_key_detailed_diagnostics| option
+  42. The |g:ycm_global_ycm_extra_conf| option
+  43. The |g:ycm_confirm_extra_conf| option
+  44. The |g:ycm_extra_conf_globlist| option
+  45. The |g:ycm_filepath_completion_use_working_dir| option
+  46. The |g:ycm_semantic_triggers| option
+  47. The |g:ycm_cache_omnifunc| option
+  48. The |g:ycm_use_ultisnips_completer| option
+  49. The |g:ycm_goto_buffer_command| option
+  50. The |g:ycm_disable_for_files_larger_than_kb| option
+  51. The |g:ycm_use_clangd| option
+  52. The |g:ycm_clangd_binary_path| option
+  53. The |g:ycm_clangd_args| option
+  54. The |g:ycm_clangd_uses_ycmd_caching| option
+  55. The |g:ycm_language_server| option
+  56. The |g:ycm_disable_signature_help| option
+  57. The |g:ycm_gopls_binary_path| option
+  58. The |g:ycm_gopls_args| option
+  59. The |g:ycm_rls_binary_path| and 'g:ycm_rustc_binary_path' options
+  60. The |g:ycm_tsserver_binary_path| option
+  61. The |g:ycm_roslyn_binary_path| option
  14. FAQ                                                    |youcompleteme-faq|
  15. Contributor Code of Conduct    |youcompleteme-contributor-code-of-conduct|
  16. Contact                                            |youcompleteme-contact|
@@ -360,10 +362,11 @@ YCM also provides semantic IDE-like features in a number of languages,
 including:
 
 - displaying signature help (argument hints) when entering the arguments to a
-  function call
+  function call (Vim only)
 - finding declarations, definitions, usages, etc. of identifiers,
 - displaying type information for classes, variables, functions etc.,
 - displaying documentation for methods, members, etc. in the preview window,
+  or in a popup next to the cursor (Vim only)
 - fixing common coding errors, like missing semi-colons, typos, etc.,
 - semantic renaming of variables across files,
 - formatting code,
@@ -384,12 +387,17 @@ Below we can see YCM being able to do a few things:
 
   Image: YouCompleteMe GIF subcommands demo (see reference [23])
 
+And here's some documentation being shown in a hover popup, automatically and
+manually:
+
+  Image: hover demo (see reference [24])
+
 Features vary by file type, so make sure to check out the file type feature
 summary and the full list of completer subcommands to find out what's available
 for your favourite languages.
 
 You'll also find that YCM has filepath completers (try typing './' in a file)
-and a completer that integrates with UltiSnips [24].
+and a completer that integrates with UltiSnips [25].
 
 ===============================================================================
                                                    *youcompleteme-installation*
@@ -433,13 +441,13 @@ These instructions (using 'install.py') are the quickest way to install
 YouCompleteMe, however they may not work for everyone. If the following
 instructions don't work for you, check out the full installation guide.
 
-MacVim [25] is required. YCM won't work with the pre-installed Vim from Apple
-as its Python support is broken. If you don't already use MacVim [25], install
-it with Homebrew [26]. Install CMake as well:
+MacVim [26] is required. YCM won't work with the pre-installed Vim from Apple
+as its Python support is broken. If you don't already use MacVim [26], install
+it with Homebrew [27]. Install CMake as well:
 >
   brew install cmake macvim
 <
-Install YouCompleteMe with Vundle [27].
+Install YouCompleteMe with Vundle [28].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the 'ycm_core' library APIs have changed (happens rarely), YCM
@@ -463,18 +471,18 @@ Compiling YCM **without** semantic support for C-family languages:
 <
 The following additional language support options are available:
 
-- C# support: install Mono with Homebrew [26] or by downloading the Mono
-  macOS package [28] and add '--cs-completer' when calling 'install.py'.
+- C# support: install Mono with Homebrew [27] or by downloading the Mono
+  macOS package [29] and add '--cs-completer' when calling 'install.py'.
 
-- Go support: install Go [29] and add '--go-completer' when calling
+- Go support: install Go [30] and add '--go-completer' when calling
   'install.py'.
 
-- JavaScript and TypeScript support: install Node.js and npm [30] and add
+- JavaScript and TypeScript support: install Node.js and npm [31] and add
   '--ts-completer' when calling 'install.py'.
 
 - Rust support: add '--rust-completer' when calling 'install.py'.
 
-- Java support: install JDK8 (version 8 required) [31] and add
+- Java support: install JDK8 (version 8 required) [32] and add
   '--java-completer' when calling 'install.py'.
 
 To simply compile with everything enabled, there's a '--all' flag. You need to
@@ -528,11 +536,11 @@ Make sure you have Vim 7.4.1578 with Python 3 support. The Vim package on
 Fedora 27 and later and the pre-installed Vim on Ubuntu 16.04 and later are
 recent enough. You can see the version of Vim installed by running 'vim
 --version'. If the version is too old, you may need to compile Vim from source
-[32] (don't worry, it's easy).
+[33] (don't worry, it's easy).
 
 **NOTE**: For all features, such as signature help, use Vim 8.1.1875 or later.
 
-Install YouCompleteMe with Vundle [27].
+Install YouCompleteMe with Vundle [28].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the 'ycm_core' library APIs have changed (happens rarely), YCM
@@ -571,18 +579,18 @@ Compiling YCM **without** semantic support for C-family languages:
 <
 The following additional language support options are available:
 
-- C# support: install Mono [33] and add '--cs-completer' when calling
+- C# support: install Mono [34] and add '--cs-completer' when calling
   'install.py'.
 
-- Go support: install Go [29] and add '--go-completer' when calling
+- Go support: install Go [30] and add '--go-completer' when calling
   'install.py'.
 
-- JavaScript and TypeScript support: install Node.js and npm [30] and add
+- JavaScript and TypeScript support: install Node.js and npm [31] and add
   '--ts-completer' when calling 'install.py'.
 
 - Rust support: add '--rust-completer' when calling 'install.py'.
 
-- Java support: install JDK8 (version 8 required) [31] and add
+- Java support: install JDK8 (version 8 required) [32] and add
   '--java-completer' when calling 'install.py'.
 
 To simply compile with everything enabled, there's a '--all' flag. You need to
@@ -609,7 +617,7 @@ Windows ~
 -------------------------------------------------------------------------------
 Quick start, installing all completers ~
 
-- Install Visual Studio Build Tools 2017 [34]
+- Install Visual Studio Build Tools 2017 [35]
 - Install cmake, vim and python
 - Install go, node and npm
 - Compile YCM
@@ -619,7 +627,7 @@ Quick start, installing all completers ~
   cd YouCompleteMe
   python3 install.py --all
 <
-- Add 'set encoding=utf-8' to your vimrc [35]
+- Add 'set encoding=utf-8' to your vimrc [36]
 - For plugging an arbitrary LSP server, check the relevant section
 
 -------------------------------------------------------------------------------
@@ -637,7 +645,7 @@ the version and which Python is supported by typing ':version' inside Vim. Look
 at the features included: '+python3/dyn' for Python 3. Take note of the Vim
 architecture, i.e. 32 or 64-bit. It will be important when choosing the Python
 installer. We recommend using a 64-bit client. Daily updated installers of
-32-bit and 64-bit Vim with Python 3 support [36] are available.
+32-bit and 64-bit Vim with Python 3 support [37] are available.
 
 **NOTE**: For all features, such as signature help, use Vim 8.1.1875 or later.
 
@@ -645,12 +653,12 @@ Add the line:
 >
   set encoding=utf-8
 <
-to your vimrc [35] if not already present. This option is required by YCM. Note
+to your vimrc [36] if not already present. This option is required by YCM. Note
 that it does not prevent you from editing a file in another encoding than
 UTF-8. You can do that by specifying the '|++enc|' argument to the ':e'
 command.
 
-Install YouCompleteMe with Vundle [27].
+Install YouCompleteMe with Vundle [28].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the 'ycm_core' library APIs have changed (happens rarely), YCM
@@ -658,7 +666,7 @@ will notify you to recompile it. You should then rerun the install process.
 
 Download and install the following software:
 
-- Python 3 [37]. Be sure to pick the version corresponding to your Vim
+- Python 3 [38]. Be sure to pick the version corresponding to your Vim
   architecture. It is _Windows x86_ for a 32-bit Vim and _Windows x86-64_ for
   a 64-bit Vim. We recommend installing Python 3. Additionally, the version
   of Python you install must match up exactly with the version of Python that
@@ -668,9 +676,9 @@ Download and install the following software:
   looking for Python 3.5. You'll need one or the other installed, matching
   the version number exactly.
 
-- CMake [38]. Add CMake executable to the PATH environment variable.
+- CMake [39]. Add CMake executable to the PATH environment variable.
 
-- Visual Studio Build Tools 2017 [34]. During setup, select _Visual C++ build
+- Visual Studio Build Tools 2017 [35]. During setup, select _Visual C++ build
   tools_ in _Workloads_.
 
 Compiling YCM **with** semantic support for C-family languages through
@@ -687,17 +695,17 @@ Compiling YCM **without** semantic support for C-family languages:
 The following additional language support options are available:
 
 - C# support: add '--cs-completer' when calling 'install.py'. Be sure that
-  the build utility 'msbuild' is in your PATH [39].
+  the build utility 'msbuild' is in your PATH [40].
 
-- Go support: install Go [29] and add '--go-completer' when calling
+- Go support: install Go [30] and add '--go-completer' when calling
   'install.py'.
 
-- JavaScript and TypeScript support: install Node.js and npm [30] and add
+- JavaScript and TypeScript support: install Node.js and npm [31] and add
   '--ts-completer' when calling 'install.py'.
 
 - Rust support: add '--rust-completer' when calling 'install.py'.
 
-- Java support: install JDK8 (version 8 required) [31] and add
+- Java support: install JDK8 (version 8 required) [32] and add
   '--java-completer' when calling 'install.py'.
 
 To simply compile with everything enabled, there's a '--all' flag. You need to
@@ -764,7 +772,7 @@ For FreeBSD 11.x, the requirement is cmake:
 >
   pkg install cmake
 <
-Install YouCompleteMe with Vundle [27].
+Install YouCompleteMe with Vundle [28].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the 'ycm_core' library APIs have changed (happens rarely), YCM
@@ -791,15 +799,15 @@ The following additional language support options are available:
 - C# support: install Mono and add '--cs-completer' when calling
   './install.py'.
 
-- Go support: install Go [29] and add '--go-completer' when calling
+- Go support: install Go [30] and add '--go-completer' when calling
   './install.py'.
 
-- JavaScript and TypeScript support: install Node.js and npm [30] and add
+- JavaScript and TypeScript support: install Node.js and npm [31] and add
   '--ts-completer' when calling 'install.py'.
 
 - Rust support: add '--rust-completer' when calling './install.py'.
 
-- Java support: install JDK8 (version 8 required) [31] and add
+- Java support: install JDK8 (version 8 required) [32] and add
   '--java-completer' when calling './install.py'.
 
 To simply compile with everything enabled, there's a '--all' flag. You need to
@@ -823,7 +831,7 @@ that are conservatively turned off by default that you may want to turn on.
                                         *youcompleteme-full-installation-guide*
 Full Installation Guide ~
 
-The full installation guide [40] has been moved to the wiki.
+The full installation guide [41] has been moved to the wiki.
 
 ===============================================================================
                                           *youcompleteme-quick-feature-summary*
@@ -967,7 +975,7 @@ General Usage ~
 If the offered completions are too broad, keep typing characters; YCM will
 continue refining the offered completions based on your input.
 
-Filtering is "smart-case" and "smart-diacritic [41]" sensitive; if you are
+Filtering is "smart-case" and "smart-diacritic [42]" sensitive; if you are
 typing only lowercase letters, then it's case-insensitive. If your input
 contains uppercase letters, then the uppercase letters in your query must match
 uppercase letters in the completion strings (the lowercase letters still match
@@ -1018,7 +1026,7 @@ and presents the results to you.
 Client-Server Architecture ~
 
 YCM has a client-server architecture; the Vim part of YCM is only a thin client
-that talks to the ycmd HTTP+JSON server [42] that has the vast majority of YCM
+that talks to the ycmd HTTP+JSON server [43] that has the vast majority of YCM
 logic and functionality. The server is started and stopped automatically as you
 start and stop Vim.
 
@@ -1051,7 +1059,7 @@ The signatures popup is hidden when there are no matching signatures or when
 you leave insert mode. There is no key binding to clear the popup.
 
 For more details on this feature and a few demos, check out the PR that
-proposed it [43].
+proposed it [44].
 
 -------------------------------------------------------------------------------
                                     *youcompleteme-general-semantic-completion*
@@ -1069,7 +1077,7 @@ C-family Semantic Completion ~
 users should migrate to clangd, as it provides more features and better
 performance. Users who rely on 'override_filename' in their
 '.ycm_extra_conf.py' will need to stay on the old 'libclang' engine.
-Instructions on how to stay on the old engine are available on the wiki [44].
+Instructions on how to stay on the old engine are available on the wiki [45].
 
 Advantages of clangd over libclang include:
 
@@ -1110,8 +1118,8 @@ parse your code, YouCompleteMe can't provide semantic analysis.
 There are 2 methods which can be used to provide compile flags to clang:
 
 -------------------------------------------------------------------------------
-                           *youcompleteme-option-1-use-compilation-database-45*
-Option 1: Use a compilation database [45] ~
+                           *youcompleteme-option-1-use-compilation-database-46*
+Option 1: Use a compilation database [46] ~
 
 The easiest way to get YCM to compile your code is to use a compilation
 database. A compilation database is usually generated by your build system
@@ -1119,13 +1127,13 @@ database. A compilation database is usually generated by your build system
 in your project.
 
 For information on how to generate a compilation database, see the clang
-documentation [45]. In short:
+documentation [46]. In short:
 
 - If using CMake, add '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON' when configuring
   (or add 'set( CMAKE_EXPORT_COMPILE_COMMANDS ON )' to 'CMakeLists.txt') and
   copy or symlink the generated database to the root of your project.
-- If using Ninja, check out the 'compdb' tool ('-t compdb') in its docs [46].
-- If using GNU make, check out compiledb [47] or Bear [48].
+- If using Ninja, check out the 'compdb' tool ('-t compdb') in its docs [47].
+- If using GNU make, check out compiledb [48] or Bear [49].
 - For other build systems, check out '.ycm_extra_conf.py' below.
 
 If no '.ycm_extra_conf.py' is found, YouCompleteMe automatically tries to load
@@ -1189,14 +1197,14 @@ That's it! This is actually enough for most projects, but for complex projects
 it is not uncommon to integrate directly with an existing build system using
 the full power of the Python language.
 
-For a more elaborate example, see ycmd's own '.ycm_extra_conf.py' [49]. You
+For a more elaborate example, see ycmd's own '.ycm_extra_conf.py' [50]. You
 should be able to use it _as a starting point_. **Don't** just copy/paste that
 file somewhere and expect things to magically work; **your project needs
 different flags**. Hint: just replace the strings in the 'flags' variable with
 compilation flags necessary for your project. That should be enough for 99% of
 projects.
 
-You could also consider using YCM-Generator [50] to generate the
+You could also consider using YCM-Generator [51] to generate the
 'ycm_extra_conf.py' file.
 
 -------------------------------------------------------------------------------
@@ -1229,7 +1237,7 @@ Java quick Start ~
    your Java project, by following the instructions below.
 
 3. (Optional) Configure the LSP server. The jdt.ls configuration options
-   [51] can be found in their codebase.
+   [52] can be found in their codebase.
 
 4. If you previously used Eclim or Syntastic for Java, disable them for
    Java.
@@ -1246,7 +1254,7 @@ Java Project Files ~
 In order to provide semantic analysis, the Java completion engine requires
 knowledge of your project structure. In particular it needs to know the class
 path to use, when compiling your code. Fortunately jdt.ls [17] supports eclipse
-project files [52], maven projects [53] and gradle projects [54].
+project files [53], maven projects [54] and gradle projects [55].
 
 **NOTE:** Our recommendation is to use either maven or gradle projects.
 
@@ -1281,7 +1289,7 @@ native Java support. This can be done temporarily with ':EclimDisable'.
                                                *youcompleteme-eclipse-projects*
 Eclipse Projects ~
 
-Eclipse style projects require two files: .project [52] and .classpath [55].
+Eclipse style projects require two files: .project [53] and .classpath [56].
 
 If your project already has these files due to previously being set up within
 eclipse, then no setup is required. jdt.ls [17] should load the project just
@@ -1290,7 +1298,7 @@ fine (it's basically eclipse after all).
 However, if not, it is possible (easy in fact) to craft them manually, though
 it is not recommended. You're better off using gradle or maven (see below).
 
-A simple eclipse style project example [56] can be found in the ycmd test
+A simple eclipse style project example [57] can be found in the ycmd test
 directory. Normally all that is required is to copy these files to the root of
 your project and to edit the '.classpath' to add additional libraries, such as:
 >
@@ -1310,10 +1318,10 @@ don't already use eclipse to manage your projects.
                                                  *youcompleteme-maven-projects*
 Maven Projects ~
 
-Maven needs a file named pom.xml [53] in the root of the project. Once again a
-simple pom.xml [57] can be found in ycmd source.
+Maven needs a file named pom.xml [54] in the root of the project. Once again a
+simple pom.xml [58] can be found in ycmd source.
 
-The format of pom.xml [53] files is way beyond the scope of this document, but
+The format of pom.xml [54] files is way beyond the scope of this document, but
 we do recommend using the various tools that can generate them for you, if
 you're not familiar with them already.
 
@@ -1321,10 +1329,10 @@ you're not familiar with them already.
                                                 *youcompleteme-gradle-projects*
 Gradle Projects ~
 
-Gradle projects require a build.gradle [54]. Again, there is a trivial example
-in ycmd's tests [58].
+Gradle projects require a build.gradle [55]. Again, there is a trivial example
+in ycmd's tests [59].
 
-The format of build.gradle [54] files is way beyond the scope of this document,
+The format of build.gradle [55] files is way beyond the scope of this document,
 but we do recommend using the various tools that can generate them for you, if
 you're not familiar with them already.
 
@@ -1388,7 +1396,7 @@ fall back to the other way of finding the file.
 Python Semantic Completion ~
 
 YCM relies on the Jedi [12] engine to provide completion and code navigation.
-By default, it will pick the version of Python running the ycmd server [42] and
+By default, it will pick the version of Python running the ycmd server [43] and
 use its 'sys.path'. While this is fine for simple projects, this needs to be
 configurable when working with virtual environments or in a project with
 third-party packages. The next sections explain how to do that.
@@ -1455,7 +1463,7 @@ the second position of 'sys.path':
     sys_path.insert( 1, '/path/to/third_party/package' )
     return sys_path
 <
-A more advanced example can be found in YCM's own '.ycm_extra_conf.py' [59].
+A more advanced example can be found in YCM's own '.ycm_extra_conf.py' [60].
 
 -------------------------------------------------------------------------------
                                 *youcompleteme-configuring-through-vim-options*
@@ -1500,7 +1508,7 @@ Completions and GoTo commands within the current crate and its dependencies
 should work out of the box with no additional configuration (provided that you
 built YCM with the '--rust-completer' flag; see the _Installation_ section for
 details). The install script takes care of installing the Rust source code
-[60], so no configuration is necessary.
+[61], so no configuration is necessary.
 
 To configure RLS look up [rls configuration options][ rls-preferences]. The
 value of the 'ls' key must be structured as in the following example:
@@ -1534,29 +1542,29 @@ built YCM with the '--go-completer' flag; see the _Installation_ section for
 details). The server only works for projects with the "canonical" layout.
 
 While YCM can configure a LSP server, currently 'gopls' doesn't implement the
-required notification [61].
+required notification [62].
 
 -------------------------------------------------------------------------------
                       *youcompleteme-javascript-typescript-semantic-completion*
 JavaScript and TypeScript Semantic Completion ~
 
-**NOTE:** YCM originally used the Tern [62] engine for JavaScript but due to
-Tern [62] not being maintained anymore by its main author and the TSServer [15]
+**NOTE:** YCM originally used the Tern [63] engine for JavaScript but due to
+Tern [63] not being maintained anymore by its main author and the TSServer [15]
 engine offering more features, YCM is moving to TSServer [15]. This won't
-affect you if you were already using Tern [62] but you are encouraged to do the
+affect you if you were already using Tern [63] but you are encouraged to do the
 switch by deleting the 'third_party/ycmd/third_party/tern_runtime/node_modules'
-directory in YCM folder. If you are a new user but still want to use Tern [62],
+directory in YCM folder. If you are a new user but still want to use Tern [63],
 you should pass the '--js-completer' option to the 'install.py' script during
-installation. Further instructions on how to setup YCM with Tern [62] are
-available on the wiki [63].
+installation. Further instructions on how to setup YCM with Tern [63] are
+available on the wiki [64].
 
 All JavaScript and TypeScript features are provided by the TSServer [15]
 engine, which is included in the TypeScript SDK. To enable these features,
-install Node.js and npm [30] and call the 'install.py' script with the
+install Node.js and npm [31] and call the 'install.py' script with the
 '--ts-completer' flag.
 
-TSServer [15] relies on the 'jsconfig.json' file [64] for JavaScript and the
-'tsconfig.json' file [65] for TypeScript to analyze your project. Ensure the
+TSServer [15] relies on the 'jsconfig.json' file [65] for JavaScript and the
+'tsconfig.json' file [66] for TypeScript to analyze your project. Ensure the
 file exists at the root of your project.
 
 To get diagnostics in JavaScript, set the 'checkJs' option to 'true' in your
@@ -1573,7 +1581,7 @@ To get diagnostics in JavaScript, set the 'checkJs' option to 'true' in your
 Semantic Completion for Other Languages ~
 
 C-family, C#, Go, Java, Python, Rust, and JavaScript/TypeScript languages are
-supported natively by YouCompleteMe using the Clang [66], OmniSharp-Roslyn
+supported natively by YouCompleteMe using the Clang [67], OmniSharp-Roslyn
 [13], Gopls [14], jdt.ls [17], Jedi [12], rls [16], and TSServer [15] engines,
 respectively. Check the installation section for instructions to enable these
 features if desired.
@@ -1606,7 +1614,7 @@ be:
 When configuring a LSP server the value of the 'name' key will be used as the
 "kwargs[ 'language' ]".
 
-See the LSP Examples [67] project for more examples of configuring the likes of
+See the LSP Examples [68] project for more examples of configuring the likes of
 PHP, Ruby, Kotlin, and D.
 
 -------------------------------------------------------------------------------
@@ -1634,7 +1642,7 @@ semantic completions if it does not have a native semantic completion engine
 for your file's filetype. Vim comes with okayish omnifuncs for various
 languages like Ruby, PHP, etc. It depends on the language.
 
-You can get a stellar omnifunc for Ruby with Eclim [68]. Just make sure you
+You can get a stellar omnifunc for Ruby with Eclim [69]. Just make sure you
 have the _latest_ Eclim installed and configured (this means Eclim '>= 2.2.*'
 and Eclipse '>= 4.2.*').
 
@@ -1651,7 +1659,7 @@ Writing New Semantic Completers ~
 
 You have two options here: writing an 'omnifunc' for Vim's omnicomplete system
 that YCM will then use through its omni-completer, or a custom completer for
-YCM using the Completer API [69].
+YCM using the Completer API [70].
 
 Here are the differences between the two approaches:
 
@@ -1670,7 +1678,7 @@ Here are the differences between the two approaches:
   than VimScript.
 
 If you want to use the 'omnifunc' system, see the relevant Vim docs with ':h
-complete-functions'. For the Completer API, see the API docs [69].
+complete-functions'. For the Completer API, see the API docs [70].
 
 If you want to upstream your completer into YCM's source, you should use the
 Completer API.
@@ -1721,7 +1729,7 @@ current file in Vim's 'locationlist', which can be opened with the ':lopen' and
 ':lclose' commands (make sure you have set 'let
 g:ycm_always_populate_location_list = 1' in your vimrc). A good way to toggle
 the display of the 'locationlist' with a single key mapping is provided by
-another (very small) Vim plugin called ListToggle [70] (which also makes it
+another (very small) Vim plugin called ListToggle [71] (which also makes it
 possible to change the height of the 'locationlist' window), also written by
 yours truly.
 
@@ -1767,7 +1775,7 @@ Commands ~
 -------------------------------------------------------------------------------
 The *:YcmRestartServer* command
 
-If the ycmd completion server [42] suddenly stops for some reason, you can
+If the ycmd completion server [43] suddenly stops for some reason, you can
 restart it with this command.
 
 -------------------------------------------------------------------------------
@@ -1815,7 +1823,7 @@ semantic completion engine.
 The *:YcmToggleLogs* command
 
 This command presents the list of logfiles created by YCM, the ycmd server
-[42], and the semantic engine server for the current filetype, if any. One of
+[43], and the semantic engine server for the current filetype, if any. One of
 these logfiles can be opened in the editor (or closed if already open) by
 entering the corresponding number or by clicking on it with the mouse.
 Additionally, this command can take the logfile names as arguments. Use the
@@ -2186,7 +2194,7 @@ documentations to find out what commands are supported and which arguments are
 expected.
 
 The support for 'ExecuteCommand' was implemented to support plugins like
-vimspector [71] to debug java, but isn't limited to that specific use case.
+vimspector [72] to debug java, but isn't limited to that specific use case.
 
 -------------------------------------------------------------------------------
 The *RestartServer* subcommand
@@ -2222,7 +2230,7 @@ For example:
   call youcompleteme#GetErrorCount()
 <
 Both this function and |youcompleteme#GetWarningCount| can be useful when
-integrating YCM with other Vim plugins. For example, a lightline [72] user
+integrating YCM with other Vim plugins. For example, a lightline [73] user
 could add a diagnostics section to their statusline which would display the
 number of errors and warnings.
 
@@ -2236,6 +2244,47 @@ For example:
 >
   call youcompleteme#GetWarningCount()
 <
+-------------------------------------------------------------------------------
+                                           *youcompleteme#GetCommandResponse()*
+The 'youcompleteme#GetCommandResponse( ... )' function ~
+
+Run a completer subcommand and return the result as a string. This can be
+useful for example to display the 'GetGoc' output in a popup window, e.g.:
+>
+  let s:ycm_hover_popup = -1
+  function s:Hover()
+    let response = youcompleteme#GetCommandResponse( 'GetDoc' )
+    if response == ''
+      return
+    endif
+  
+    call popup_hide( s:ycm_hover_popup )
+    let s:ycm_hover_popup = popup_atcursor( balloon_split( response ), {} )
+  endfunction
+  
+  " CursorHold triggers in normal mode after a delay
+  autocmd CursorHold * call s:Hover()
+  " Or, if you prefer, a mapping:
+  nnoremap <silent> <leader>D :call <SID>Hover()<CR>
+<
+**NOTE**: This is only an example, for real hover support, see
+|g:ycm_auto_hover|.
+
+If the completer subcommand result is not a string (for example, it's a FixIt
+or a Location), or if the completer subcommand raises an error, an empty string
+is returned, so that calling code does not have to check for complex error
+conditions.
+
+The arguments to the function are the same as the arguments to the
+|:YcmCompleter| ex command, e.g. the name of the subcommand, followed by any
+additional subcommand arguments. As with the 'YcmCompleter' command, if the
+first argument is 'ft=<filetype>' the request is targetted at the specified
+filetype completer. This is an advanced usage and not necessary in most cases.
+
+NOTE: The request is run synchronously and blocks Vim until the response is
+received, so we do not recommend running this as part of an autocommand that
+triggers frequently.
+
 ===============================================================================
                                                    *youcompleteme-autocommands*
 Autocommands ~
@@ -2286,12 +2335,12 @@ Options ~
 
 All options have reasonable defaults so if the plug-in works after installation
 you don't need to change any options. These options can be configured in your
-vimrc script [35] by including a line like this:
+vimrc script [36] by including a line like this:
 >
   let g:ycm_min_num_of_chars_for_completion = 1
 <
-Note that after changing an option in your vimrc script [35] you have to
-restart ycmd [42] with the |:YcmRestartServer| command for the changes to take
+Note that after changing an option in your vimrc script [36] you have to
+restart ycmd [43] with the |:YcmRestartServer| command for the changes to take
 effect.
 
 -------------------------------------------------------------------------------
@@ -2577,6 +2626,28 @@ Default: '1'
   let g:ycm_echo_current_diagnostic = 1
 <
 -------------------------------------------------------------------------------
+The *g:ycm_auto_hover* option
+
+This option controls whether or not YCM shows documentation in a popup at the
+cursor location after a short delay. Only supported in Vim.
+
+The displayed documentation depends on what the completer for the current
+language supports. It's selected in this order of preference: 'GetHover'
+|GetDoc|, |GetType|.
+
+When this option is set to "'CursorHold'", the popup is displayed on the
+'CursorHold' autocommand. See ':help CursorHold' for the deatils, but this
+means that it is displayed after 'updatetime' milliseconds. When set to an
+empty string, the popup is not automatically displayed.
+
+In addition to this setting, there is the '<plug>(YCMHover)' mapping, which can
+be used to manually trigger the popup. For example:
+>
+  nmap <leader>D <plug>(YCMHover)
+<
+Default: "'CursorHold'"
+
+-------------------------------------------------------------------------------
 The *g:ycm_filter_diagnostics* option
 
 This option controls which diagnostics will be rendered by YCM. This option
@@ -2591,13 +2662,13 @@ YCM will not render it.
 
 The following filter types are supported:
 
-- "regex": Accepts a string regular expression [73]. This type matches when
+- "regex": Accepts a string regular expression [74]. This type matches when
   the regex (treated as case-insensitive) is found in the diagnostic text.
 
 - "level": Accepts a string level, either "warning" or "error." This type
   matches when the diagnostic has the same level.
 
-**NOTE:** The regex syntax is **NOT** Vim's, it's Python's [73].
+**NOTE:** The regex syntax is **NOT** Vim's, it's Python's [74].
 
 Default: '{}'
 >
@@ -2686,7 +2757,7 @@ from the 'tagfiles()' Vim function which examines the 'tags' Vim option. See
 
 YCM will re-index your tags files if it detects that they have been modified.
 
-The only supported tag format is the Exuberant Ctags format [74]. The format
+The only supported tag format is the Exuberant Ctags format [75]. The format
 from "plain" ctags is NOT supported. Ctags needs to be called with the
 '--fields=+l' option (that's a lowercase 'L', not a one) because YCM needs the
 'language:<lang>' field in the tags output.
@@ -2723,7 +2794,7 @@ handy; it's a way of sending data from Vim to your 'Settings' function in your
 '.ycm_extra_conf.py' file.
 
 This option is supposed to be a list of VimScript expression strings that are
-evaluated for every request to the ycmd server [42] and then passed to your
+evaluated for every request to the ycmd server [43] and then passed to your
 'Settings' function as a 'client_data' keyword argument.
 
 For instance, if you set this option to "['v:version']", your 'Settings'
@@ -2752,7 +2823,7 @@ YCM will by default search for an appropriate Python interpreter on your
 system. You can use this option to override that behavior and force the use of
 a specific interpreter of your choosing.
 
-**NOTE:** This interpreter is only used for the ycmd server [42]. The YCM
+**NOTE:** This interpreter is only used for the ycmd server [43]. The YCM
 client running inside Vim always uses the Python interpreter that's embedded
 inside Vim.
 
@@ -2763,7 +2834,7 @@ Default: "''"
 -------------------------------------------------------------------------------
 The *g:ycm_keep_logfiles* option
 
-When this option is set to '1', YCM and the ycmd completion server [42] will
+When this option is set to '1', YCM and the ycmd completion server [43] will
 keep the logfiles around after shutting down (they are deleted on shutdown by
 default).
 
@@ -2776,7 +2847,7 @@ Default: '0'
 -------------------------------------------------------------------------------
 The *g:ycm_log_level* option
 
-The logging level that YCM and the ycmd completion server [42] use. Valid
+The logging level that YCM and the ycmd completion server [43] use. Valid
 values are the following, from most verbose to least verbose: - 'debug' -
 'info' - 'warning' - 'error' - 'critical'
 
@@ -2926,7 +2997,7 @@ The *g:ycm_key_list_stop_completion* option
 
 This option controls the key mappings used to close the completion menu. This
 is useful when the menu is blocking the view, when you need to insert the
-'<TAB>' character, or when you want to expand a snippet from UltiSnips [24] and
+'<TAB>' character, or when you want to expand a snippet from UltiSnips [25] and
 navigate through it.
 
 Default: "['<C-y>']"
@@ -3068,7 +3139,7 @@ It's also possible to use a regular expression as a trigger. You have to prefix
 your trigger with 're!' to signify it's a regex trigger. For instance,
 're!\w+\.' would only trigger after the '\w+\.' regex matches.
 
-**NOTE:** The regex syntax is **NOT** Vim's, it's Python's [73].
+**NOTE:** The regex syntax is **NOT** Vim's, it's Python's [74].
 
 Default: '[see next line]'
 >
@@ -3249,7 +3320,7 @@ Default: '[]'
   let g:ycm_gopls_args = []
 <
 -------------------------------------------------------------------------------
-The *g:ycm_rls_binary_path* and *g:ycm_rustc_binary_path* options
+The *g:ycm_rls_binary_path* and 'g:ycm_rustc_binary_path' options
 
 Similar to the 'gopls' path, these two options tell YCM which 'rls' and 'rustc'
 to use.
@@ -3279,17 +3350,17 @@ The FAQ section has been moved to the wiki [9].
 Contributor Code of Conduct ~
 
 Please note that this project is released with a Contributor Code of Conduct
-[75]. By participating in this project you agree to abide by its terms.
+[76]. By participating in this project you agree to abide by its terms.
 
 ===============================================================================
                                                         *youcompleteme-contact*
 Contact ~
 
 If you have questions about the plugin or need help, please join the Gitter
-room [1] or use the ycm-users [76] mailing list.
+room [1] or use the ycm-users [77] mailing list.
 
 If you have bug reports or feature suggestions, please use the issue tracker
-[77]. Before you do, please carefully read CONTRIBUTING.md [78] as this asks
+[78]. Before you do, please carefully read CONTRIBUTING.md [79] as this asks
 for important diagnostics which the team will use to help get you going.
 
 The latest version of the plugin is available at
@@ -3304,7 +3375,7 @@ YouCompleteMe maintainers directly using the contact details.
                                                         *youcompleteme-license*
 License ~
 
-This software is licensed under the GPL v3 license [79]. © 2015-2018
+This software is licensed under the GPL v3 license [80]. © 2015-2018
 YouCompleteMe contributors
 
 ===============================================================================
@@ -3334,61 +3405,62 @@ References ~
 [21] https://user-images.githubusercontent.com/10026824/34471853-af9cf32a-ef53-11e7-8229-de534058ddc4.gif
 [22] https://user-images.githubusercontent.com/10584846/58738348-5060da80-83fd-11e9-9537-d07fdbf4554c.gif
 [23] https://i.imgur.com/nmUUbdl.gif
-[24] https://github.com/SirVer/ultisnips/blob/master/doc/UltiSnips.txt
-[25] https://macvim-dev.github.io/macvim/
-[26] https://brew.sh
-[27] https://github.com/VundleVim/Vundle.vim#about
-[28] https://www.mono-project.com/docs/getting-started/install/mac/
-[29] https://golang.org/doc/install
-[30] https://docs.npmjs.com/getting-started/installing-node#1-install-nodejs--npm
-[31] https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
-[32] https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source
-[33] https://www.mono-project.com/download/stable/#download-lin
-[34] https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15
-[35] https://vimhelp.appspot.com/starting.txt.html#vimrc
-[36] https://github.com/vim/vim-win32-installer/releases
-[37] https://www.python.org/downloads/windows/
-[38] https://cmake.org/download/
-[39] https://stackoverflow.com/questions/6319274/how-do-i-run-msbuild-from-the-command-line-using-windows-sdk-7-1
-[40] https://github.com/ycm-core/YouCompleteMe/wiki/Full-Installation-Guide
-[41] https://www.unicode.org/glossary/#diacritic
-[42] https://github.com/ycm-core/ycmd
-[43] https://github.com/ycm-core/ycmd/pull/1255
-[44] https://github.com/ycm-core/YouCompleteMe/wiki/C-family-Semantic-Completion-through-libclang
-[45] https://clang.llvm.org/docs/JSONCompilationDatabase.html
-[46] https://ninja-build.org/manual.html
-[47] https://pypi.org/project/compiledb/
-[48] https://github.com/rizsotto/Bear
-[49] https://raw.githubusercontent.com/ycm-core/ycmd/66030cd94299114ae316796f3cad181cac8a007c/.ycm_extra_conf.py
-[50] https://github.com/rdnetto/YCM-Generator
-[51] https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
-[52] https://help.eclipse.org/oxygen/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fproject_description_file.html
-[53] https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html
-[54] https://docs.gradle.org/current/userguide/tutorial_java_projects.html
-[55] https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjdt%2Fcore%2FIClasspathEntry.html
-[56] https://github.com/ycm-core/ycmd/tree/3602f38ef7a762fc765afd75e562aec9a134711e/ycmd/tests/java/testdata/simple_eclipse_project
-[57] https://github.com/ycm-core/ycmd/blob/3602f38ef7a762fc765afd75e562aec9a134711e/ycmd/tests/java/testdata/simple_maven_project/pom.xml
-[58] https://github.com/ycm-core/ycmd/tree/3602f38ef7a762fc765afd75e562aec9a134711e/ycmd/tests/java/testdata/simple_gradle_project
-[59] https://github.com/ycm-core/YouCompleteMe/blob/master/.ycm_extra_conf.py
-[60] https://www.rust-lang.org/downloads.html
-[61] https://github.com/golang/tools/blob/master/internal/lsp/server.go#L120
-[62] https://ternjs.net
-[63] https://github.com/ycm-core/YouCompleteMe/wiki/JavaScript-Semantic-Completion-through-Tern
-[64] https://code.visualstudio.com/docs/languages/jsconfig
-[65] https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
-[66] https://clang.llvm.org/
-[67] https://github.com/ycm-core/lsp-examples
-[68] http://eclim.org/
-[69] https://github.com/ycm-core/ycmd/blob/master/ycmd/completers/completer.py
-[70] https://github.com/ycm-core/ListToggle
-[71] https://github.com/puremourning/vimspector
-[72] https://github.com/itchyny/lightline.vim
-[73] https://docs.python.org/2/library/re.html#regular-expression-syntax
-[74] http://ctags.sourceforge.net/FORMAT
-[75] https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
-[76] https://groups.google.com/forum/?hl=en#!forum/ycm-users
-[77] https://github.com/ycm-core/YouCompleteMe/issues?state=open
-[78] https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
-[79] https://www.gnu.org/copyleft/gpl.html
+[24] https://user-images.githubusercontent.com/10584846/80312146-91af6500-87db-11ea-996b-7396f3134d1f.gif
+[25] https://github.com/SirVer/ultisnips/blob/master/doc/UltiSnips.txt
+[26] https://macvim-dev.github.io/macvim/
+[27] https://brew.sh
+[28] https://github.com/VundleVim/Vundle.vim#about
+[29] https://www.mono-project.com/docs/getting-started/install/mac/
+[30] https://golang.org/doc/install
+[31] https://docs.npmjs.com/getting-started/installing-node#1-install-nodejs--npm
+[32] https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
+[33] https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source
+[34] https://www.mono-project.com/download/stable/#download-lin
+[35] https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15
+[36] https://vimhelp.appspot.com/starting.txt.html#vimrc
+[37] https://github.com/vim/vim-win32-installer/releases
+[38] https://www.python.org/downloads/windows/
+[39] https://cmake.org/download/
+[40] https://stackoverflow.com/questions/6319274/how-do-i-run-msbuild-from-the-command-line-using-windows-sdk-7-1
+[41] https://github.com/ycm-core/YouCompleteMe/wiki/Full-Installation-Guide
+[42] https://www.unicode.org/glossary/#diacritic
+[43] https://github.com/ycm-core/ycmd
+[44] https://github.com/ycm-core/ycmd/pull/1255
+[45] https://github.com/ycm-core/YouCompleteMe/wiki/C-family-Semantic-Completion-through-libclang
+[46] https://clang.llvm.org/docs/JSONCompilationDatabase.html
+[47] https://ninja-build.org/manual.html
+[48] https://pypi.org/project/compiledb/
+[49] https://github.com/rizsotto/Bear
+[50] https://raw.githubusercontent.com/ycm-core/ycmd/66030cd94299114ae316796f3cad181cac8a007c/.ycm_extra_conf.py
+[51] https://github.com/rdnetto/YCM-Generator
+[52] https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+[53] https://help.eclipse.org/oxygen/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fproject_description_file.html
+[54] https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html
+[55] https://docs.gradle.org/current/userguide/tutorial_java_projects.html
+[56] https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjdt%2Fcore%2FIClasspathEntry.html
+[57] https://github.com/ycm-core/ycmd/tree/3602f38ef7a762fc765afd75e562aec9a134711e/ycmd/tests/java/testdata/simple_eclipse_project
+[58] https://github.com/ycm-core/ycmd/blob/3602f38ef7a762fc765afd75e562aec9a134711e/ycmd/tests/java/testdata/simple_maven_project/pom.xml
+[59] https://github.com/ycm-core/ycmd/tree/3602f38ef7a762fc765afd75e562aec9a134711e/ycmd/tests/java/testdata/simple_gradle_project
+[60] https://github.com/ycm-core/YouCompleteMe/blob/master/.ycm_extra_conf.py
+[61] https://www.rust-lang.org/downloads.html
+[62] https://github.com/golang/tools/blob/master/internal/lsp/server.go#L120
+[63] https://ternjs.net
+[64] https://github.com/ycm-core/YouCompleteMe/wiki/JavaScript-Semantic-Completion-through-Tern
+[65] https://code.visualstudio.com/docs/languages/jsconfig
+[66] https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
+[67] https://clang.llvm.org/
+[68] https://github.com/ycm-core/lsp-examples
+[69] http://eclim.org/
+[70] https://github.com/ycm-core/ycmd/blob/master/ycmd/completers/completer.py
+[71] https://github.com/ycm-core/ListToggle
+[72] https://github.com/puremourning/vimspector
+[73] https://github.com/itchyny/lightline.vim
+[74] https://docs.python.org/2/library/re.html#regular-expression-syntax
+[75] http://ctags.sourceforge.net/FORMAT
+[76] https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
+[77] https://groups.google.com/forum/?hl=en#!forum/ycm-users
+[78] https://github.com/ycm-core/YouCompleteMe/issues?state=open
+[79] https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
+[80] https://www.gnu.org/copyleft/gpl.html
 
 vim: ft=help

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -206,6 +206,9 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
+let g:ycm_auto_hover =
+      \ get( g:, 'ycm_auto_hover', 'CursorHold' )
+
 "
 " List of ycmd options.
 "

--- a/test/commands.test.vim
+++ b/test/commands.test.vim
@@ -83,6 +83,8 @@ function! Test_GetCommandResponse()
   " on a command, no error
   call setpos( '.', [ 0, 1, 3 ] )
   call assert_equal( '', youcompleteme#GetCommandResponse( 'GetDoc' ) )
+
+  %bwipe!
 endfunction
 
 
@@ -94,4 +96,21 @@ function! Test_GetCommandResponse_FixIt()
   call assert_equal( '',
                    \ youcompleteme#GetCommandResponse( 'FixIt' ) )
 
+  %bwipe!
+endfunction
+
+function! Test_GetDefinedSubcommands_Native()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/fixit.c', {} )
+  call assert_equal( 1, count( youcompleteme#GetDefinedSubcommands(),
+                             \ 'GetDoc' ) )
+
+  %bwipe!
+endfunction
+
+function! Test_GetDefinedSubcommands_NoNative()
+  enew
+  setf not_a_filetype
+  call assert_equal( [], youcompleteme#GetDefinedSubcommands() )
+
+  %bwipe!
 endfunction

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -1,0 +1,162 @@
+function! SetUp()
+  let g:ycm_use_clangd = 1
+  let g:ycm_keep_logfiles = 1
+  let g:ycm_log_level = 'DEBUG'
+  nnoremap <leader>D <Plug>(YCMHover)
+  call youcompleteme#test#setup#SetUp()
+endfunction
+
+function! TearDown()
+  let g:ycm_auto_hover='CursorHold'
+endfunction
+
+function! Test_Hover_Uses_GetDoc()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
+                                        \ { 'delay': 2 } )
+
+  call assert_equal( 'python', &syntax )
+
+  " no doc
+  call setpos( '.', [ 0, 1, 1 ] )
+  doautocmd CursorHold
+  call assert_equal( 'GetDoc', b:ycm_hover_command )
+
+  let loc = screenpos( win_getid(), 2, 1 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+  let loc = screenpos( win_getid(), 2, 2 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  " some doc - autocommand
+  call setpos( '.', [ 0, 12, 3 ] )
+  doautocmd CursorHold
+  let loc = screenpos( win_getid(), 11, 4 )
+  let popup = popup_locate( loc.row, loc.col )
+  call assert_notequal( 0, popup )
+  call assert_equal( [ 'Test_OneLine()', '', 'This is the one line output.' ],
+                   \ getbufline( winbufnr( popup ), 1, '$' ) )
+  call assert_equal( 'python', getbufvar( winbufnr( popup ), '&syntax' ) )
+
+  " some doc - mapping
+  call setpos( '.', [ 0, 12, 3 ] )
+  normal \D
+  let loc = screenpos( win_getid(), 11, 4 )
+  let popup = popup_locate( loc.row, loc.col )
+  call assert_notequal( 0, popup )
+  call assert_equal( [ 'Test_OneLine()', '', 'This is the one line output.' ],
+                   \ getbufline( winbufnr( popup ), 1, '$' ) )
+  call assert_equal( 'python', getbufvar( winbufnr( popup ), '&syntax' ) )
+
+  call popup_clear()
+  %bwipe!
+endfunction
+
+function! Test_Hover_Uses_GetHover()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
+                                        \ { 'delay': 2 } )
+  doautocmd CursorHold
+  let b:ycm_hover_command = 'GetHover'
+
+  " Only the generic LSP completer supports the GetHover response, so i guess we
+  " test the error condition here...
+
+  " Python desn't support GetHover
+  call setpos( '.', [ 0, 12, 3 ] )
+  normal \D
+  let loc = screenpos( win_getid(), 11, 4 )
+  cal assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  %bwipe!
+endfunction
+
+function! Test_Hover_Uses_GetType()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
+                                        \ { 'delay': 2 } )
+  doautocmd CursorHold
+  let b:ycm_hover_command = 'GetType'
+
+  doautocmd CursorHold
+
+  let loc = screenpos( win_getid(), 2, 1 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+  let loc = screenpos( win_getid(), 2, 2 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  " some doc - autocommand
+  call setpos( '.', [ 0, 12, 3 ] )
+  doautocmd CursorHold
+  let loc = screenpos( win_getid(), 11, 4 )
+  let popup = popup_locate( loc.row, loc.col )
+  call assert_notequal( 0, popup )
+  call assert_equal( [ 'def Test_OneLine()' ],
+                   \ getbufline( winbufnr( popup ), 1, '$' ) )
+  call assert_equal( 'python', getbufvar( winbufnr( popup ), '&syntax' ) )
+
+  " some doc - mapping
+  call setpos( '.', [ 0, 12, 3 ] )
+  normal \D
+  let loc = screenpos( win_getid(), 11, 4 )
+  let popup = popup_locate( loc.row, loc.col )
+  call assert_notequal( 0, popup )
+  call assert_equal( [ 'def Test_OneLine()' ],
+                   \ getbufline( winbufnr( popup ), 1, '$' ) )
+  call assert_equal( 'python', getbufvar( winbufnr( popup ), '&syntax' ) )
+
+  call popup_clear()
+  %bwipe!
+endfunction
+
+function! Test_Hover_NonNative()
+  call youcompleteme#test#setup#OpenFile( '_not_a_file', { 'native_ft': 0 } )
+  setfiletype NoASupportedFileType
+  let messages_before = execute( 'messages' )
+  doautocmd CursorHold
+  call assert_false( exists( 'b:ycm_hover_command' ) )
+  call assert_equal( messages_before, execute( 'messages' ) )
+
+  normal \D
+  call assert_false( exists( 'b:ycm_hover_command' ) )
+  call assert_equal( messages_before, execute( 'messages' ) )
+
+  %bwipe!
+endfunction
+
+function SetUp_Test_Hover_Disabled_NonNative()
+  let g:ycm_auto_hover = ''
+endfunction
+
+function! Test_Hover_Disabled_NonNative()
+  call youcompleteme#test#setup#OpenFile( '_not_a_file', { 'native_ft': 0 } )
+  setfiletype NoASupportedFileType
+  let messages_before = execute( 'messages' )
+  silent doautocmd CursorHold
+  call assert_false( exists( 'b:ycm_hover_command' ) )
+  call assert_equal( messages_before, execute( 'messages' ) )
+
+  %bwipe!
+endfunction
+
+function! SetUp_Test_Hover_Disabled()
+  let g:ycm_auto_hover = ''
+endfunction
+
+function! Test_Hover_Disabled()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
+                                        \ { 'delay': 2 } )
+
+  let messages_before = execute( 'messages' )
+
+  call assert_false( exists( 'b:ycm_hover_command' ) )
+
+  call setpos( '.', [ 0, 12, 3 ] )
+  silent doautocmd CursorHold
+  let loc = screenpos( win_getid(), 11, 4 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  normal \D
+  let loc = screenpos( win_getid(), 11, 4 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  call assert_equal( messages_before, execute( 'messages' ) )
+
+  %bwipeout!
+endfunction

--- a/test/lib/autoload/youcompleteme/test/setup.vim
+++ b/test/lib/autoload/youcompleteme/test/setup.vim
@@ -43,10 +43,13 @@ function! youcompleteme#test#setup#OpenFile( f, kwargs ) abort
     " completers. For python and others, we actually need to parse the debug
     " info to check the server state.
     YcmForceCompileAndDiagnostics
-  endif
 
-  " Sometimes, that's just not enough to ensure stuff works
-  exe 'sleep' get( a:kwargs, 'delay', 7 )
+    " Sometimes, that's just not enough to ensure stuff works
+    let delay = get( a:kwargs, 'delay', 7 )
+    if delay > 0
+      exe 'sleep' delay
+    endif
+  endif
 
   " FIXME: We need a much more robust way to wait for the server to be ready
 endfunction


### PR DESCRIPTION
    Add auto-hover behaviour (on by default)

    This adds a hover feature, enabled by default on the CursorHold
    autocommand (default: 4s), along with a <Plug> mapping to manually
    trigger it.

    We pick the subcommand to use based on preference order: GetHover,
    GetDoc, GetType and remember the choice to avoid too many blocking
    calls.

    We enable syntax highlighting in the popup like in the signature help
    popup, using the syntax of the current buffer. This isn't perfect
    because some hover responses are markdown, though we tend to try and
    hide that in our GetDoc and GetType. So we use `markdown` for GetHover
    and `&syntax` for GetDoc/GetType.

    Technically the response fromn the server is either plaintext or
    markdown. We could actually use markdown.<current lang> in case that
    gives better results with a good markdown syntax file, though that's not
    usually the case. We could change ycmd to always request markdown and
    insist users set g:markdown_fenced_languages, but that's a bit of a
    stretch too.

    Does not work in neovim due to using a popup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3661)
<!-- Reviewable:end -->
