### PR TITLE
don't check file size in unsupported filetypes

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -446,10 +446,6 @@ function! s:AllowedToCompleteInBuffer( buffer )
 
   let filetype = getbufvar( a:buffer, '&filetype' )
 
-  if empty( filetype ) || s:DisableOnLargeFile( a:buffer )
-    return 0
-  endif
-
   let whitelist_allows = type( g:ycm_filetype_whitelist ) != type( {} ) ||
         \ has_key( g:ycm_filetype_whitelist, '*' ) ||
         \ s:HasAnyKey( g:ycm_filetype_whitelist, split( filetype, '\.' ) )
@@ -457,6 +453,11 @@ function! s:AllowedToCompleteInBuffer( buffer )
         \ !s:HasAnyKey( g:ycm_filetype_blacklist, split( filetype, '\.' ) )
 
   let allowed = whitelist_allows && blacklist_allows
+
+  if empty( filetype ) || !allowed || s:DisableOnLargeFile( a:buffer )
+    return 0
+  endif
+
   if allowed
     let s:previous_allowed_buffer_number = bufnr( a:buffer )
   endif

--- a/test/filesize.test.vim
+++ b/test/filesize.test.vim
@@ -1,0 +1,49 @@
+function! SetUp()
+  let g:ycm_use_clangd = 1
+  let g:ycm_confirm_extra_conf = 0
+  let g:ycm_auto_trigger = 1
+  let g:ycm_keep_logfiles = 1
+  let g:ycm_always_populate_location_list = 1
+
+  " diagnostics take ages
+  let g:ycm_test_min_delay = 7 
+  call youcompleteme#test#setup#SetUp()
+endfunction
+
+function! TearDown()
+  call youcompleteme#test#setup#CleanUp()
+endfunction
+
+function! Test_Open_Unsupported_Filetype_Messages()
+  messages clear
+  enew
+
+  let X = join( map( range( 0, 1000 * 1024 + 1 ), {->'X'} ), '' )
+  call append( line( '$' ), X )
+
+  w! Xtest
+
+  let l:stderr = substitute( execute( 'messages' ), '\n', '\t', 'g' )
+  call assert_notmatch( 'the file exceeded the max size', stderr )
+
+  %bwipeout!
+  call delete( 'Xtest' )
+endfunction
+
+function! Test_Open_Supported_Filetype_Messages()
+  enew
+
+  let X = join( map( range( 0, 1000 * 1024 + 1 ), {->'X'} ), '' )
+  call append( line( '$' ), X )
+
+  w! Xtest
+  messages clear
+  setf cpp
+
+  let l:stderr = substitute( execute( 'messages' ), '\n', '\t', 'g' )
+  call assert_match( 'the file exceeded the max size', stderr )
+  call assert_equal( 1, b:ycm_largefile )
+
+  %bwipeout!
+  call delete( 'Xtest' )
+endfunction


### PR DESCRIPTION
Previously, this was providing a false negatives. Now,
if the filetype is not approved, we immediately return
without trying to finish opening it.

Signed-off-by: Kevin Morris <kevr.gtalk@gmail.com>

This PR/Commit chain is made to satisfy https://github.com/ycm-core/YouCompleteMe/issues/3463. Currently, the test works, however I'd like to generate the files from inside of the test and reload YCM when the buffer is filled up. I've tried quite a few different things, but I'm a bit lost as to how to do it. Any advice would be greatly appreciated.

PS: There are some formatting issues in this commit; I'll patch it up shortly, just wanted to get this PR in here to get some eyes on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3753)
<!-- Reviewable:end -->
