### PR TITLE
[READY] Slightly improve the syntax heuristic for hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -2382,11 +2382,15 @@ that it is displayed after `updatetime` milliseconds.  When set to an empty
 string, the popup is not automatically displayed.
 
 In addition to this setting, there is the `<plug>(YCMHover)` mapping, which can
-be used to manually trigger the popup. For example:
+be used to manually trigger or hide the popup (it works like a toggle).
+For example:
 
 ```viml
 nmap <leader>D <plug>(YCMHover)
 ```
+
+After dismissing the popup with this mapping, it will not be automatically
+triggered again until the cursor is moved (i.e. `CursorMoved` autocommand).
 
 Default: `'CursorHold'`
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1351,8 +1351,26 @@ if exists( '*popup_atcursor' )
                             \ '&syntax',
                             \ b:ycm_hover.syntax )
   endfunction
+
+  function! s:ToggleHover()
+    let pos = popup_getpos( s:cursorhold_popup )
+    if !empty( pos ) && pos.visible
+      call popup_hide( s:cursorhold_popup )
+      let s:cursorhold_popup = -1
+
+      " Diable the auto-trigger until the next cursor movement.
+      call s:DisableAutoHover()
+      augroup YCMHover
+        autocmd! CursorMoved <buffer>
+        autocmd CursorMoved <buffer> call s:EnableAutoHover()
+      augroup END
+    else
+      call s:Hover()
+    endif
+  endfunction
+
   let s:enable_hover = 1
-  nnoremap <silent> <plug>(YCMHover) :<C-u>call <SID>Hover()<CR>
+  nnoremap <silent> <plug>(YCMHover) :<C-u>call <SID>ToggleHover()<CR>
 else
   " Don't break people's mappings if this feature is disabled, just do nothing.
   nnoremap <silent> <plug>(YCMHover) <Nop>

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1306,24 +1306,33 @@ if exists( '*popup_atcursor' )
       return
     endif
 
-    if !has_key( b:, 'ycm_hover_command' )
+    if !has_key( b:, 'ycm_hover' )
       let cmds = youcompleteme#GetDefinedSubcommands()
       if index( cmds, 'GetHover' ) >= 0
-        let b:ycm_hover_command = 'GetHover'
+        let b:ycm_hover = {
+              \ 'command': 'GetHover',
+              \ 'syntax': 'markdown',
+              \ }
       elseif index( cmds, 'GetDoc' ) >= 0
-        let b:ycm_hover_command = 'GetDoc'
+        let b:ycm_hover = {
+              \ 'command': 'GetDoc',
+              \ 'syntax': '',
+              \ }
       elseif index( cmds, 'GetType' ) >= 0
-        let b:ycm_hover_command = 'GetType'
+        let b:ycm_hover = {
+              \ 'command': 'GetType',
+              \ 'syntax': &syntax,
+              \ }
       else
-        let b:ycm_hover_command = v:none
+        let b:ycm_hover = {}
       endif
     endif
 
-    if b:ycm_hover_command == v:none
+    if empty( b:ycm_hover )
       return
     endif
 
-    let response = youcompleteme#GetCommandResponse( b:ycm_hover_command )
+    let response = youcompleteme#GetCommandResponse( b:ycm_hover.command )
     if response == ''
       return
     endif
@@ -1334,15 +1343,13 @@ if exists( '*popup_atcursor' )
           \   {
           \     'padding': [ 0, 1, 0, 1 ],
           \     'maxwidth': &columns,
+          \     'moved': 'word',
           \     'close': 'button',
           \   }
           \ )
-    if b:ycm_hover_command ==# 'GetHover'
-      let syn = 'markdown.' . &syntax
-    else
-      let syn = &syntax
-    endif
-    call setbufvar( winbufnr( s:cursorhold_popup ), '&syntax', syn )
+    call setbufvar( winbufnr( s:cursorhold_popup ),
+                            \ '&syntax',
+                            \ b:ycm_hover.syntax )
   endfunction
   let s:enable_hover = 1
   nnoremap <silent> <plug>(YCMHover) :<C-u>call <SID>Hover()<CR>

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -680,8 +680,10 @@ def YouCompleteMe_UpdateDiagnosticInterface( ycm, post_vim_message, *args ):
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
+@patch( 'ycm.client.event_notification.EventNotification.Done',
+        return_value = True )
 def YouCompleteMe_UpdateDiagnosticInterface_OldVim_test(
-    post_vim_message, filetype_completer_exists, ycm ):
+    request_done, post_vim_message, filetype_completer_exists, ycm ):
   YouCompleteMe_UpdateDiagnosticInterface( ycm, post_vim_message )
 
 
@@ -692,8 +694,10 @@ def YouCompleteMe_UpdateDiagnosticInterface_OldVim_test(
         return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
 @patch( 'ycm.tests.test_utils.VIM_VERSION', Version( 8, 1, 614 ) )
+@patch( 'ycm.client.event_notification.EventNotification.Done',
+        return_value = True )
 def YouCompleteMe_UpdateDiagnosticInterface_NewVim_test(
-    post_vim_message, filetype_completer_exists, ycm ):
+    request_done, post_vim_message, filetype_completer_exists, ycm ):
   YouCompleteMe_UpdateDiagnosticInterface( ycm, post_vim_message )
 
 

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -51,8 +51,7 @@ endfunction
 
 function! Test_Compl_After_Trigger()
   call youcompleteme#test#setup#OpenFile(
-        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp',
-        \ #{ delay: 2 } )
+        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp', {} )
 
   call setpos( '.', [ 0, 11, 6 ] )
 
@@ -77,8 +76,7 @@ endfunctio
 
 function! Test_Force_Semantic_TopLevel()
   call youcompleteme#test#setup#OpenFile(
-        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp',
-        \ #{ delay: 2 } )
+        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp', {} )
 
   call setpos( '.', [ 0, 17, 5 ] )
 
@@ -106,8 +104,7 @@ endfunction
 
 function! Test_Select_Next_Previous()
   call youcompleteme#test#setup#OpenFile(
-        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp',
-        \ #{ delay: 2 } )
+        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp', {} )
 
   call setpos( '.', [ 0, 11, 6 ] )
 
@@ -157,8 +154,7 @@ endfunction
 
 function! Test_Enter_Delete_Chars_Updates_Filter()
   call youcompleteme#test#setup#OpenFile(
-        \ 'test/testdata/cpp/completion.cc',
-        \ #{ delay: 2 } )
+        \ 'test/testdata/cpp/completion.cc', {} )
 
   call setpos( '.', [ 0, 23, 31 ] )
 
@@ -313,12 +309,10 @@ function! Test_Completion_FixIt()
   " file, auto_include_workaround #includes auto_include.h, so that clangd knows
   " about it
   call youcompleteme#test#setup#OpenFile(
-        \ 'test/testdata/cpp/auto_include_workaround.cc',
-        \ #{ delay: 2 } )
+        \ 'test/testdata/cpp/auto_include_workaround.cc', {} )
 
   call youcompleteme#test#setup#OpenFile(
-        \ 'test/testdata/cpp/auto_include.cc',
-        \ #{ delay: 2 } )
+        \ 'test/testdata/cpp/auto_include.cc', {} )
 
   function Check1( id )
     call s:WaitForCompletion()
@@ -353,8 +347,7 @@ endfunction
 
 function! Test_Select_Next_Previous_InsertModeMapping()
   call youcompleteme#test#setup#OpenFile(
-        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp',
-        \ #{ delay: 2 } )
+        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp', {} )
 
   call setpos( '.', [ 0, 11, 6 ] )
 

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -5,6 +5,9 @@ function! SetUp()
   let g:ycm_keep_logfiles = 1
   let g:ycm_log_level = 'DEBUG'
   let g:ycm_always_populate_location_list = 1
+
+  " diagnostics take ages
+  let g:ycm_test_min_delay = 7
   call youcompleteme#test#setup#SetUp()
 endfunction
 

--- a/test/docker/manual/image/Dockerfile
+++ b/test/docker/manual/image/Dockerfile
@@ -2,6 +2,10 @@ ARG YCM_PYTHON=py3
 
 FROM youcompleteme/ycm-vim-${YCM_PYTHON}:test
 
+RUN apt-get update && \
+  apt-get -y --no-install-recommends install less && \
+  apt-get -y autoremove
+
 RUN useradd -ms /bin/bash -d /home/dev -G sudo dev && \
     echo "dev:dev" | chpasswd && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/sudo

--- a/test/docker/manual/image/Dockerfile
+++ b/test/docker/manual/image/Dockerfile
@@ -1,6 +1,6 @@
 ARG YCM_PYTHON=py3
 
-FROM puremourning/ycm-vim-${YCM_PYTHON}:test
+FROM youcompleteme/ycm-vim-${YCM_PYTHON}:test
 
 RUN useradd -ms /bin/bash -d /home/dev -G sudo dev && \
     echo "dev:dev" | chpasswd && \

--- a/test/docker/manual/run
+++ b/test/docker/manual/run
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 
-PY=py3
-
-if [ "$1" == '--py' ]; then
-  PY=py${2}
-  shift
-  shift
-fi
-
-CONTAINER=youcompleteme/ycm-vim-${PY}:manual
+CONTAINER=youcompleteme/ycm-vim-py3:manual
 
 pushd $(dirname $0)
   docker run --mount src="$(pwd)/../../../",target=/home/dev/YouCompleteMe,type=bind \

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -11,8 +11,7 @@ function! TearDown()
 endfunction
 
 function! Test_Hover_Uses_GetDoc()
-  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
-                                        \ { 'delay': 2 } )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
 
   call assert_equal( 'python', &syntax )
 
@@ -52,8 +51,7 @@ function! Test_Hover_Uses_GetDoc()
 endfunction
 
 function! Test_Hover_Uses_GetHover()
-  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
-                                        \ { 'delay': 2 } )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
   py3 <<EOPYTHON
 from unittest import mock
 with mock.patch.object( ycm_state,
@@ -79,8 +77,7 @@ EOPYTHON
 endfunction
 
 function! Test_Hover_Uses_None()
-  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
-                                        \ { 'delay': 2 } )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
   py3 <<EOPYTHON
 from unittest import mock
 with mock.patch.object( ycm_state, 'GetDefinedSubcommands', return_value = [] ):
@@ -99,8 +96,7 @@ EOPYTHON
 endfunction
 
 function! Test_Hover_Uses_GetType()
-  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
-                                        \ { 'delay': 2 } )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
 
   py3 <<EOPYTHON
 from unittest import mock
@@ -192,8 +188,7 @@ function! SetUp_Test_AutoHover_Disabled()
 endfunction
 
 function! Test_AutoHover_Disabled()
-  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
-                                        \ { 'delay': 2 } )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
 
   let messages_before = execute( 'messages' )
 
@@ -226,8 +221,7 @@ function! Test_AutoHover_Disabled()
 endfunction
 
 function! Test_Hover_MoveCursor()
-  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
-                                        \ { 'delay': 2 } )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
   function! CheckPopupVisible()
     let loc = screenpos( win_getid(), 11, 3 )
     let popup = popup_locate( loc.row, loc.col )
@@ -282,8 +276,7 @@ function! Test_Hover_MoveCursor()
 endfunction
 
 function! Test_Hover_Dismiss()
-  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
-                                        \ { 'delay': 2 } )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
   function! CheckPopupVisible()
     let loc = screenpos( win_getid(), 11, 3 )
     let popup = popup_locate( loc.row, loc.col )

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -2,7 +2,7 @@ function! SetUp()
   let g:ycm_use_clangd = 1
   let g:ycm_keep_logfiles = 1
   let g:ycm_log_level = 'DEBUG'
-  nnoremap <leader>D <Plug>(YCMHover)
+  nmap <leader>D <Plug>(YCMHover)
   call youcompleteme#test#setup#SetUp()
 endfunction
 
@@ -35,6 +35,7 @@ function! Test_Hover_Uses_GetDoc()
   call assert_equal( [ 'Test_OneLine()', '', 'This is the one line output.' ],
                    \ getbufline( winbufnr( popup ), 1, '$' ) )
   call assert_equal( '', getbufvar( winbufnr( popup ), '&syntax' ) )
+  call popup_clear()
 
   " some doc - mapping
   call setpos( '.', [ 0, 12, 3 ] )
@@ -73,6 +74,7 @@ EOPYTHON
   let loc = screenpos( win_getid(), 11, 4 )
   cal assert_equal( 0, popup_locate( loc.row, loc.col ) )
 
+  call popup_clear()
   %bwipe!
 endfunction
 
@@ -92,6 +94,7 @@ EOPYTHON
   let loc = screenpos( win_getid(), 11, 4 )
   cal assert_equal( 0, popup_locate( loc.row, loc.col ) )
 
+  call popup_clear()
   %bwipe!
 endfunction
 
@@ -123,6 +126,7 @@ EOPYTHON
   call assert_equal( [ 'def Test_OneLine()' ],
                    \ getbufline( winbufnr( popup ), 1, '$' ) )
   call assert_equal( 'python', getbufvar( winbufnr( popup ), '&syntax' ) )
+  call popup_clear()
 
   " some doc - mapping
   call setpos( '.', [ 0, 12, 3 ] )
@@ -134,7 +138,20 @@ EOPYTHON
                    \ getbufline( winbufnr( popup ), 1, '$' ) )
   call assert_equal( 'python', getbufvar( winbufnr( popup ), '&syntax' ) )
 
+  " hide it again
+  normal \D
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  " show it again
+  normal \D
+  let loc = screenpos( win_getid(), 11, 4 )
+  let popup = popup_locate( loc.row, loc.col )
+  call assert_notequal( 0, popup )
+  call assert_equal( [ 'def Test_OneLine()' ],
+                   \ getbufline( winbufnr( popup ), 1, '$' ) )
+  call assert_equal( 'python', getbufvar( winbufnr( popup ), '&syntax' ) )
   call popup_clear()
+
   %bwipe!
 endfunction
 
@@ -150,6 +167,7 @@ function! Test_Hover_NonNative()
   call assert_false( exists( 'b:ycm_hover' ) )
   call assert_equal( messages_before, execute( 'messages' ) )
 
+  call popup_clear()
   %bwipe!
 endfunction
 
@@ -165,14 +183,15 @@ function! Test_Hover_Disabled_NonNative()
   call assert_false( exists( 'b:ycm_hover' ) )
   call assert_equal( messages_before, execute( 'messages' ) )
 
+  call popup_clear()
   %bwipe!
 endfunction
 
-function! SetUp_Test_Hover_Disabled()
+function! SetUp_Test_AutoHover_Disabled()
   let g:ycm_auto_hover = ''
 endfunction
 
-function! Test_Hover_Disabled()
+function! Test_AutoHover_Disabled()
   call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
                                         \ { 'delay': 2 } )
 
@@ -184,12 +203,124 @@ function! Test_Hover_Disabled()
   silent doautocmd CursorHold
   let loc = screenpos( win_getid(), 11, 4 )
   call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+  call assert_equal( messages_before, execute( 'messages' ) )
 
+  " Manual hover is still supported
+  normal \D
+  let loc = screenpos( win_getid(), 11, 3 )
+  let popup = popup_locate( loc.row, loc.col )
+  call assert_notequal( 0, popup )
+  call assert_equal( [ 'Test_OneLine()', '', 'This is the one line output.' ],
+                   \ getbufline( winbufnr( popup ), 1, '$' ) )
+  call assert_equal( '', getbufvar( winbufnr( popup ), '&syntax' ) )
+  call assert_equal( messages_before, execute( 'messages' ) )
+
+  " Manual close hover is still supported
   normal \D
   let loc = screenpos( win_getid(), 11, 4 )
   call assert_equal( 0, popup_locate( loc.row, loc.col ) )
-
   call assert_equal( messages_before, execute( 'messages' ) )
 
+  call popup_clear()
+  %bwipeout!
+endfunction
+
+function! Test_Hover_MoveCursor()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
+                                        \ { 'delay': 2 } )
+  function! CheckPopupVisible()
+    let loc = screenpos( win_getid(), 11, 3 )
+    let popup = popup_locate( loc.row, loc.col )
+    call assert_notequal( 0, popup )
+    call assert_equal( [ 'Test_OneLine()', '', 'This is the one line output.' ],
+                     \ getbufline( winbufnr( popup ), 1, '$' ) )
+    call assert_equal( '', getbufvar( winbufnr( popup ), '&syntax' ) )
+  endfunction
+
+  " needed so that the feedkeys calls actually trigger vim to notice the cursor
+  " moving. We also need to enter/exit insert mode as Vim only checks for these
+  " cursor moved events in very specific times. In particular, _not_ while
+  " running a script (like we are here), but it _does_ on enter/exit insert
+  " mode.
+  call test_override( 'char_avail', 1 )
+
+  call setpos( '.', [ 0, 12, 3 ] )
+  doautocmd CursorHold
+  redraw
+  call CheckPopupVisible()
+
+  call feedkeys( "li\<Esc>", 'xt' )
+  redraw
+  call CheckPopupVisible()
+
+  " letters within word
+  call feedkeys( "4li\<Esc>", 'xt' )
+  redraw
+  call CheckPopupVisible()
+
+  " word
+  call feedkeys( "wi\<Esc>", 'xt' )
+  redraw
+  let loc = screenpos( win_getid(), 11, 3 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  call feedkeys( "b\\D", 'xt' )
+  redraw
+  call CheckPopupVisible()
+
+  " line
+  call feedkeys( "ji\<Esc>", 'xt' )
+  redraw
+  let loc = screenpos( win_getid(), 11, 3 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  call test_override( 'ALL', 0 )
+  delfunc CheckPopupVisible
+
+  call popup_clear()
+  %bwipeout!
+endfunction
+
+function! Test_Hover_Dismiss()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py',
+                                        \ { 'delay': 2 } )
+  function! CheckPopupVisible()
+    let loc = screenpos( win_getid(), 11, 3 )
+    let popup = popup_locate( loc.row, loc.col )
+    call assert_notequal( 0, popup )
+    call assert_equal( [ 'Test_OneLine()', '', 'This is the one line output.' ],
+                     \ getbufline( winbufnr( popup ), 1, '$' ) )
+    call assert_equal( '', getbufvar( winbufnr( popup ), '&syntax' ) )
+  endfunction
+
+  " needed so that the feedkeys calls actually trigger vim to notice the cursor
+  " moving. We also need to enter/exit insert mode as Vim only checks for these
+  " cursor moved events in very specific times. In particular, _not_ while
+  " running a script (like we are here), but it _does_ on enter/exit insert
+  " mode.
+  call test_override( 'char_avail', 1 )
+
+  call setpos( '.', [ 0, 12, 3 ] )
+  doautocmd CursorHold
+  call CheckPopupVisible()
+
+  " Dismiss
+  normal \D
+  let loc = screenpos( win_getid(), 11, 3 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  " Make sure it doesn't come back
+  doautocmd CursorHold
+  let loc = screenpos( win_getid(), 11, 3 )
+  call assert_equal( 0, popup_locate( loc.row, loc.col ) )
+
+  " Move the cursor (again this is tricky). I couldn't find any tests in vim's
+  " own code that trigger CursorMoved, so we just cheat. (for the record, just
+  " moving the cursor in the middle of this script does not trigger CursorMoved)
+  doautocmd CursorMoved
+  doautocmd CursorHold
+  call CheckPopupVisible()
+
+  call popup_clear()
   %bwipeout!
 endfunction

--- a/test/lib/autoload/youcompleteme/test/setup.vim
+++ b/test/lib/autoload/youcompleteme/test/setup.vim
@@ -9,7 +9,7 @@ function! youcompleteme#test#setup#SetUp() abort
     pyx del ycm_state
   endif
 
-  source $PWD/vimrc
+  exe 'source' getcwd() . '/vimrc'
 
   " This is a bit of a hack
   runtime! plugin/**/*.vim

--- a/test/lib/autoload/youcompleteme/test/setup.vim
+++ b/test/lib/autoload/youcompleteme/test/setup.vim
@@ -33,7 +33,9 @@ function! youcompleteme#test#setup#OpenFile( f, kwargs ) abort
         \ . '/'
         \ . a:f
 
-  if get( a:kwargs, 'native_ft', 1 )
+  let native_ft = get( a:kwargs, 'native_ft', 1 )
+
+  if native_ft
     call WaitForAssert( {->
         \ assert_true( pyxeval( 'ycm_state.NativeFiletypeCompletionUsable()' ) )
         \ } )
@@ -43,9 +45,17 @@ function! youcompleteme#test#setup#OpenFile( f, kwargs ) abort
     " completers. For python and others, we actually need to parse the debug
     " info to check the server state.
     YcmForceCompileAndDiagnostics
+  endif
 
+  if native_ft || get( a:kwargs, 'force_delay', 0 )
     " Sometimes, that's just not enough to ensure stuff works
-    let delay = get( a:kwargs, 'delay', 7 )
+    if exists( '$YCM_TEST_DELAY' )
+      let default_delay = $YCM_TEST_DELAY
+    else
+      let default_delay = get( g:, 'ycm_test_delay', 2 )
+    endif
+    let delay = max( [ get( a:kwargs, 'delay', default_delay ),
+                   \   get( g:, 'ycm_test_min_delay', 0 ) ] )
     if delay > 0
       exe 'sleep' delay
     endif

--- a/test/lib/run_test.vim
+++ b/test/lib/run_test.vim
@@ -36,7 +36,8 @@
 let s:single_test_timeout = 60000
 
 " Restrict the runtimepath to the exact minimum needed for testing
-set rtp=$PWD/lib,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after
+let &rtp = getcwd() . '/lib'
+set rtp +=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after
 
 call ch_logfile( 'debuglog', 'w' )
 

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -120,7 +120,7 @@ endfunction
 function! Test_Signatures_After_Trigger()
   call youcompleteme#test#setup#OpenFile(
         \ '/test/testdata/vim/mixed_filetype.vim',
-        \ { 'native_ft': 0 } )
+        \ { 'native_ft': 0, 'force_delay': v:true } )
 
   call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'vim' ) } )
   call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'python' ) } )

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -1,5 +1,21 @@
 let s:timer_interval = 2000
 
+function! s:WaitForSigHelpAvailable( filetype )
+  let tries = 0
+  call WaitFor( {-> s:_CheckSignatureHelpAvailable( a:filetype ) } )
+  while py3eval(
+        \ 'ycm_state._signature_help_available_requests[ '
+        \ . 'vim.eval( "a:filetype" ) ].Response() == "PENDING"' ) &&
+        \ tries < 10
+    " Force sending another request
+    py3 ycm_state._signature_help_available_requests[
+          \ vim.eval( 'a:filetype' ) ].Start( vim.eval( 'a:filetype' ) )
+    call WaitFor( {-> s:_CheckSignatureHelpAvailable( a:filetype ) } )
+    let tries += 1
+  endwhile
+  call ch_log( "Signature help is avaialble now for " . a:filetype )
+endfunction
+
 function! s:_ClearSigHelp()
   pythonx _sh_state = sh.UpdateSignatureHelp( _sh_state, {} )
   call assert_true( pyxeval( '_sh_state.popup_win_id is None' ),
@@ -123,7 +139,7 @@ function! Test_Signatures_After_Trigger()
         \ { 'native_ft': 0, 'force_delay': v:true } )
 
   call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'vim' ) } )
-  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'python' ) } )
+  call s:WaitForSigHelpAvailable( 'python' )
 
   call setpos( '.', [ 0, 3, 17 ] )
 
@@ -193,7 +209,7 @@ function! Test_Signatures_With_PUM_NoSigns()
         \ '/third_party/ycmd/ycmd/tests/clangd/testdata/general_fallback'
         \ . '/make_drink.cc', {} )
 
-  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'cpp' ) } )
+  call s:WaitForSigHelpAvailable( 'cpp' )
 
   " Make sure that error signs don't shift the window
   setlocal signcolumn=no
@@ -268,7 +284,7 @@ function! Test_Signatures_With_PUM_Signs()
         \ '/third_party/ycmd/ycmd/tests/clangd/testdata/general_fallback'
         \ . '/make_drink.cc', {} )
 
-  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'cpp' ) } )
+  call s:WaitForSigHelpAvailable( 'cpp' )
 
   " Make sure that sign causes the popup to shift
   setlocal signcolumn=auto
@@ -508,7 +524,7 @@ endfunction
 
 function! Test_Signatures_TopLine()
   call youcompleteme#test#setup#OpenFile( 'test/testdata/python/test.py', {} )
-  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'python' ) } )
+  call s:WaitForSigHelpAvailable( 'python' )
   call setpos( '.', [ 0, 1, 24 ] )
   call test_override( 'char_avail', 1 )
 
@@ -528,7 +544,7 @@ endfunction
 
 function! Test_Signatures_TopLineWithPUM()
   call youcompleteme#test#setup#OpenFile( 'test/testdata/python/test.py', {} )
-  call WaitFor( {-> s:_CheckSignatureHelpAvailable( 'python' ) } )
+  call s:WaitForSigHelpAvailable( 'python' )
   call setpos( '.', [ 0, 1, 24 ] )
   call test_override( 'char_avail', 1 )
 


### PR DESCRIPTION
1. improve the syntax detection

We use this heuristic:

* For GetHover - use markdown
* For GetDoc - use nothing
* For GetType - use the current file syntax

You can also (undocumentedly) set b:ycm_hover to a dict with 'command'
and 'syntax' keys to manually override this if you so choose.

This also improves the tests - they now mock the python layer so that we
actually test the vimscript properly and cover the different cases.

Fixes #3667 

--- 

2. improve the popup display/hide mechanics:

* close the popup on 'word' rather than the default 'WORD' cursor movement.
* allow user more control by making the mapping a toggle

Incidentally, I found that the tests were garbage, and were never actually triggering the mapping (fixed by using `nmap` not `nnoremap`) and that there is a simple way to test the actual code

Fixes #3669 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3668)
<!-- Reviewable:end -->
