### PR TITLE
[READY] Two tiny fixes

### DIFF
--- a/python/ycm/client/resolve_completion_request.py
+++ b/python/ycm/client/resolve_completion_request.py
@@ -73,7 +73,7 @@ def ResolveCompletionItem( completion_request, item ):
     completion_extra_data = json.loads( item[ 'user_data' ] )
   except KeyError:
     return None
-  except json.JSONDecodeError:
+  except ( TypeError, json.JSONDecodeError ):
     # Can happen with the omni completer
     return None
 

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -38,7 +38,7 @@ BWIPEOUT_REGEX = re.compile(
 GETBUFVAR_REGEX = re.compile(
   '^getbufvar\\((?P<buffer_number>[0-9]+), "(?P<option>.+)"\\)$' )
 MATCHADD_REGEX = re.compile(
-  '^matchadd\\(\'(?P<group>.+)\', \'(?P<pattern>.+)\'\\)$' )
+  '^matchadd\\(\'(?P<group>.+)\', \'(?P<pattern>.+)\', -1\\)$' )
 MATCHDELETE_REGEX = re.compile( '^matchdelete\\((?P<id>\\d+)\\)$' )
 OMNIFUNC_REGEX_FORMAT = (
   '^{omnifunc_name}\\((?P<findstart>[01]),[\'"](?P<base>.*)[\'"]\\)$' )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -277,7 +277,7 @@ def GetDiagnosticMatchesInCurrentWindow():
 def AddDiagnosticMatch( match ):
   # TODO: Use matchaddpos which is much faster given that we always are using a
   # location rather than an actual pattern
-  return GetIntValue( f"matchadd('{ match.group }', '{ match.pattern }')" )
+  return GetIntValue( f"matchadd('{ match.group }', '{ match.pattern }', -1)" )
 
 
 def RemoveDiagnosticMatch( match ):


### PR DESCRIPTION
- Swallow TypeError when omnicompleter puts garbage in item["user_data"]
- Highlight diagnostics with low priority, to allow hlsearch to work

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

One commit stops an ugly backtrace when OmniCompleter encounters garbage (dict)
in the completion item's `user_data` on completion resolve request.
The other makes diagnostic highlighting play nicer with `hlsearch`.

No tests, because I have no idea how to test either of these.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3780)
<!-- Reviewable:end -->
