### PR TITLE
Use `'close': 'click'` behavior for hover popups

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1344,7 +1344,7 @@ if exists( '*popup_atcursor' )
           \     'padding': [ 0, 1, 0, 1 ],
           \     'maxwidth': &columns,
           \     'moved': 'word',
-          \     'close': 'button',
+          \     'close': 'click',
           \   }
           \ )
     call setbufvar( winbufnr( s:cursorhold_popup ),


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't. [Didn't include tests, have rationale below]
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The behavior used to be `'close': 'button'` which shows an 'X' in the top right of the popup. It's some times not clear that the 'X' is a button. The popup disappears when the cursor moves and the hover command now has toggle behavior so it seems less necessary. This new `'close': 'click'` behavior removes this button, but still closes the popup when clicking anywhere in the popup, so the mouse can still be used.

The change seems trivial so I didn't include any tests. 🤔

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3675)
<!-- Reviewable:end -->
