### PR TITLE
[READY] Maximise displayed text for hover popup

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1338,13 +1338,36 @@ if exists( '*popup_atcursor' )
     endif
 
     call popup_hide( s:cursorhold_popup )
+
+    " Try to position the popup at the cursor, but avoid wrapping. If the
+    " longest line is > screen width (&columns), then we just have to wrap, and
+    " place the popup at the leftmost column.
+    "
+    " Find the longest line (FIXME: probably doesn't work well for multi-byte)
+    let lines = split( response, "\n" )
+    let len = max( map( copy( lines ), "len( v:val )" ) )
+
+    let wrap = 0
+    let col = 'cursor'
+
+    " max width is screen columns minus x padding (2)
+    if len >= (&columns - 2)
+      " There's at least one line > our max - enable word wrap and draw the
+      " popup at the leftmost column
+      let col = 1
+      let wrap = 1
+    endif
+
     let s:cursorhold_popup = popup_atcursor(
-          \   split( response, "\n" ),
+          \   lines,
           \   {
+          \     'col': col,
+          \     'wrap': wrap,
           \     'padding': [ 0, 1, 0, 1 ],
-          \     'maxwidth': &columns,
           \     'moved': 'word',
+          \     'maxwidth': &columns,
           \     'close': 'click',
+          \     'fixed': 0,
           \   }
           \ )
     call setbufvar( winbufnr( s:cursorhold_popup ),

--- a/test/testdata/python/doc.py
+++ b/test/testdata/python/doc.py
@@ -12,3 +12,27 @@ def Main():
   Test_OneLine()
   Test_MultiLine()
 
+
+def Really_Long_Method( which, has, some, param, that, take, the, whole, line ):
+  """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum egestas libero urna, vel sagittis felis condimentum in. Nulla arcu eros, aliquet vel mollis vitae, semper eu ex. Donec posuere quam et ornare sagittis. Curabitur nunc ex, fringilla quis lorem sed, dignissim congue felis. Integer vestibulum ac elit vel blandit. Nam non dui urna. Integer eu semper massa. Nullam ac elit interdum, aliquet elit nec, porttitor orci. Duis tempus justo lorem, ac fringilla ante viverra egestas. Etiam eleifend enim ac libero dapibus, quis condimentum lectus tristique. Fusce feugiat, lorem et faucibus eleifend, ipsum nisi maximus justo, at consectetur ligula leo vitae justo."""
+  # Really long one-line
+  pass
+
+
+def Really_Long_Method_2():
+  """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum egestas
+  libero urna, vel sagittis felis condimentum in. Nulla arcu eros, aliquet vel
+  mollis vitae, semper eu ex. Donec posuere quam et ornare sagittis. Curabitur
+  nunc ex, fringilla quis lorem sed, dignissim congue felis. Integer vestibulum
+  ac elit vel blandit. Nam non dui urna. Integer eu semper massa. Nullam ac elit
+  interdum, aliquet elit nec, porttitor orci. Duis tempus justo lorem, ac
+  fringilla ante viverra egestas. Etiam eleifend enim ac libero dapibus, quis
+  condimentum lectus tristique. Fusce feugiat, lorem et faucibus eleifend, ipsum
+  nisi maximus justo, at consectetur ligula leo vitae justo."""
+  # Really long one para
+  pass
+
+
+def Moan():
+  Really_Long_Method()
+  Really_Long_Method_2()


### PR DESCRIPTION
Previously we relied on popup_atcursor to display the popup in a
sensible place. However, by default 'wrap' is enabled, which prevents
vim from shifting the popup to the left to show it on the screen (even
if you set minwidth). As a result it was possible for the popup to
display a very small vertical section when triggered close to the
right-hand screen edge.

The solution is to enable wrapping, which lets vim shift the popup. The
edge-case is that we _do_ want wrapping if there are lines that are
likely to be wrapped. Therefore in that case (when any line is > some
maximum width), we just force the popup to be placed at column 1 and
enable wrapping.

The maximum width for this wrapping is calculated as the screen width in
columns minus the padding we add in the x-axis. THis is a bit hacky as
it doesn't work properly for multi-byte characters, though the
calculation is likely to be _conservative_ in taht case, so it's
probably ok.

Fixes #3676

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3679)
<!-- Reviewable:end -->
