### PR TITLE
Clarifications for ycm_filter_diagnostics in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2479,18 +2479,24 @@ not render it.
 The following filter types are supported:
 
 - "regex": Accepts a string [regular expression][python-re]. This type matches
-when the regex (treated as case-insensitive) is found in the diagnostic text.
+when the regex (treated as case-insensitive) is found anywhere in the diagnostic
+text (`re.search`, not `re.match`)
 - "level": Accepts a string level, either "warning" or "error." This type
-matches when the diagnostic has the same level.
+matches when the diagnostic has the same level, that is,
+specifying `level: "error"` will remove **all** errors from the diagnostics.
 
 **NOTE:** The regex syntax is **NOT** Vim's, it's [Python's][python-re].
 
 Default: `{}`
 
+The following example will do, for java filetype only:
+- Remove **all** error level diagnostics, and,
+- Also remove anything that contains `ta<something>co`
+
 ```viml
 let g:ycm_filter_diagnostics = {
   \ "java": {
-  \      "regex": [ ".*taco.*", ... ],
+  \      "regex": [ "ta.+co", ... ],
   \      "level": "error",
   \      ...
   \    }


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.: **README update only**
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

I bumped into this today, pretty hard. My filter was:

```
let g:ycm_filter_diagnostics = {
  \ "cpp": {
  \      "regex": [ ".*\[-Wunknown-warning-option\].*"],
  \      "level": "error",
  \    }
  \ }
```

And none of the errors would pop up due to the use of "level": "error" which I assumed would do: 

```
for all diagnostics:
   if level == "error":
       if re.match(regex):
           hide
```
Whereas  it actually does:    

```
for all diagnostics:
   if re.search(regex):
      hide
   if level == "error": 
      hide
```

My filter ended up:

```
let g:ycm_filter_diagnostics = {
  \ "cpp": {
  \      "regex": [ "-Wunknown-warning-option"],
  \    }
  \ }
```

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3761)
<!-- Reviewable:end -->
