### PR TITLE
Fix name of popup function

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -505,7 +505,7 @@ function! s:SetUpCompleteopt()
   " Also, having this option set breaks the plugin.
   set completeopt-=longest
 
-  if g:ycm_add_preview_to_completeopt ==# 'popup' && exists( '*popup_open' )
+  if g:ycm_add_preview_to_completeopt ==# 'popup' && exists( '*popup_create' )
     set completeopt+=popup
   elseif g:ycm_add_preview_to_completeopt
     set completeopt+=preview


### PR DESCRIPTION

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

When `g:ycm_add_preview_to_completeopt` is set to `'popup'`, we want to check whether Vim actually supports popups. The correct function to check for is `popup_create`, not `popup_open` (see `:help popup_create`)

No tests because it seems unnecessary. 

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
