### PR TITLE
[READY] Allow completion on a buffer without filetype

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -478,6 +478,9 @@ function! s:AllowedToCompleteInBuffer( buffer )
   endif
 
   let filetype = getbufvar( a:buffer, '&filetype' )
+  if empty( filetype )
+    let filetype = 'ycm_nofiletype'
+  endif
 
   let whitelist_allows = type( g:ycm_filetype_whitelist ) != v:t_dict ||
         \ has_key( g:ycm_filetype_whitelist, '*' ) ||
@@ -487,7 +490,7 @@ function! s:AllowedToCompleteInBuffer( buffer )
 
   let allowed = whitelist_allows && blacklist_allows
 
-  if empty( filetype ) || !allowed || s:DisableOnLargeFile( a:buffer )
+  if !allowed || s:DisableOnLargeFile( a:buffer )
     return 0
   endif
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -715,7 +715,10 @@ def EscapeForVim( text ):
 
 
 def CurrentFiletypes():
-  return ToUnicode( vim.eval( "&filetype" ) ).split( '.' )
+  filetypes = vim.eval( "&filetype" )
+  if not filetypes:
+    filetypes = 'ycm_nofiletype'
+  return ToUnicode( filetypes ).split( '.' )
 
 
 def CurrentFiletypesEnabled( disabled_filetypes ):
@@ -729,7 +732,10 @@ def CurrentFiletypesEnabled( disabled_filetypes ):
 
 def GetBufferFiletypes( bufnr ):
   command = f'getbufvar({ bufnr }, "&ft")'
-  return ToUnicode( vim.eval( command ) ).split( '.' )
+  filetypes = vim.eval( command )
+  if not filetypes:
+    filetypes = 'ycm_nofiletype'
+  return ToUnicode( filetypes ).split( '.' )
 
 
 def FiletypesForBuffer( buffer_object ):

--- a/test/completion_info.test.vim
+++ b/test/completion_info.test.vim
@@ -55,9 +55,9 @@ function! Test_ResolveCompletion_OnChange()
   " Only the java completer actually uses the completion resolve
   call youcompleteme#test#setup#OpenFile(
         \ '/third_party/ycmd/ycmd/tests/java/testdata/simple_eclipse_project' .
-        \ '/src/com/test/MethodsWithDocumentation.java', { 'delay': 15 } )
+        \ '/src/com/test/TestWithDocumentation.java', { 'delay': 15 } )
 
-  call setpos( '.', [ 0, 33, 20 ] )
+  call setpos( '.', [ 0, 6, 21 ] )
   " Required to trigger TextChangedI
   " https://github.com/vim/vim/issues/4665#event-2480928194
   call test_override( 'char_avail', 1 )
@@ -106,7 +106,7 @@ function! Test_ResolveCompletion_OnChange()
     endif
   endfunction
 
-  call FeedAndCheckMain( 'C.', funcref( 'Check1' ) )
+  call FeedAndCheckMain( 'cw', funcref( 'Check1' ) )
 
   call assert_false( pumvisible(), 'pumvisible()' )
   call assert_equal( 1, found_getAString )
@@ -121,9 +121,9 @@ function! Test_DontResolveCompletion_AlreadyResolved()
   " Only the java completer actually uses the completion resolve
   call youcompleteme#test#setup#OpenFile(
         \ '/third_party/ycmd/ycmd/tests/java/testdata/simple_eclipse_project' .
-        \ '/src/com/test/MethodsWithDocumentation.java', { 'delay': 15 } )
+        \ '/src/com/test/TestWithDocumentation.java', { 'delay': 15 } )
 
-  call setpos( '.', [ 0, 34, 12 ] )
+  call setpos( '.', [ 0, 7, 12 ] )
   " Required to trigger TextChangedI
   " https://github.com/vim/vim/issues/4665#event-2480928194
   call test_override( 'char_avail', 1 )

--- a/test/filesize.test.vim
+++ b/test/filesize.test.vim
@@ -4,6 +4,9 @@ function! SetUp()
   let g:ycm_auto_trigger = 1
   let g:ycm_keep_logfiles = 1
   let g:ycm_always_populate_location_list = 1
+  let g:ycm_filetype_blacklist = {
+        \ 'ycm_nofiletype': 1
+        \ }
 
   " diagnostics take ages
   let g:ycm_test_min_delay = 7 


### PR DESCRIPTION
Introduce "fake" filetype `ycm_nofiletype` that is used to handle all
buffers without filetype.

closes #3776

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3777)
<!-- Reviewable:end -->
