### PR TITLE
[READY] Resolve completion item detailed_info on demand (where possible)

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
   "configurations": {
     "python - launch pytest": {
       "adapter": "debugpy",

--- a/README.md
+++ b/README.md
@@ -5,17 +5,11 @@ YouCompleteMe: a code-completion engine for Vim
 [![Build status](https://dev.azure.com/YouCompleteMe/YCM/_apis/build/status/ycm-core.YouCompleteMe?branchName=master)](https://dev.azure.com/YouCompleteMe/YCM/_build?definitionId=3&branchName=master)
 [![Coverage status](https://img.shields.io/codecov/c/github/ycm-core/YouCompleteMe/master.svg)](https://codecov.io/gh/ycm-core/YouCompleteMe)
 
-Warning: Support for Python 3.5 has ended
-----
+NOTE: Minimum Requirements Have Changed
+----------------------------------------
 
-In mid 2020, YCM dropped support for Python 3.5 runtime.
-
-Why?
-
-On 13th September 2020, Python 3.5 will be officially end of life. And therefore, so
-will its relationship with YouCompleteMe and ycmd.
-
-Looking for Python 2 support? Check the [Wiki](https://github.com/ycm-core/YouCompleteMe/wiki/Python-2).
+Our policy is to suppor the Vim version that's in the latest LTS of Ubuntu.
+That's currently Ubuntu 20.04 which contains `vim-nox` at `v8.1.2269`.
 
 Help, Advice, Support
 ---------------------
@@ -23,7 +17,11 @@ Help, Advice, Support
 Looking for help, advice or support? Having problems getting YCM to work?
 
 First carefully read the [installation instructions](#installation) for your OS.
-We recommend you use the supplied `install.py`.
+We recommend you use the supplied `install.py` - the "full" installation guide
+is for rare, advanced use cases and most users should use `install.py`.
+
+If the server isn't starting and you're getting a "YouCompleteMe unavailable"
+error, check the [Troubleshooting][wiki-troubleshooting] guide.
 
 Next check the [User Guide](#user-guide) section on the semantic completer that
 you are using. For C/C++/Objective-C/Objective-C++/CUDA, you  _must_ read [this
@@ -43,6 +41,7 @@ Contents
 
 - [Intro](#intro)
 - [Installation](#installation)
+    - [Requirements](#requirements)
     - [macOS](#macos)
     - [Linux 64-bit](#linux-64-bit)
     - [Windows](#windows)
@@ -84,8 +83,12 @@ Contents
 Intro
 -----
 
-YouCompleteMe is a fast, as-you-type, fuzzy-search code completion engine for
-[Vim][]. It has several completion engines:
+YouCompleteMe is a fast, as-you-type, fuzzy-search code completion,
+comprehension and refactoring engine for [Vim][].
+
+It has several completion engines built in and supports any protocol-compliant
+Language Server, so can work with practically any language. YouCompleteMe
+contains:
 
 - an identifier-based engine that works with every programming language,
 - a powerful [clangd][]-based engine that provides native semantic code
@@ -144,14 +147,6 @@ and detects warnings or errors, they will be presented in various ways. You
 don't need to save your file or press any keyboard shortcut to trigger this, it
 "just happens" in the background.
 
-In essence, YCM obsoletes the following Vim plugins because it has all of their
-features plus extra:
-
-- clang_complete
-- AutoComplPop
-- Supertab
-- neocomplcache
-
 **And that's not all...**
 
 YCM might be the only vim completion engine with the correct Unicode support.
@@ -208,6 +203,16 @@ and a completer that integrates with [UltiSnips][].
 Installation
 ------------
 
+### Requirements
+
+Minimum supported versions:
+- Vim v8.1.2269 huge build, compiled with Python 3.6 support (aka `vim-nox` in
+  Ubuntu 20.04 LTS)
+- Python 3.6 runtime, compiled with `--enable-shared` (or `--enable-framework`)
+
+Please note that some features are not availble in Neovim, and Neovim is not
+officially supported.
+
 ### macOS
 
 #### Quick start, installing all completers
@@ -215,22 +220,16 @@ Installation
 - Install YCM plugin via [Vundle][]
 - Install cmake, macvim and python; Note that the *system* vim is not supported.
 
-&nbsp;
-
-    brew install cmake macvim python
-
-- Install mono, go, node and npm
-
-&nbsp;
-
-    brew install mono go nodejs
+```
+brew install cmake macvim python mono go nodejs
+```
 
 - Compile YCM
 
-&nbsp;
-
-    cd ~/.vim/bundle/YouCompleteMe
-    python3 install.py --all
+```
+cd ~/.vim/bundle/YouCompleteMe
+python3 install.py --all
+```
 
 - For plugging an arbitrary LSP server, check [the relevant section](#plugging-an-arbitrary-lsp-server)
 
@@ -262,13 +261,18 @@ automatically when you run `clang` for the first time, or manually by running
 Compiling YCM **with** semantic support for C-family languages through
 **clangd**:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clangd-completer
+```
+cd ~/.vim/bundle/YouCompleteMe
+./install.py --clangd-completer
+```
 
 Compiling YCM **without** semantic support for C-family languages:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py
+```
+cd ~/.vim/bundle/YouCompleteMe
+./install.py
+```
+
 
 The following additional language support options are available:
 
@@ -288,8 +292,10 @@ specify it manually by adding `--clangd-completer`. So, to install with all
 language features, ensure `xbuild`, `go`, `node` and `npm` tools
 are installed and in your `PATH`, then simply run:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --all
+```
+cd ~/.vim/bundle/YouCompleteMe
+./install.py --all
+```
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -307,17 +313,17 @@ that are conservatively turned off by default that you may want to turn on.
 - Install YCM plugin via [Vundle][]
 - Install cmake, vim and python
 
-&nbsp;
-
-    apt install build-essential cmake vim python3-dev
+```
+apt install build-essential cmake vim python3-dev
+```
 
 - Install mono-complete, go, node and npm
 - Compile YCM
 
-&nbsp;
-
-    cd ~/.vim/bundle/YouCompleteMe
-    python3 install.py --all
+```
+cd ~/.vim/bundle/YouCompleteMe
+python3 install.py --all
+```
 
 - For plugging an arbitrary LSP server, check [the relevant section](#plugging-an-arbitrary-lsp-server)
 
@@ -346,32 +352,36 @@ Install development tools, CMake, and Python headers:
 
 - Fedora 27 and later:
 
-&nbsp;
-
-      sudo dnf install cmake gcc-c++ make python3-devel
+```
+sudo dnf install cmake gcc-c++ make python3-devel
+```
 
 - Ubuntu 14.04:
 
-&nbsp;
-
-      sudo apt install build-essential cmake3 python3-dev
+```
+sudo apt install build-essential cmake3 python3-dev
+```
 
 - Ubuntu 16.04 and later:
 
-&nbsp;
-
-      sudo apt install build-essential cmake python3-dev
+```
+sudo apt install build-essential cmake python3-dev
+```
 
 Compiling YCM **with** semantic support for C-family languages through
 **clangd**:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    python3 install.py --clangd-completer
+```
+cd ~/.vim/bundle/YouCompleteMe
+python3 install.py --clangd-completer
+```
 
 Compiling YCM **without** semantic support for C-family languages:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    python3 install.py
+```
+cd ~/.vim/bundle/YouCompleteMe
+python3 install.py
+```
 
 The following additional language support options are available:
 
@@ -390,8 +400,10 @@ specify it manually by adding `--clangd-completer`. So, to install with all
 language features, ensure `xbuild`, `go`, `node`, `npm` and tools
 are installed and in your `PATH`, then simply run:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    python3 install.py --all
+```
+cd ~/.vim/bundle/YouCompleteMe
+python3 install.py --all
+```
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -412,10 +424,10 @@ that are conservatively turned off by default that you may want to turn on.
 - Install go, node and npm
 - Compile YCM
 
-&nbsp;
-
-    cd YouCompleteMe
-    python3 install.py --all
+```
+cd YouCompleteMe
+python3 install.py --all
+```
 
 - Add `set encoding=utf-8` to your [vimrc][]
 - For plugging an arbitrary LSP server, check [the relevant section](#plugging-an-arbitrary-lsp-server)
@@ -442,7 +454,9 @@ Python 3 support][vim-win-download] are available.
 
 Add the line:
 
-    set encoding=utf-8
+```viml
+set encoding=utf-8
+```
 
 to your [vimrc][] if not already present. This option is required by YCM. Note
 that it does not prevent you from editing a file in another encoding than UTF-8.
@@ -474,13 +488,17 @@ Download and install the following software:
 Compiling YCM **with** semantic support for C-family languages through
 **clangd**:
 
-    cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-    python install.py --clangd-completer
+```
+cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
+python install.py --clangd-completer
+```
 
 Compiling YCM **without** semantic support for C-family languages:
 
-    cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-    python install.py
+```
+cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
+python install.py
+```
 
 The following additional language support options are available:
 
@@ -499,8 +517,10 @@ specify it manually by adding `--clangd-completer`. So, to install with all
 language features, ensure `msbuild`, `go`, `node` and `npm` tools
 are installed and in your `PATH`, then simply run:
 
-    cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-    python install.py --all
+```
+cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
+python install.py --all
+```
 
 You can specify the Microsoft Visual C++ (MSVC) version using the `--msvc`
 option. YCM officially supports MSVC 14 (Visual Studio 2015), 15 (2017) and
@@ -522,17 +542,17 @@ that are conservatively turned off by default that you may want to turn on.
 - Install YCM plugin via [Vundle][]
 - Install cmake
 
-&nbsp;
-
-    pkg install cmake
+```
+pkg install cmake
+```
 
 - Install xbuild, go, node and npm
 - Compile YCM
 
-&nbsp;
-
-    cd ~/.vim/bundle/YouCompleteMe
-    python3 install.py --all
+```
+cd ~/.vim/bundle/YouCompleteMe
+python3 install.py --all
+```
 
 - For plugging an arbitrary LSP server, check [the relevant section](#plugging-an-arbitrary-lsp-server)
 
@@ -554,7 +574,9 @@ Vim installed by running `vim --version`.
 
 For FreeBSD 11.x, the requirement is cmake:
 
-    pkg install cmake
+```
+pkg install cmake
+```
 
 Install YouCompleteMe with [Vundle][].
 
@@ -566,18 +588,24 @@ process.
 Compiling YCM **with** semantic support for C-family languages through
 **clangd**:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clangd-completer
+```
+cd ~/.vim/bundle/YouCompleteMe
+./install.py --clangd-completer
+```
 
 Compiling YCM **without** semantic support for C-family languages:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py
+```
+cd ~/.vim/bundle/YouCompleteMe
+./install.py
+```
 
 If the `python` executable is not present, or the default `python` is not the
 one that should be compiled against, specify the python interpreter explicitly:
 
-    python3 install.py --clangd-completer
+```
+python3 install.py --clangd-completer
+```
 
 The following additional language support options are available:
 
@@ -596,8 +624,10 @@ specify it manually by adding `--clangd-completer`. So, to install with all
 language features, ensure `xbuild`, `go`, `node`, `npm` and tools
 are installed and in your `PATH`, then simply run:
 
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --all
+```
+cd ~/.vim/bundle/YouCompleteMe
+./install.py --all
+```
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -3324,6 +3354,6 @@ This software is licensed under the [GPL v3 license][gpl].
 [vimspector]: https://github.com/puremourning/vimspector
 [compiledb]: https://pypi.org/project/compiledb/
 [signature-help-pr]: https://github.com/ycm-core/ycmd/pull/1255
-[legacy-py2]: https://github.com/ycm-core/YouCompleteMe/tree/legacy-py2
 [wiki-faq]: https://github.com/ycm-core/YouCompleteMe/wiki/FAQ
 [wiki-full-install]: https://github.com/ycm-core/YouCompleteMe/wiki/Full-Installation-Guide
+[wiki-troubleshooting]: https://github.com/ycm-core/YouCompleteMe/wiki/Troubleshooting-steps-for-ycmd-server-SHUT-DOWN

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,39 @@ jobs:
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
       CODECOV_JOB_NAME: '$(Agent.JobName)'
+- job: linuxvim_min
+  displayName: 'Linux Earliest Vim tests'
+  pool:
+    # List of available software on this image:
+    # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/linux/Ubuntu1604-README.md
+    vmImage: 'ubuntu-18.04'
+  strategy:
+    matrix:
+      'Python 3.6':
+        IMAGE: ycm-vim-py3
+        PIP: pip3
+    maxParallel: 2
+  variables:
+    COVERAGE: true
+    YCM_TEST_STDOUT: true
+  container: 'youcompleteme/$(IMAGE):test'
+  steps:
+  - checkout: self
+    submodules: recursive
+  - bash: sudo -H $(PIP) install -r python/test_requirements.txt
+    displayName: Install dependencies
+  - bash: python3 ./install.py --ts-completer --clangd-completer --java-completer
+    displayName: Build ycmd
+  # use the system vim - should be the minimal supported version
+  - script: ./test/run_vim_tests --vim /usr/bin/vim
+    displayName: Run vim tests
+  - bash: codecov --disable gcov --name '$(Agent.JobName)'
+    displayName: Send coverage
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
+      CODECOV_JOB_NAME: '$(Agent.JobName)'
 - job: linuxvim
-  displayName: 'Linux Vim tests'
+  displayName: 'Linux Recent Vim tests'
   pool:
     # List of available software on this image:
     # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/linux/Ubuntu1604-README.md

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -24,27 +24,18 @@ function! s:restore_cpo()
   unlet s:save_cpo
 endfunction
 
+" NOTE: The minimum supported version is 8.1.2269, but neovim always reports as
+" v:version 800, but will largely work.
+let s:is_neovim = has( 'nvim' )
+
 if exists( "g:loaded_youcompleteme" )
   call s:restore_cpo()
   finish
-elseif v:version < 704 || (v:version == 704 && !has( 'patch1578' ))
+elseif ( v:version < 801 || (v:version == 801 && !has( 'patch2269' )) ) &&
+      \ !s:is_neovim
   echohl WarningMsg |
-        \ echomsg "YouCompleteMe unavailable: requires Vim 7.4.1578+." |
+        \ echomsg "YouCompleteMe unavailable: requires Vim 8.1.2269+." |
         \ echohl None
-  if v:version == 704 && has( 'patch8056' )
-    " Very very special case for users of the default Vim on macOS. For some
-    " reason, that version of Vim contains a completely arbitrary (presumably
-    " custom) patch '8056', which fools users (but not our has( 'patch1578' )
-    " check) into thinking they have a sufficiently new Vim. In fact they do
-    " not and YCM fails to initialise. So we give them a more specific warning.
-    echohl WarningMsg
-          \ | echomsg
-          \ "Info: You appear to be running the default system Vim on macOS. "
-          \ . "It reports as patch 8056, but it is really older than 1578. "
-          \ . "Please consider MacVim, homebrew Vim or a self-built Vim that "
-          \ . "satisfies the minimum requirement."
-          \ | echohl None
-  endif
   call s:restore_cpo()
   finish
 elseif !has( 'timers' )
@@ -54,8 +45,7 @@ elseif !has( 'timers' )
         \ echohl None
   call s:restore_cpo()
   finish
-elseif ( v:version > 800 || ( v:version == 800 && has( 'patch1436' ) ) ) &&
-     \ !has( 'python3_compiled' )
+elseif !has( 'python3_compiled' )
   echohl WarningMsg |
         \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .
         \ "Python (3.6.0+) support." |
@@ -81,16 +71,6 @@ elseif &encoding !~? 'utf-\?8'
 endif
 
 let g:loaded_youcompleteme = 1
-
-let s:default_options = {}
-if exists( '*json_decode' )
-  let s:script_folder_path = expand( '<sfile>:p:h' )
-  let s:option_file = s:script_folder_path .
-        \ '/../third_party/ycmd/ycmd/default_settings.json'
-  if filereadable( s:option_file )
-    let s:default_options = json_decode( join( readfile( s:option_file ) ) )
-  endif
-endif
 
 "
 " List of YCM options.
@@ -296,16 +276,6 @@ let g:ycm_java_jdtls_workspace_root_path =
 " This option is deprecated.
 let g:ycm_python_binary_path =
       \ get( g:, 'ycm_python_binary_path', '' )
-
-" Populate any other (undocumented) options set in the ycmd
-" default_settings.json. This ensures that any part of ycm that uses ycmd code
-" will have the default set. I'm looking at you, Omni-completer.
-for key in keys( s:default_options )
-  if ! has_key( g:, 'ycm_' . key )
-    let g:[ 'ycm_' . key ] = s:default_options[ key ]
-  endif
-endfor
-unlet key
 
 if has( 'vim_starting' ) " Loading at startup.
   " We defer loading until after VimEnter to allow the gui to fork (see

--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -15,20 +15,42 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-from ycm import vimsupport
+import os
+import json
+
+from ycm import vimsupport, paths
 from ycmd import identifier_utils
 
 YCM_VAR_PREFIX = 'ycm_'
 
 
-def GetUserOptions():
+def GetUserOptions( default_options = {} ):
   """Builds a dictionary mapping YCM Vim user options to values. Option names
   don't have the 'ycm_' prefix."""
+
+  user_options = {}
+
+  # First load the default settings from ycmd. We do this to ensure that any
+  # client-side code that assumes all options are loaded (such as the
+  # omnicompleter) don't have to constantly check for values being present, and
+  # so that we don't jave to dulicate the list of server settings in
+  # youcomplete.vim
+  defaults_file =  os.path.join( paths.DIR_OF_YCMD,
+                                 'ycmd',
+                                 'default_settings.json' )
+  if os.path.exists( defaults_file ):
+    with open( defaults_file ) as defaults_file_handle:
+      user_options = json.load( defaults_file_handle )
+
+  # Override the server defaults with any client-generated defaults
+  user_options.update( default_options )
+
+  # Finally, override with any user-specified values in the g: dict
+
   # We only evaluate the keys of the vim globals and not the whole dictionary
   # to avoid unicode issues.
   # See https://github.com/Valloric/YouCompleteMe/pull/2151 for details.
   keys = vimsupport.GetVimGlobalsKeys()
-  user_options = {}
   for key in keys:
     if not key.startswith( YCM_VAR_PREFIX ):
       continue

--- a/python/ycm/client/resolve_completion_request.py
+++ b/python/ycm/client/resolve_completion_request.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2020 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from ycm.client.base_request import ( BaseRequest,
+                                      DisplayServerException,
+                                      MakeServerException )
+from ycm.client.completion_request import ConvertCompletionDataToVimData
+
+import logging
+import json
+_logger = logging.getLogger( __name__ )
+
+
+class ResolveCompletionRequest( BaseRequest ):
+  def __init__( self, request_data ):
+    super().__init__()
+    self.request_data = request_data
+
+  def Start( self ):
+    self._response_future = self.PostDataToHandlerAsync( self.request_data,
+                                                         'resolve_completion' )
+
+  def Done( self ):
+    return bool( self._response_future ) and self._response_future.done()
+
+
+  def OnCompleteDone( self ):
+    # This is required to be compatible with the "CompletionRequest" API. We're
+    # not really a CompletionRequest, but we are mutually exclusive with
+    # completion requests, so we impleent this API.
+    pass
+
+
+  def Response( self ):
+    response = self.HandleFuture( self._response_future,
+                                  truncate_message = True,
+                                  display_message = True )
+
+    if not response or not response[ 'completion' ]:
+      return { 'completion': [] }
+
+    # Vim may not be able to convert the 'errors' entry to its internal format
+    # so we remove it from the response.
+    errors = response.pop( 'errors', [] )
+    for e in errors:
+      exception = MakeServerException( e )
+      _logger.error( exception )
+      DisplayServerException( exception, truncate_message = True )
+
+    response[ 'completion' ] = ConvertCompletionDataToVimData(
+        response[ 'completion' ] )
+    return response
+
+
+def ResolveCompletionItem( completion_request, item ):
+  if not completion_request.Done():
+    return None
+  try:
+    completion_extra_data = json.loads( item[ 'user_data' ] )
+  except KeyError:
+    return None
+  except json.JSONDecodeError:
+    # Can happen with the omni completer
+    return None
+
+  request_data = completion_request.request_data
+  try:
+    # Note: We mutate the request_data inside the original completion request
+    # and pass it into the new request object. this is just a big efficiency
+    # saving. The request_data for a Done() request is almost certainly no
+    # longer needed.
+    request_data[ 'resolve' ] = completion_extra_data[ 'resolve' ]
+  except KeyError:
+    return None
+
+  resolve_request = ResolveCompletionRequest( request_data )
+  resolve_request.Start()
+  return resolve_request

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -26,10 +26,10 @@ from ycm.client import completion_request
 
 class ConvertCompletionResponseToVimDatas_test:
   """ This class tests the
-      completion_request._ConvertCompletionResponseToVimDatas method """
+      completion_request.ConvertCompletionResponseToVimDatas method """
 
   def _Check( self, completion_data, expected_vim_data ):
-    vim_data = completion_request._ConvertCompletionDataToVimData(
+    vim_data = completion_request.ConvertCompletionDataToVimData(
         completion_data )
 
     try:

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -1,4 +1,6 @@
-function! s:CheckCompletionItems( expected_props, ... )
+scriptencoding utf-8
+
+function! CheckCompletionItems( expected_props, ... )
   let prop = 'abbr'
   if a:0 > 0
     let prop = a:1
@@ -22,17 +24,17 @@ function! s:CheckCompletionItems( expected_props, ... )
         \ .. string( abbrs ) )
 endfunction
 
-function! s:FeedAndCheckMain( keys, func )
+function! FeedAndCheckMain( keys, func )
   call timer_start( 500, a:func )
   call feedkeys( a:keys, 'tx!' )
 endfunction
 
-function! s:FeedAndCheckAgain( keys, func )
+function! FeedAndCheckAgain( keys, func )
   call timer_start( 500, a:func )
   call feedkeys( a:keys )
 endfunction
 
-function! s:WaitForCompletion()
+function! WaitForCompletion()
   call WaitForAssert( {->
         \ assert_true( pyxeval( 'ycm_state.GetCurrentCompletionRequest() is not None' ) )
         \ } )
@@ -45,7 +47,7 @@ function! s:WaitForCompletion()
         \ }, 10000 )
 endfunction
 
-function! s:CheckCurrentLine( expected_value )
+function! CheckCurrentLine( expected_value )
   return assert_equal( a:expected_value, getline( '.' ) )
 endfunction
 
@@ -62,11 +64,11 @@ function! Test_Compl_After_Trigger()
   " Must do the checks in a timer callback because we need to stay in insert
   " mode until done.
   function! Check( id ) closure
-    call s:WaitForCompletion()
+    call WaitForCompletion()
     call feedkeys( "\<ESC>" )
   endfunction
 
-  call s:FeedAndCheckMain( 'cl.', funcref( 'Check' ) )
+  call FeedAndCheckMain( 'cl.', funcref( 'Check' ) )
   " Checks run in insert mode, then exit insert mode.
   call assert_false( pumvisible(), 'pumvisible()' )
 
@@ -81,7 +83,7 @@ function! Test_Force_Semantic_TopLevel()
   call setpos( '.', [ 0, 17, 5 ] )
 
   function! Check( id )
-    cal s:WaitForCompletion()
+    cal WaitForCompletion()
     let items = complete_info( [ 'items' ] )[ 'items' ]
     call assert_equal( 1, len( filter( items, 'v:val.abbr ==# "Foo"' ) ),
           \ 'Foo should be in the suggestions' )
@@ -94,7 +96,7 @@ function! Test_Force_Semantic_TopLevel()
     call feedkeys( "\<ESC>" )
   endfunction
 
-  call s:FeedAndCheckMain( "i\<C-Space>", funcref( 'Check' ) )
+  call FeedAndCheckMain( "i\<C-Space>", funcref( 'Check' ) )
   " Checks run in insert mode, then exit insert mode.
   call assert_false( pumvisible(), 'pumvisible()' )
 
@@ -113,38 +115,38 @@ function! Test_Select_Next_Previous()
   call test_override( 'char_avail', 1 )
 
   function! Check( id )
-    call s:WaitForCompletion()
+    call WaitForCompletion()
 
-    call s:CheckCurrentLine( '  foo.' )
-    call s:CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCurrentLine( '  foo.' )
+    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
 
-    call s:FeedAndCheckAgain( "\<Tab>", funcref( 'Check2' ) )
+    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( '  foo.c' )
-    call s:CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call WaitForCompletion()
+    call CheckCurrentLine( '  foo.c' )
+    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
 
-    call s:FeedAndCheckAgain( "\<Tab>", funcref( 'Check3' ) )
+    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check3' ) )
   endfunction
 
   function! Check3( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( '  foo.x' )
-    call s:CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call WaitForCompletion()
+    call CheckCurrentLine( '  foo.x' )
+    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
 
-    call s:FeedAndCheckAgain( "\<BS>y", funcref( 'Check4' ) )
+    call FeedAndCheckAgain( "\<BS>y", funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( '  foo.y' )
-    call s:CheckCompletionItems( [ 'y' ] )
+    call WaitForCompletion()
+    call CheckCurrentLine( '  foo.y' )
+    call CheckCompletionItems( [ 'y' ] )
     call feedkeys( "\<ESC>" )
   endfunction
 
-  call s:FeedAndCheckMain( 'cl.', funcref( 'Check' ) )
+  call FeedAndCheckMain( 'cl.', funcref( 'Check' ) )
   " Checks run in insert mode, then exit insert mode.
   call assert_false( pumvisible(), 'pumvisible()' )
 
@@ -163,37 +165,37 @@ function! Test_Enter_Delete_Chars_Updates_Filter()
   call test_override( 'char_avail', 1 )
 
   function! Check1( id )
-    call s:WaitForCompletion()
-    call s:CheckCompletionItems( [ 'colourOfLine', 'lengthOfLine' ] )
-    call s:FeedAndCheckAgain( "\<BS>", funcref( "Check2" ) )
+    call WaitForCompletion()
+    call CheckCompletionItems( [ 'colourOfLine', 'lengthOfLine' ] )
+    call FeedAndCheckAgain( "\<BS>", funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
-    call s:WaitForCompletion()
-    call s:CheckCompletionItems( [
+    call WaitForCompletion()
+    call CheckCompletionItems( [
           \ 'operator=(…)',
           \ 'colourOfLine',
           \ 'lengthOfLine',
           \ 'RED_AND_YELLOW' ] )
-    call s:FeedAndCheckAgain( 'w', funcref( 'Check3' ) )
+    call FeedAndCheckAgain( 'w', funcref( 'Check3' ) )
   endfunction
 
   function! Check3( id )
-    call s:WaitForCompletion()
-    call s:CheckCompletionItems( [ 'RED_AND_YELLOW' ] )
+    call WaitForCompletion()
+    call CheckCompletionItems( [ 'RED_AND_YELLOW' ] )
     " now type something that doesnt match
-    call s:FeedAndCheckAgain( 'this_does_not_match', funcref( 'Check4' ) )
+    call FeedAndCheckAgain( 'this_does_not_match', funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
     call WaitForAssert( { -> assert_false( pumvisible() ) } )
-    call s:CheckCurrentLine(
+    call CheckCurrentLine(
           \ '  p->line.colourOfLine = Line::owthis_does_not_match' )
-    call s:CheckCompletionItems( [] )
+    call CheckCompletionItems( [] )
     call feedkeys( "\<Esc>" )
   endfunction
 
-  call s:FeedAndCheckMain( 'cl:ol', funcref( 'Check1' ) )
+  call FeedAndCheckMain( 'cl:ol', funcref( 'Check1' ) )
   " Checks run in insert mode, then exit insert mode.
   call assert_false( pumvisible(), 'pumvisible()' )
 
@@ -223,36 +225,36 @@ function! Test_OmniComplete_Filter()
   let s:omnifunc_items = [ 'test', 'testing', 'testy' ]
 
   function! Check1( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'te:te' )
-    call s:CheckCompletionItems( [ 'test', 'testy', 'testing' ], 'word' )
-    call s:FeedAndCheckAgain( 'y', funcref( 'Check2' ) )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'te:te' )
+    call CheckCompletionItems( [ 'test', 'testy', 'testing' ], 'word' )
+    call FeedAndCheckAgain( 'y', funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'te:tey' )
-    call s:CheckCompletionItems( [ 'testy' ], 'word' )
-    call s:FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'te:tey' )
+    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
   endfunction
 
   function! Check3( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'te:testy' )
-    call s:CheckCompletionItems( [ 'testy' ], 'word' )
-    call s:FeedAndCheckAgain( "\<C-p>", funcref( 'Check4' ) )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'te:testy' )
+    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call FeedAndCheckAgain( "\<C-p>", funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'te:tey' )
-    call s:CheckCompletionItems( [ 'testy' ], 'word' )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'te:tey' )
+    call CheckCompletionItems( [ 'testy' ], 'word' )
     call feedkeys( "\<Esc>" )
   endfunction
 
   call setline(1, 'te:' )
   call setpos( '.', [ 0, 1, 3 ] )
-  call s:FeedAndCheckMain( 'ate', 'Check1' )
+  call FeedAndCheckMain( 'ate', 'Check1' )
 
   %bwipeout!
 endfunction
@@ -270,36 +272,36 @@ function! Test_OmniComplete_Force()
   let s:omnifunc_items = [ 'test', 'testing', 'testy' ]
 
   function! Check1( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'te' )
-    call s:CheckCompletionItems( [ 'test', 'testy', 'testing' ], 'word' )
-    call s:FeedAndCheckAgain( 'y', funcref( 'Check2' ) )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'te' )
+    call CheckCompletionItems( [ 'test', 'testy', 'testing' ], 'word' )
+    call FeedAndCheckAgain( 'y', funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'tey' )
-    call s:CheckCompletionItems( [ 'testy' ], 'word' )
-    call s:FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'tey' )
+    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
   endfunction
 
   function! Check3( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'testy' )
-    call s:CheckCompletionItems( [ 'testy' ], 'word' )
-    call s:FeedAndCheckAgain( "\<C-p>", funcref( 'Check4' ) )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'testy' )
+    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call FeedAndCheckAgain( "\<C-p>", funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'tey' )
-    call s:CheckCompletionItems( [ 'testy' ], 'word' )
+    call WaitForCompletion()
+    call CheckCurrentLine( 'tey' )
+    call CheckCompletionItems( [ 'testy' ], 'word' )
     call feedkeys( "\<Esc>" )
   endfunction
 
   call setline(1, 'te' )
   call setpos( '.', [ 0, 1, 3 ] )
-  call s:FeedAndCheckMain( "a\<C-Space>", 'Check1' )
+  call FeedAndCheckMain( "a\<C-Space>", 'Check1' )
   %bwipeout!
 endfunction
 
@@ -315,32 +317,32 @@ function! Test_Completion_FixIt()
         \ 'test/testdata/cpp/auto_include.cc', {} )
 
   function Check1( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'do_a' )
-    call s:CheckCompletionItems( [ 'do_a_thing(Thing thing)',
+    call WaitForCompletion()
+    call CheckCurrentLine( 'do_a' )
+    call CheckCompletionItems( [ 'do_a_thing(Thing thing)',
                                  \ 'do_another_thing()' ] )
-    call s:FeedAndCheckAgain( "\<Tab>" , funcref( 'Check2' ) )
+    call FeedAndCheckAgain( "\<Tab>" , funcref( 'Check2' ) )
   endfunction
 
   function Check2( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( 'do_a_thing' )
-    call s:CheckCompletionItems( [ 'do_a_thing(Thing thing)',
+    call WaitForCompletion()
+    call CheckCurrentLine( 'do_a_thing' )
+    call CheckCompletionItems( [ 'do_a_thing(Thing thing)',
                                  \ 'do_another_thing()' ] )
-    call s:FeedAndCheckAgain( '(' , funcref( 'Check3' ) )
+    call FeedAndCheckAgain( '(' , funcref( 'Check3' ) )
   endfunction
 
 
   function Check3( id )
     call WaitForAssert( {-> assert_false( pumvisible(), 'pumvisible()' ) } )
-    call s:CheckCurrentLine( 'do_a_thing(' )
+    call CheckCurrentLine( 'do_a_thing(' )
     call assert_equal( '#include "auto_include.h"', getline( 1 ) )
     call feedkeys( "\<Esc>" )
   endfunction
 
 
   call setpos( '.', [ 0, 3, 1 ] )
-  call s:FeedAndCheckMain( "Ado_a\<C-Space>", funcref( 'Check1' ) )
+  call FeedAndCheckMain( "Ado_a\<C-Space>", funcref( 'Check1' ) )
 
   %bwipeout!
 endfunction
@@ -358,46 +360,46 @@ function! Test_Select_Next_Previous_InsertModeMapping()
   call test_override( 'char_avail', 1 )
 
   function! Check( id )
-    call s:WaitForCompletion()
+    call WaitForCompletion()
 
-    call s:CheckCurrentLine( '  foo.' )
-    call s:CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCurrentLine( '  foo.' )
+    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
 
-    call s:FeedAndCheckAgain( "\<C-n>", funcref( 'Check2' ) )
+    call FeedAndCheckAgain( "\<C-n>", funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( '  foo.c' )
-    call s:CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call WaitForCompletion()
+    call CheckCurrentLine( '  foo.c' )
+    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
 
-    call s:FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
+    call FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
   endfunction
 
   function! Check3( id )
-    call s:WaitForCompletion()
-    call s:CheckCurrentLine( '  foo.x' )
-    call s:CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call WaitForCompletion()
+    call CheckCurrentLine( '  foo.x' )
+    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
 
-    call s:FeedAndCheckAgain( "\<BS>a", funcref( 'Check4' ) )
+    call FeedAndCheckAgain( "\<BS>a", funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
-    call s:CheckCurrentLine( '  foo.a' )
-    call s:CheckCompletionItems( [] )
-    call s:FeedAndCheckAgain( "\<C-n>", funcref( 'Check5' ) )
+    call CheckCurrentLine( '  foo.a' )
+    call CheckCompletionItems( [] )
+    call FeedAndCheckAgain( "\<C-n>", funcref( 'Check5' ) )
   endfunction
 
   function! Check5( id )
     " The last ctrl-n moved to the next line
-    call s:CheckCurrentLine( '}' )
+    call CheckCurrentLine( '}' )
     call assert_equal( [ 0, 12, 2, 0 ], getpos( '.' ) )
-    call s:CheckCompletionItems( [] )
+    call CheckCompletionItems( [] )
     call feedkeys( "\<Esc>" )
   endfunction
 
 
-  call s:FeedAndCheckMain( 'cl.', funcref( 'Check' ) )
+  call FeedAndCheckMain( 'cl.', funcref( 'Check' ) )
   " Checks run in insert mode, then exit insert mode.
   call assert_false( pumvisible(), 'pumvisible()' )
 

--- a/test/completion.test.vim
+++ b/test/completion.test.vim
@@ -5,8 +5,7 @@ function! SetUp()
   let g:ycm_keep_logfiles = 1
   let g:ycm_log_level = 'DEBUG'
 
-  " Use the default, which _should_ be the new API
-  unlet! g:ycm_use_completion_api
+  let g:ycm_add_preview_to_completeopt = 1
 
   call youcompleteme#test#setup#SetUp()
 endfunction
@@ -17,7 +16,7 @@ endfunction
 
 exe 'source' expand( "<sfile>:p:h" ) .. '/completion.common.vim'
 
-function! Test_Using_New_API()
+function! Test_Using_Upfront_Resolve()
   let debug_info = split( execute( 'YcmDebugInfo' ), "\n" )
   enew
   setf cpp
@@ -25,14 +24,14 @@ function! Test_Using_New_API()
   call assert_equal( '', &completefunc )
 
   for line in debug_info
-    if line =~# "^-- Completion API: "
-      let ver = substitute( line, "^-- Completion API: ", "", "" )
-      call assert_equal( '1', ver, 'API version' )
+    if line =~# "^-- Resolve completions: "
+      let ver = substitute( line, "^-- Resolve completions: ", "", "" )
+      call assert_equal( 'Up front', ver, 'API version' )
       return
     endif
   endfor
 
-  call assert_report( "Didn't find the API version in the YcmDebugInfo" )
+  call assert_report( "Didn't find the resolve type in the YcmDebugInfo" )
 
   %bwipeout!
 endfunction

--- a/test/completion_info.test.vim
+++ b/test/completion_info.test.vim
@@ -1,0 +1,166 @@
+function! s:AssertInfoPopupNotVisible()
+  call WaitForAssert( {-> assert_true(
+        \ popup_findinfo() == 0 ||
+        \ !popup_getpos( popup_findinfo() ).visible ) } )
+endfunction
+
+function! s:AssertInfoPopupVisible()
+  call WaitForAssert( {-> assert_true(
+        \ popup_findinfo() != 0 &&
+        \ !empty( popup_getpos( popup_findinfo() ) ) &&
+        \ popup_getpos( popup_findinfo() ).visible ) } )
+endfunction
+
+function! SetUp()
+  let g:ycm_use_clangd = 1
+  let g:ycm_confirm_extra_conf = 0
+  let g:ycm_auto_trigger = 1
+  let g:ycm_keep_logfiles = 1
+  let g:ycm_log_level = 'DEBUG'
+
+  let g:ycm_add_preview_to_completeopt = 'popup'
+
+  call youcompleteme#test#setup#SetUp()
+endfunction
+
+function! TearDown()
+  call youcompleteme#test#setup#CleanUp()
+endfunction
+
+exe 'source' expand( "<sfile>:p:h" ) .. '/completion.common.vim'
+
+function! Test_Using_Ondemand_Resolve()
+  let debug_info = split( execute( 'YcmDebugInfo' ), "\n" )
+  enew
+  setf cpp
+
+  call assert_equal( '', &completefunc )
+
+  for line in debug_info
+    if line =~# "^-- Resolve completions: "
+      let ver = substitute( line, "^-- Resolve completions: ", "", "" )
+      call assert_equal( 'On demand', ver, 'API version' )
+      return
+    endif
+  endfor
+
+  call assert_report( "Didn't find the resolve type in the YcmDebugInfo" )
+
+  %bwipeout!
+endfunction
+
+function! Test_ResolveCompletion_OnChange()
+  call SkipIf( !exists( '*popup_findinfo' ), 'no popup_findinfo' )
+
+  " Only the java completer actually uses the completion resolve
+  call youcompleteme#test#setup#OpenFile(
+        \ '/third_party/ycmd/ycmd/tests/java/testdata/simple_eclipse_project' .
+        \ '/src/com/test/MethodsWithDocumentation.java', { 'delay': 15 } )
+
+  call setpos( '.', [ 0, 33, 20 ] )
+  " Required to trigger TextChangedI
+  " https://github.com/vim/vim/issues/4665#event-2480928194
+  call test_override( 'char_avail', 1 )
+
+  function! Check1( id )
+    call WaitForCompletion()
+    call s:AssertInfoPopupNotVisible()
+    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check2', [ 0 ] ) )
+  endfunction
+
+  let found_getAString = 0
+
+  function! Check2( counter, id ) closure
+    call WaitForCompletion()
+    call s:AssertInfoPopupVisible()
+    let info_popup_id = popup_findinfo()
+
+    let compl = complete_info()
+    let selected = compl.items[ compl.selected ]
+
+    " All items should be resolved
+    " NOTE: Even after resolving the item still has this as there's no way to
+    " update the user data of the item at this point (need a vim change to do
+    " that)
+    call assert_true( has_key( json_decode( selected.user_data ),
+          \ 'resolve' ) )
+
+    if selected.word ==# 'getAString'
+      " It's line 5 because we truncated the signature to fit it in
+      call WaitForAssert( { ->
+            \ assert_equal( [ 'MethodsWithDocumentation.getAString() : String',
+                            \ '',
+                            \ 'getAString() : String',
+                            \ '',
+                            \ 'Single line description.',
+                            \ ],
+            \               getbufline( winbufnr( info_popup_id ), '1', '5' ) )
+            \ } )
+      let found_getAString += 1
+    endif
+
+    if a:counter < 10
+      call FeedAndCheckAgain( "\<Tab>", funcref( 'Check2', [ a:counter + 1 ] ) )
+    else
+      call feedkeys( "\<Esc>" )
+    endif
+  endfunction
+
+  call FeedAndCheckMain( 'C.', funcref( 'Check1' ) )
+
+  call assert_false( pumvisible(), 'pumvisible()' )
+  call assert_equal( 1, found_getAString )
+
+  call test_override( 'ALL', 0 )
+  %bwipeout!
+endfunction
+
+function! Test_DontResolveCompletion_AlreadyResolved()
+  call SkipIf( !exists( '*popup_findinfo' ), 'no popup_findinfo' )
+
+  " Only the java completer actually uses the completion resolve
+  call youcompleteme#test#setup#OpenFile(
+        \ '/third_party/ycmd/ycmd/tests/java/testdata/simple_eclipse_project' .
+        \ '/src/com/test/MethodsWithDocumentation.java', { 'delay': 15 } )
+
+  call setpos( '.', [ 0, 34, 12 ] )
+  " Required to trigger TextChangedI
+  " https://github.com/vim/vim/issues/4665#event-2480928194
+  call test_override( 'char_avail', 1 )
+
+  function! Check1( id )
+    call WaitForCompletion()
+    call CheckCompletionItems( [ 'hashCode' ], 'word' )
+    call s:AssertInfoPopupNotVisible()
+    call assert_equal( -1, complete_info().selected )
+
+    let compl = complete_info()
+    let hashCode = compl.items[ 0 ]
+    call assert_equal( 1, len( compl.items ) )
+    call assert_equal( 'hashCode', hashCode.word )
+    call assert_false( has_key( json_decode( hashCode.user_data ),
+          \ 'resolve' ) )
+
+    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check2' ) )
+  endfunction
+
+  function! Check2( id )
+    call WaitForCompletion()
+    call s:AssertInfoPopupVisible()
+
+    let compl = complete_info()
+    let selected = compl.items[ 0 ]
+    call assert_equal( 1, len( compl.items ) )
+    call assert_equal( 'hashCode', selected.word )
+    call assert_false( has_key( json_decode( selected.user_data ),
+          \ 'resolve' ) )
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+  call FeedAndCheckMain( 'C', funcref( 'Check1' ) )
+
+  call assert_false( pumvisible(), 'pumvisible()' )
+
+  call test_override( 'ALL', 0 )
+  %bwipeout!
+endfunction

--- a/test/completion_noresolve.test.vim
+++ b/test/completion_noresolve.test.vim
@@ -5,7 +5,7 @@ function! SetUp()
   let g:ycm_keep_logfiles = 1
   let g:ycm_log_level = 'DEBUG'
 
-  let g:ycm_use_completion_api = 0
+  set completeopt-=preview
 
   call youcompleteme#test#setup#SetUp()
 endfunction
@@ -16,23 +16,22 @@ endfunction
 
 exe 'source' expand( "<sfile>:p:h" ) .. '/completion.common.vim'
 
-function! Test_Using_Old_API()
+function! Test_No_Resolve()
   let debug_info = split( execute( 'YcmDebugInfo' ), "\n" )
-
   enew
   setf cpp
 
-  call assert_equal( 'youcompleteme#CompleteFunc', &completefunc )
+  call assert_equal( '', &completefunc )
 
   for line in debug_info
-    if line =~# "^-- Completion API: "
-      let ver = substitute( line, "^-- Completion API: ", "", "" )
-      call assert_equal( '0', ver, 'API version' )
+    if line =~# "^-- Resolve completions: "
+      let ver = substitute( line, "^-- Resolve completions: ", "", "" )
+      call assert_equal( 'Never', ver, 'API version' )
       return
     endif
   endfor
 
-  call assert_report( "Didn't find the API version in the YcmDebugInfo" )
+  call assert_report( "Didn't find the resolve type in the YcmDebugInfo" )
 
   %bwipeout!
 endfunction

--- a/test/docker/ci/image/Dockerfile
+++ b/test/docker/ci/image/Dockerfile
@@ -1,11 +1,10 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL C.UTF-8
 
-ARG VIM_VERSION=v8.1.1875
+ARG VIM_VERSION=v8.2.1456
 ARG YCM_VIM_PYTHON=python3
-ARG YCM_PYTHON_VERSION=3.5.2
 
 RUN apt-get update && \
   apt-get -y dist-upgrade && \
@@ -19,14 +18,12 @@ RUN apt-get update && \
                      cmake \
                      curl \
                      sudo \
-                     python-dev \
-                     python-pip \
-                     python-setuptools \
                      python3-dev \
                      python3-pip \
                      python3-setuptools \
                      openjdk-11-jdk-headless \
                      npm \
+                     vim-nox \
                      zlib1g-dev && \
   apt-get -y autoremove
 

--- a/test/fixit.test.vim
+++ b/test/fixit.test.vim
@@ -40,7 +40,7 @@ endfunction
 
 function! Test_Unresolved_Fixit_Works()
   call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/fixit.c', {} )
-  call setpos( '.', [ 0, 3, 2 ] )
+  call setpos( '.', [ 0, 3, 15 ] )
   call assert_equal( '  printf("%s",1);', getline( '.' ) )
   function! SelectEntry( id ) closure
     redraw
@@ -49,7 +49,7 @@ function! Test_Unresolved_Fixit_Works()
   call timer_start( 2000, funcref( 'SelectEntry' ) )
   YcmCompleter FixIt
   redraw
-  call assert_equal( '  auto dummy = 1;', getline( '.' ) )
+  call assert_equal( '  auto dummy = 1;', getline( 3 ) )
   call assert_equal( '  printf("%s", dummy);', getline( 4 ) )
   %bwipeout!
   delfunction SelectEntry

--- a/test/lib/plugin/shared.vim
+++ b/test/lib/plugin/shared.vim
@@ -6,6 +6,19 @@ if exists('*WaitFor')
   finish
 endif
 
+" Run skip the current test if some expression returns true
+func SkipIf( expr, msg )
+  if type(a:expr) == v:t_func
+    let skip = a:expr()
+  else
+    let skip = eval(a:expr)
+  endif
+
+  if skip
+    throw 'SKIPPED: ' . a:msg
+  endif
+endfunction
+
 " Wait for up to five seconds for "expr" to become true.  "expr" can be a
 " stringified expression to evaluate, or a funcref without arguments.
 " Using a lambda works best.  Example:

--- a/test/lib/run_test.vim
+++ b/test/lib/run_test.vim
@@ -353,7 +353,7 @@ def _InitCoverage():
   except ImportError:
     return None
 
-  cov = coverage.Coverage( data_file='.coverage.python' )
+  cov = coverage.Coverage( data_file='.coverage.python', data_suffix = True )
   cov.start()
   return cov
 

--- a/test/run_vim_tests
+++ b/test/run_vim_tests
@@ -12,7 +12,14 @@ elif [ "$1" == "--stdout" ]; then
   shift
 fi
 
-RUN_VIM="vim --clean --not-a-term"
+VIM=vim
+if [ "$1" == "--vim" ]; then
+  VIM=$2
+  shift
+  shift
+fi
+
+RUN_VIM="${VIM} --clean --not-a-term"
 RUN_TEST="${RUN_VIM} -S lib/run_test.vim"
 
 pushd $(dirname $0) > /dev/null


### PR DESCRIPTION
This goes with https://github.com/ycm-core/ycmd/pull/1473

In the client, the implementation is a bit fiddly, but boils down to this section of the vim help:

```
						*complete-popuphidden*
If the information for the popup is obtained asynchronously, use "popuphidden"
in 'completeopt'.  The info popup will then be initially hidden and
|popup_show()| must be called once it has been filled with the info.  This can
be done with a |CompleteChanged| autocommand, something like this: >
	set completeopt+=popuphidden
	au CompleteChanged * call UpdateCompleteInfo()
	func UpdateCompleteInfo()
	  " Cancel any pending info fetch
	  let item = v:event.completed_item
	  " Start fetching info for the item then call ShowCompleteInfo(info)
	endfunc
	func ShowCompleteInfo(info)
	  let id = popup_findinfo()
	  if id
	    call popup_settext(id, 'async info: ' .. a:info)
	    call popup_show(id)
	  endif
	endfunc
```

So:

* we can request the resolve on `CompleteChanged`
* we already store the extra_data in the completion user data, so we just pull out the `resolve` key from there
* when we have the resolved data, we call `popup_findinfo()` and then `popup_settext()` and `popup_show()` on that ID
* we re-use the `_latest_completion_request` so that we don't have outstanding resolve and completion requests
* we re-use the `request_data` from the completion request for efficiency and correctness (server will reject if the request data changes _at all_)
* we re-use the 'completion' poller, for the same reasons.

Simple, right ?

Well, there are some caveats:

* We only want to do this if Vim supports it
* We only want to do this if `completeopt` contains `popup` (we add `popuphidden` ourselves). Otherwise, we just break the preview window
* Some items will already be resolved, so we don't want to waste time re-resolving
* We should provide a way to turn off this async resolve in case the delay is too much or it's buggy. We use `g:ycm_max_num_candidates_to_resolve` for this with `-1` meaning no limit (the current behaviour). We force the value of this to 10 if we're going to do async resolve. This is a sort of cheap 'capabilities' implementation for this feature.


TODO:

* [x] Can we put `popuphidden` around the call to `complete()` like we do with `noselect` ? I tried it a while back and it didn't work.
* [x] Can we update the completion items in-place  ? I think we can't (text lock) and/or other reasons, but check and study vim code to see if enhacing vim is an option.
* [x] Write the tests!
* [x] Update README

For the record, none of tis works in neovim, unsurprisingly.

cc @habamax

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3758)
<!-- Reviewable:end -->
