### PR TITLE
feat: allow completion on a buffer without filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -2368,6 +2368,26 @@ let g:ycm_filetype_blacklist = {
       \}
 ```
 
+Note that completion works for buffers without filetype too. If you don't want it use
+`ycm_nofiletype` to turn it off:
+
+```viml
+let g:ycm_filetype_blacklist = {
+      \ 'tagbar': 1,
+      \ 'notes': 1,
+      \ 'markdown': 1,
+      \ 'netrw': 1,
+      \ 'unite': 1,
+      \ 'text': 1,
+      \ 'vimwiki': 1,
+      \ 'pandoc': 1,
+      \ 'infolog': 1,
+      \ 'leaderf': 1,
+      \ 'mail': 1,
+      \ 'ycm_nofiletype': 1
+      \}
+```
+
 ### The `g:ycm_filetype_specific_completion_to_disable` option
 
 This option controls for which Vim filetypes (see `:h filetype`) should the YCM

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -478,6 +478,9 @@ function! s:AllowedToCompleteInBuffer( buffer )
   endif
 
   let filetype = getbufvar( a:buffer, '&filetype' )
+  if empty(filetype)
+    let filetype = 'ycm_nofiletype'
+  endif
 
   let whitelist_allows = type( g:ycm_filetype_whitelist ) != v:t_dict ||
         \ has_key( g:ycm_filetype_whitelist, '*' ) ||

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -478,7 +478,7 @@ function! s:AllowedToCompleteInBuffer( buffer )
   endif
 
   let filetype = getbufvar( a:buffer, '&filetype' )
-  if empty(filetype)
+  if empty( filetype )
     let filetype = 'ycm_nofiletype'
   endif
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2595,6 +2595,24 @@ Default: '[see next line]'
         \ 'mail': 1
         \}
 <
+Note that completion works for buffers without filetype too. If you don't want it use
+'ycm_nofiletype' to turn it off:
+
+    let g:ycm_filetype_blacklist = {
+        \ 'tagbar': 1,
+        \ 'notes': 1,
+        \ 'markdown': 1,
+        \ 'netrw': 1,
+        \ 'unite': 1,
+        \ 'text': 1,
+        \ 'vimwiki': 1,
+        \ 'pandoc': 1,
+        \ 'infolog': 1,
+        \ 'leaderf': 1,
+        \ 'mail': 1,
+        \ 'ycm_nofiletype': 1
+        \}
+
 -------------------------------------------------------------------------------
 The *g:ycm_filetype_specific_completion_to_disable* option
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -715,7 +715,10 @@ def EscapeForVim( text ):
 
 
 def CurrentFiletypes():
-  return ToUnicode( vim.eval( "&filetype" ) ).split( '.' )
+  filetypes = vim.eval( "&filetype" )
+  if len(filetypes) == 0:
+      filetypes = 'ycm_nofiletype'
+  return ToUnicode( filetypes ).split( '.' )
 
 
 def CurrentFiletypesEnabled( disabled_filetypes ):
@@ -729,7 +732,10 @@ def CurrentFiletypesEnabled( disabled_filetypes ):
 
 def GetBufferFiletypes( bufnr ):
   command = f'getbufvar({ bufnr }, "&ft")'
-  return ToUnicode( vim.eval( command ) ).split( '.' )
+  filetypes = vim.eval( command )
+  if len(filetypes) == 0:
+      filetypes = 'ycm_nofiletype'
+  return ToUnicode( filetypes ).split( '.' )
 
 
 def FiletypesForBuffer( buffer_object ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -716,7 +716,7 @@ def EscapeForVim( text ):
 
 def CurrentFiletypes():
   filetypes = vim.eval( "&filetype" )
-  if len(filetypes) == 0:
+  if not filetypes:
       filetypes = 'ycm_nofiletype'
   return ToUnicode( filetypes ).split( '.' )
 
@@ -733,7 +733,7 @@ def CurrentFiletypesEnabled( disabled_filetypes ):
 def GetBufferFiletypes( bufnr ):
   command = f'getbufvar({ bufnr }, "&ft")'
   filetypes = vim.eval( command )
-  if len(filetypes) == 0:
+  if not filetypes:
       filetypes = 'ycm_nofiletype'
   return ToUnicode( filetypes ).split( '.' )
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -717,7 +717,7 @@ def EscapeForVim( text ):
 def CurrentFiletypes():
   filetypes = vim.eval( "&filetype" )
   if not filetypes:
-      filetypes = 'ycm_nofiletype'
+    filetypes = 'ycm_nofiletype'
   return ToUnicode( filetypes ).split( '.' )
 
 
@@ -734,7 +734,7 @@ def GetBufferFiletypes( bufnr ):
   command = f'getbufvar({ bufnr }, "&ft")'
   filetypes = vim.eval( command )
   if not filetypes:
-      filetypes = 'ycm_nofiletype'
+    filetypes = 'ycm_nofiletype'
   return ToUnicode( filetypes ).split( '.' )
 
 

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -205,7 +205,12 @@ endfunction
 
 function! Test_Compl_No_Filetype()
   enew
-  call setline( '.', 'hello ' )
+  call setline( '.', 'hello this is some text ' )
+
+  " Even when fileytpe is set to '', the filetype autocommand is triggered, but
+  " apparently, _not_ within this function.
+  doautocmd FileType
+  call assert_equal( 1, b:ycm_completing )
 
   " Required to trigger TextChangedI
   " https://github.com/vim/vim/issues/4665#event-2480928194
@@ -214,6 +219,7 @@ function! Test_Compl_No_Filetype()
   " Must do the checks in a timer callback because we need to stay in insert
   " mode until done.
   function! Check( id ) closure
+    call assert_equal( getline( '2' ), 'hell' )
     call WaitForCompletion()
     let items = complete_info().items
     call map( items, {index, value -> value.word} )
@@ -221,11 +227,12 @@ function! Test_Compl_No_Filetype()
     call feedkeys( "\<ESC>" )
   endfunction
 
-  call FeedAndCheckMain( 'Ahe', funcref( 'Check' ) )
+  call FeedAndCheckMain( 'ohell', funcref( 'Check' ) )
   " Checks run in insert mode, then exit insert mode.
   call assert_false( pumvisible(), 'pumvisible()' )
 
   call test_override( 'ALL', 0 )
+  delfunc! Check
   %bwipeout!
 endfunction
 

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -203,6 +203,30 @@ function! Test_Enter_Delete_Chars_Updates_Filter()
   %bwipeout!
 endfunction
 
+function! Test_Compl_No_Filetype()
+  enew
+  call setline( '.', 'hello ' )
+  call setpos( '.', [ 0, 1, 7 ] )
+
+  " Required to trigger TextChangedI
+  " https://github.com/vim/vim/issues/4665#event-2480928194
+  call test_override( 'char_avail', 1 )
+
+  " Must do the checks in a timer callback because we need to stay in insert
+  " mode until done.
+  function! Check( id ) closure
+    call WaitForCompletion()
+    call feedkeys( "\<ESC>" )
+  endfunction
+
+  call FeedAndCheckMain( 'ahe', funcref( 'Check' ) )
+  " Checks run in insert mode, then exit insert mode.
+  call assert_false( pumvisible(), 'pumvisible()' )
+
+  call test_override( 'ALL', 0 )
+  %bwipeout!
+endfunction
+
 function! OmniFuncTester( findstart, query )
   if a:findstart
     return s:omnifunc_start_col

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -206,7 +206,6 @@ endfunction
 function! Test_Compl_No_Filetype()
   enew
   call setline( '.', 'hello ' )
-  call setpos( '.', [ 0, 1, 7 ] )
 
   " Required to trigger TextChangedI
   " https://github.com/vim/vim/issues/4665#event-2480928194
@@ -216,10 +215,13 @@ function! Test_Compl_No_Filetype()
   " mode until done.
   function! Check( id ) closure
     call WaitForCompletion()
+    let items = complete_info().items
+    call map( items, {index, value -> value.word} )
+    call assert_equal( [ 'hello' ], items )
     call feedkeys( "\<ESC>" )
   endfunction
 
-  call FeedAndCheckMain( 'ahe', funcref( 'Check' ) )
+  call FeedAndCheckMain( 'Ahe', funcref( 'Check' ) )
   " Checks run in insert mode, then exit insert mode.
   call assert_false( pumvisible(), 'pumvisible()' )
 


### PR DESCRIPTION
Introduce "fake" filetype `ycm_nofiletype` that is used to handle all
buffers without filetype.

Closes #3775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3776)
<!-- Reviewable:end -->
