### PR TITLE
Truncate extra_menu_info when completeopt is in popup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2703,15 +2703,23 @@ let g:ycm_csharp_insert_namespace_expr = ''
 
 When this option is set to `1`, YCM will add the `preview` string to Vim's
 `completeopt` option (see `:h completeopt`). If your `completeopt` option
-already has `preview` set, there will be no effect. You can see the current
-state of your `completeopt` setting with `:set completeopt?` (yes, the question
-mark is important).
+already has `preview` set, there will be no effect. Alternatively, when set to
+`popup` and your version of Vim supports popup windows (see `:help popup`), the
+`popup` string will be used instead. You can see the current state of your
+`completeopt` setting with `:set completeopt?` (yes, the question mark is
+important).
 
 When `preview` is present in `completeopt`, YCM will use the `preview` window at
 the top of the file to store detailed information about the current completion
 candidate (but only if the candidate came from the semantic engine). For
 instance, it would show the full function prototype and all the function
 overloads in the window if the current completion is a function name.
+
+When `popup` is present in `completeopt`, YCM will instead use a `popup`
+window to the side of the completion popup for storing detailed information
+about the current completion candidate. In addition, YCM may truncate the
+detailed completion information in order to give the popup sufficient room
+to display that detailed information.
 
 Default: `0`
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -505,7 +505,9 @@ function! s:SetUpCompleteopt()
   " Also, having this option set breaks the plugin.
   set completeopt-=longest
 
-  if g:ycm_add_preview_to_completeopt
+  if g:ycm_add_preview_to_completeopt ==# 'popup' && exists( '*popup_open' )
+    set completeopt+=popup
+  elseif g:ycm_add_preview_to_completeopt
     set completeopt+=preview
   endif
 endfunction

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2936,15 +2936,23 @@ The *g:ycm_add_preview_to_completeopt* option
 
 When this option is set to '1', YCM will add the 'preview' string to Vim's
 'completeopt' option (see ':h completeopt'). If your 'completeopt' option
-already has 'preview' set, there will be no effect. You can see the current
-state of your 'completeopt' setting with ':set completeopt?' (yes, the question
-mark is important).
+already has 'preview' set, there will be no effect. Alternatively, when set to
+'popup' and your version of Vim supports popup windows (see ':help popup'),
+the 'popup' string will be used instead. You can see the current state of your
+'completeopt' setting with ':set completeopt?' (yes, the question mark is
+important).
 
 When 'preview' is present in 'completeopt', YCM will use the 'preview' window
 at the top of the file to store detailed information about the current
 completion candidate (but only if the candidate came from the semantic engine).
 For instance, it would show the full function prototype and all the function
 overloads in the window if the current completion is a function name.
+
+When 'popup' is present in 'completeopt', YCM will instead use a 'popup'
+window to the side of the completion popup for storing detailed information
+about the current completion candidate. In addition, YCM may truncate the
+detailed completion information in order to give the popup sufficient room
+to display that detailed information.
 
 Default: '0'
 >

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2937,8 +2937,8 @@ The *g:ycm_add_preview_to_completeopt* option
 When this option is set to '1', YCM will add the 'preview' string to Vim's
 'completeopt' option (see ':h completeopt'). If your 'completeopt' option
 already has 'preview' set, there will be no effect. Alternatively, when set to
-'popup' and your version of Vim supports popup windows (see ':help popup'),
-the 'popup' string will be used instead. You can see the current state of your
+'popup' and your version of Vim supports popup windows (see ':help popup'), the
+'popup' string will be used instead. You can see the current state of your
 'completeopt' setting with ':set completeopt?' (yes, the question mark is
 important).
 
@@ -2948,11 +2948,11 @@ completion candidate (but only if the candidate came from the semantic engine).
 For instance, it would show the full function prototype and all the function
 overloads in the window if the current completion is a function name.
 
-When 'popup' is present in 'completeopt', YCM will instead use a 'popup'
-window to the side of the completion popup for storing detailed information
-about the current completion candidate. In addition, YCM may truncate the
-detailed completion information in order to give the popup sufficient room
-to display that detailed information.
+When 'popup' is present in 'completeopt', YCM will instead use a 'popup' window
+to the side of the completion popup for storing detailed information about the
+current completion candidate. In addition, YCM may truncate the detailed
+completion information in order to give the popup sufficient room to display
+that detailed information.
 
 Default: '0'
 >

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -181,11 +181,25 @@ def _GetCompletionInfoField( completion_data ):
 
 def _ConvertCompletionDataToVimData( completion_data ):
   # See :h complete-items for a description of the dictionary fields.
+  extra_menu_info = completion_data.get( 'extra_menu_info', '' )
+  preview_info = _GetCompletionInfoField( completion_data )
+
+  # When we are using a popup for the preview_info, it needs to fit on the
+  # screen alongside the extra_menu_info. Let's use some heuristics.  If the
+  # length of the extra_menu_info is more than, say 50% of screen, truncate it
+  # and stick it in the preview_info.
+  if vimsupport.UsingPreviewPopup():
+    max_width = max( int( vimsupport.DisplayWidth() / 3 ), 3 )
+    extra_menu_info_width = vimsupport.DisplayWidthOfString( extra_menu_info )
+    if extra_menu_info_width > max_width:
+      preview_info = extra_menu_info + '\n\n' + preview_info
+      extra_menu_info = extra_menu_info[ : ( max_width - 3 ) ] + '...'
+
   return {
     'word'     : completion_data[ 'insertion_text' ],
     'abbr'     : completion_data.get( 'menu_text', '' ),
-    'menu'     : completion_data.get( 'extra_menu_info', '' ),
-    'info'     : _GetCompletionInfoField( completion_data ),
+    'menu'     : extra_menu_info,
+    'info'     : preview_info,
     'kind'     : ToUnicode( completion_data.get( 'kind', '' ) )[ :1 ].lower(),
     # Disable Vim filtering.
     'equal'    : 1,

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -186,13 +186,14 @@ def _ConvertCompletionDataToVimData( completion_data ):
 
   # When we are using a popup for the preview_info, it needs to fit on the
   # screen alongside the extra_menu_info. Let's use some heuristics.  If the
-  # length of the extra_menu_info is more than, say 50% of screen, truncate it
+  # length of the extra_menu_info is more than, say, 1/3 of screen, truncate it
   # and stick it in the preview_info.
   if vimsupport.UsingPreviewPopup():
     max_width = max( int( vimsupport.DisplayWidth() / 3 ), 3 )
     extra_menu_info_width = vimsupport.DisplayWidthOfString( extra_menu_info )
     if extra_menu_info_width > max_width:
-      preview_info = extra_menu_info + '\n\n' + preview_info
+      if not preview_info.startswith( extra_menu_info ):
+        preview_info = extra_menu_info + '\n\n' + preview_info
       extra_menu_info = extra_menu_info[ : ( max_width - 3 ) ] + '...'
 
   return {

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -18,6 +18,7 @@
 import json
 from hamcrest import assert_that, equal_to
 from unittest.mock import patch
+from ycm.tests.conftest import UserOptions
 from ycm.tests.test_utils import MockVimModule
 vim_mock = MockVimModule()
 
@@ -216,84 +217,107 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "vim.options", { 'completeopt': b'popup,menuone',
-                           '&columns': 60 } )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopup_test( self, *args ):
-    extra_data = {
-      'doc_string':    'DOC STRING',
-    }
-    self._Check( {
-      'insertion_text':  '',
-      'menu_text':       'MENU TEXT',
-      'extra_menu_info': 'ESPECIALLY LONG EXTRA MENU INFO LOREM IPSUM DOLOR',
-      'kind':            'K',
-      'detailed_info':   'DETAILED INFO',
-      'extra_data': extra_data,
-    }, {
-      'word'     : '',
-      'abbr'     : 'MENU TEXT',
-      'menu'     : 'ESPECIALLY LONG E...',
-      'kind'     : 'k',
-      'info'     : 'ESPECIALLY LONG EXTRA MENU INFO LOREM IPSUM DOLOR\n\n' +
-                   'DETAILED INFO\nDOC STRING',
-      'equal'    : 1,
-      'dup'      : 1,
-      'empty'    : 1,
-      'user_data': json.dumps( extra_data ),
-    } )
+    with UserOptions( { '&columns': 60, '&completeopt': b'popup,menuone' } ):
+      extra_data = {
+        'doc_string':    'DOC STRING',
+      }
+      self._Check( {
+        'insertion_text':  '',
+        'menu_text':       'MENU TEXT',
+        'extra_menu_info': 'ESPECIALLY LONG EXTRA MENU INFO LOREM IPSUM DOLOR',
+        'kind':            'K',
+        'detailed_info':   'DETAILED INFO',
+        'extra_data': extra_data,
+      }, {
+        'word'     : '',
+        'abbr'     : 'MENU TEXT',
+        'menu'     : 'ESPECIALLY LONG E...',
+        'kind'     : 'k',
+        'info'     : 'ESPECIALLY LONG EXTRA MENU INFO LOREM IPSUM DOLOR\n\n' +
+                     'DETAILED INFO\nDOC STRING',
+        'equal'    : 1,
+        'dup'      : 1,
+        'empty'    : 1,
+        'user_data': json.dumps( extra_data ),
+      } )
 
 
-  @patch( "vim.options", { 'completeopt': b'popup,menuone',
-                           '&columns': 60 } )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def OnlyTruncateForPopupIfNecessary_test( self, *args ):
-    extra_data = {
-      'doc_string':    'DOC STRING',
-    }
-    self._Check( {
-      'insertion_text':  '',
-      'menu_text':       'MENU TEXT',
-      'extra_menu_info': 'EXTRA MENU INFO',
-      'kind':            'K',
-      'detailed_info':   'DETAILED INFO',
-      'extra_data': extra_data,
-    }, {
-      'word'     : '',
-      'abbr'     : 'MENU TEXT',
-      'menu'     : 'EXTRA MENU INFO',
-      'kind'     : 'k',
-      'info'     : 'DETAILED INFO\nDOC STRING',
-      'equal'    : 1,
-      'dup'      : 1,
-      'empty'    : 1,
-      'user_data': json.dumps( extra_data ),
-    } )
+    with UserOptions( { '&columns': 60, '&completeopt': b'popup,menuone' } ):
+      extra_data = {
+        'doc_string':    'DOC STRING',
+      }
+      self._Check( {
+        'insertion_text':  '',
+        'menu_text':       'MENU TEXT',
+        'extra_menu_info': 'EXTRA MENU INFO',
+        'kind':            'K',
+        'detailed_info':   'DETAILED INFO',
+        'extra_data': extra_data,
+      }, {
+        'word'     : '',
+        'abbr'     : 'MENU TEXT',
+        'menu'     : 'EXTRA MENU INFO',
+        'kind'     : 'k',
+        'info'     : 'DETAILED INFO\nDOC STRING',
+        'equal'    : 1,
+        'dup'      : 1,
+        'empty'    : 1,
+        'user_data': json.dumps( extra_data ),
+      } )
 
 
-  @patch( "vim.options", { 'completeopt': b'popup,menuone',
-                           '&columns': 60 } )
+  @patch( "ycm.vimsupport.DisplayWidthOfString", len )
+  def DontTruncateIfNotPopup_test( self, *args ):
+    with UserOptions( { '&columns': 60, '&completeopt': b'preview,menuone' } ):
+      extra_data = {
+        'doc_string':    'DOC STRING',
+      }
+      self._Check( {
+        'insertion_text':  '',
+        'menu_text':       'MENU TEXT',
+        'extra_menu_info': 'ESPECIALLY LONG EXTRA MENU INFO LOREM IPSUM DOLOR',
+        'kind':            'K',
+        'detailed_info':   'DETAILED INFO',
+        'extra_data': extra_data,
+      }, {
+        'word'     : '',
+        'abbr'     : 'MENU TEXT',
+        'menu'     : 'ESPECIALLY LONG EXTRA MENU INFO LOREM IPSUM DOLOR',
+        'kind'     : 'k',
+        'info'     : 'DETAILED INFO\nDOC STRING',
+        'equal'    : 1,
+        'dup'      : 1,
+        'empty'    : 1,
+        'user_data': json.dumps( extra_data ),
+      } )
+
+
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopupWithoutDuplication_test( self, *args ):
-    extra_data = {
-      'doc_string':    'DOC STRING',
-    }
-    self._Check( {
-      'insertion_text':  '',
-      'menu_text':       'MENU TEXT',
-      'extra_menu_info': 'ESPECIALLY LONG METHOD SIGNATURE LOREM IPSUM',
-      'kind':            'K',
-      'detailed_info':   'ESPECIALLY LONG METHOD SIGNATURE LOREM IPSUM',
-      'extra_data': extra_data,
-    }, {
-      'word'     : '',
-      'abbr'     : 'MENU TEXT',
-      'menu'     : 'ESPECIALLY LONG M...',
-      'kind'     : 'k',
-      'info'     : 'ESPECIALLY LONG METHOD SIGNATURE LOREM IPSUM\n' +
-                   'DOC STRING',
-      'equal'    : 1,
-      'dup'      : 1,
-      'empty'    : 1,
-      'user_data': json.dumps( extra_data ),
-    } )
+    with UserOptions( { '&columns': 60, '&completeopt': b'popup,menuone' } ):
+      extra_data = {
+        'doc_string':    'DOC STRING',
+      }
+      self._Check( {
+        'insertion_text':  '',
+        'menu_text':       'MENU TEXT',
+        'extra_menu_info': 'ESPECIALLY LONG METHOD SIGNATURE LOREM IPSUM',
+        'kind':            'K',
+        'detailed_info':   'ESPECIALLY LONG METHOD SIGNATURE LOREM IPSUM',
+        'extra_data': extra_data,
+      }, {
+        'word'     : '',
+        'abbr'     : 'MENU TEXT',
+        'menu'     : 'ESPECIALLY LONG M...',
+        'kind'     : 'k',
+        'info'     : 'ESPECIALLY LONG METHOD SIGNATURE LOREM IPSUM\n' +
+                     'DOC STRING',
+        'equal'    : 1,
+        'dup'      : 1,
+        'empty'    : 1,
+        'user_data': json.dumps( extra_data ),
+      } )

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -216,7 +216,7 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "ycm.vimsupport.UsingPreviewPopup", return_value = True )
+  @patch( "vim.options", { 'completeopt': b'popup,menuone' } )
   @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopup_test( self, *args ):
@@ -244,7 +244,7 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "ycm.vimsupport.UsingPreviewPopup", return_value = True )
+  @patch( "vim.options", { 'completeopt': b'popup,menuone' } )
   @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def OnlyTruncateForPopupIfNecessary_test( self, *args ):
@@ -271,7 +271,7 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "ycm.vimsupport.UsingPreviewPopup", return_value = True )
+  @patch( "vim.options", { 'completeopt': b'popup,menuone' } )
   @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopupWithoutDuplication_test( self, *args ):

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -17,7 +17,6 @@
 
 import json
 from hamcrest import assert_that, equal_to
-from unittest.mock import patch
 from ycm.tests.conftest import UserOptions
 from ycm.tests.test_utils import MockVimModule
 vim_mock = MockVimModule()
@@ -217,7 +216,6 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopup_test( self, *args ):
     with UserOptions( { '&columns': 60, '&completeopt': b'popup,menuone' } ):
       extra_data = {
@@ -244,7 +242,6 @@ class ConvertCompletionResponseToVimDatas_test:
       } )
 
 
-  @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def OnlyTruncateForPopupIfNecessary_test( self, *args ):
     with UserOptions( { '&columns': 60, '&completeopt': b'popup,menuone' } ):
       extra_data = {
@@ -270,7 +267,6 @@ class ConvertCompletionResponseToVimDatas_test:
       } )
 
 
-  @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def DontTruncateIfNotPopup_test( self, *args ):
     with UserOptions( { '&columns': 60, '&completeopt': b'preview,menuone' } ):
       extra_data = {
@@ -296,7 +292,6 @@ class ConvertCompletionResponseToVimDatas_test:
       } )
 
 
-  @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopupWithoutDuplication_test( self, *args ):
     with UserOptions( { '&columns': 60, '&completeopt': b'popup,menuone' } ):
       extra_data = {

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -216,8 +216,8 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "vim.options", { 'completeopt': b'popup,menuone' } )
-  @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
+  @patch( "vim.options", { 'completeopt': b'popup,menuone',
+                           '&columns': 60 } )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopup_test( self, *args ):
     extra_data = {
@@ -244,8 +244,8 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "vim.options", { 'completeopt': b'popup,menuone' } )
-  @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
+  @patch( "vim.options", { 'completeopt': b'popup,menuone',
+                           '&columns': 60 } )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def OnlyTruncateForPopupIfNecessary_test( self, *args ):
     extra_data = {
@@ -271,8 +271,8 @@ class ConvertCompletionResponseToVimDatas_test:
     } )
 
 
-  @patch( "vim.options", { 'completeopt': b'popup,menuone' } )
-  @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
+  @patch( "vim.options", { 'completeopt': b'popup,menuone',
+                           '&columns': 60 } )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopupWithoutDuplication_test( self, *args ):
     extra_data = {

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -247,6 +247,33 @@ class ConvertCompletionResponseToVimDatas_test:
   @patch( "ycm.vimsupport.UsingPreviewPopup", return_value = True )
   @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
   @patch( "ycm.vimsupport.DisplayWidthOfString", len )
+  def OnlyTruncateForPopupIfNecessary_test( self, *args ):
+    extra_data = {
+      'doc_string':    'DOC STRING',
+    }
+    self._Check( {
+      'insertion_text':  '',
+      'menu_text':       'MENU TEXT',
+      'extra_menu_info': 'EXTRA MENU INFO',
+      'kind':            'K',
+      'detailed_info':   'DETAILED INFO',
+      'extra_data': extra_data,
+    }, {
+      'word'     : '',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'info'     : 'DETAILED INFO\nDOC STRING',
+      'equal'    : 1,
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': json.dumps( extra_data ),
+    } )
+
+
+  @patch( "ycm.vimsupport.UsingPreviewPopup", return_value = True )
+  @patch( "ycm.vimsupport.DisplayWidth", return_value = 60 )
+  @patch( "ycm.vimsupport.DisplayWidthOfString", len )
   def TruncateForPopupWithoutDuplication_test( self, *args ):
     extra_data = {
       'doc_string':    'DOC STRING',

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -43,6 +43,8 @@ MATCHDELETE_REGEX = re.compile( '^matchdelete\\((?P<id>\\d+)\\)$' )
 OMNIFUNC_REGEX_FORMAT = (
   '^{omnifunc_name}\\((?P<findstart>[01]),[\'"](?P<base>.*)[\'"]\\)$' )
 FNAMEESCAPE_REGEX = re.compile( '^fnameescape\\(\'(?P<filepath>.+)\'\\)$' )
+STRDISPLAYWIDTH_REGEX = re.compile(
+  '^strdisplaywidth\\( ?\'(?P<text>.+)\' ?\\)$' )
 SIGN_LIST_REGEX = re.compile(
   '^silent! sign place buffer=(?P<bufnr>\\d+)$' )
 SIGN_PLACE_REGEX = re.compile(
@@ -289,6 +291,10 @@ def _MockVimEval( value ):
 
   if value == REDIR[ 'variable' ]:
     return REDIR[ 'output' ]
+
+  match = STRDISPLAYWIDTH_REGEX.search( value )
+  if match:
+    return len( match.group( 'text' ) )
 
   raise VimError( 'Unexpected evaluation: {}'.format( value ) )
 

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -70,6 +70,7 @@ VIM_MATCHES_FOR_WINDOW = defaultdict( list )
 VIM_SIGNS = []
 
 VIM_OPTIONS = {
+  '&completeopt': b'',
   '&previewheight': 12,
   '&columns': 80,
   '&ruler': 0,
@@ -183,10 +184,6 @@ def _MockVimWindowEval( value ):
 
 
 def _MockVimOptionsEval( value ):
-  result = VIM_MOCK.options.get( value )
-  if result is not None:
-    return result
-
   result = VIM_OPTIONS.get( value )
   if result is not None:
     return result
@@ -372,6 +369,14 @@ def _MockVimCommand( command ):
     return
 
   return DEFAULT
+
+
+def _MockVimOptions( option ):
+  result = VIM_OPTIONS.get( '&' + option )
+  if result is not None:
+    return result
+
+  return None
 
 
 class VimBuffer:
@@ -636,6 +641,8 @@ def MockVimModule():
   VIM_MOCK.command = MagicMock( side_effect = _MockVimCommand )
   VIM_MOCK.eval = MagicMock( side_effect = _MockVimEval )
   VIM_MOCK.error = VimError
+  VIM_MOCK.options = MagicMock()
+  VIM_MOCK.options.__getitem__.side_effect = _MockVimOptions
   sys.modules[ 'vim' ] = VIM_MOCK
 
   return VIM_MOCK

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -183,6 +183,10 @@ def _MockVimWindowEval( value ):
 
 
 def _MockVimOptionsEval( value ):
+  result = VIM_MOCK.options.get( value )
+  if result is not None:
+    return result
+
   result = VIM_OPTIONS.get( value )
   if result is not None:
     return result

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1308,3 +1308,15 @@ def ScreenPositionForLineColumnInWindow( window, line, column ):
       WinIDForWindow( window ),
       line,
       column ) )
+
+
+def UsingPreviewPopup():
+  return 'popup' in ToUnicode( vim.options[ 'completeopt' ] ).split( ',' )
+
+
+def DisplayWidth():
+  return GetIntValue( '&columns' )
+
+
+def DisplayWidthOfString( s ):
+  return GetIntValue( "strdisplaywidth( '{}' )".format( EscapeForVim( s ) ) )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1311,7 +1311,7 @@ def ScreenPositionForLineColumnInWindow( window, line, column ):
 
 
 def UsingPreviewPopup():
-  return 'popup' in ToUnicode( vim.options[ 'completeopt' ] ).split( ',' )
+  return b'popup' in vim.options[ 'completeopt' ]
 
 
 def DisplayWidth():

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1311,7 +1311,7 @@ def ScreenPositionForLineColumnInWindow( window, line, column ):
 
 
 def UsingPreviewPopup():
-  return b'popup' in vim.options[ 'completeopt' ]
+  return 'popup' in ToUnicode( vim.options[ 'completeopt' ] ).split( ',' )
 
 
 def DisplayWidth():


### PR DESCRIPTION
Fixes #3547

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Per discussion in #3547 the popup used when 'popup' is included in completeopt does not get to specify a minimum width, so for languages with verbose signatures like Typescript, the extra information (IE: documentation) that should be viewable there gets very squished and hard to read.

By introducing this simple heuristic, created by @puremourning, of allowing the extra_menu_info to have no more than ~1/3rd of the screen's width in length, we are left with ~1/3rd of the screen for the actual completion `word`, and ~1/3rd for the documentation. Since we are copying the extra_menu_info into the preview window, information loss is minimal.

We could theoretically introduce an option that could disable this truncation behavior, but I think the real solution in that case is probably for the user to not enable the 'popup' completeopt, since the popup is pretty much unusable in cases where this truncation would kick in.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3682)
<!-- Reviewable:end -->
