### PR TITLE
[READY] Allow suppressing the quickfix height changes

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -6,7 +6,7 @@
       "variables": [
         {
           "python": {
-            "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which python); else echo \"${dollar}VIRTUAL_ENV/bin/python\"; fi'"
+            "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which python3); else echo \"${dollar}VIRTUAL_ENV/bin/python\"; fi'"
           }
         },
         {

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -393,6 +393,7 @@ class VimBuffer:
    - |filetype| : buffer filetype. Empty string if no filetype is set;
    - |modified| : True if the buffer has unsaved changes, False otherwise;
    - |bufhidden|: value of the 'bufhidden' option (see :h bufhidden);
+   - |vars|:      dict for buffer-local variables
    - |omnifunc| : omni completion function used by the buffer. Must be a Python
                   function that takes the same arguments and returns the same
                   values as a Vim completion function (:h complete-functions).
@@ -411,7 +412,8 @@ class VimBuffer:
                       bufhidden = '',
                       omnifunc = None,
                       visual_start = None,
-                      visual_end = None ):
+                      visual_end = None,
+                      vars = {} ):
     self.name = os.path.realpath( name ) if name else ''
     self.number = number
     self.contents = contents
@@ -427,6 +429,7 @@ class VimBuffer:
     }
     self.visual_start = visual_start
     self.visual_end = visual_end
+    self.vars = vars # should really be a vim-specific dict-like obj
 
 
   def __getitem__( self, index ):

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -180,6 +180,19 @@ def SetFittingHeightForCurrentWindow_LineWrapOn_test( vim_command, *args ):
 
 
 @patch( 'vim.command' )
+def SetFittingHeightForCurrentWindow_NoResize_test( vim_command, *args ):
+  # Create a two lines buffer whose first line is longer than the window width.
+  current_buffer = VimBuffer( 'buffer',
+                              contents = [ 'a' * 140, 'b' * 80 ],
+                              vars = { 'ycm_no_resize': 1 } )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+    vim.current.window.width = 120
+    vim.current.window.options[ 'wrap' ] = True
+    vimsupport.SetFittingHeightForCurrentWindow()
+  vim_command.assert_not_called()
+
+
+@patch( 'vim.command' )
 def SetFittingHeightForCurrentWindow_LineWrapOff_test( vim_command, *args ):
   # Create a two lines buffer whose first line is longer than the window width.
   current_buffer = VimBuffer( 'buffer',

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -398,6 +398,9 @@ def ComputeFittingHeightForCurrentWindow():
 
 
 def SetFittingHeightForCurrentWindow():
+  if int( vim.current.buffer.vars.get( 'ycm_no_resize', 0 ) ):
+    return
+
   vim.command( f'{ ComputeFittingHeightForCurrentWindow() }wincmd _' )
 
 


### PR DESCRIPTION
Upstreaming this because it's useful. I use a lot of commands that run tests and things and the output goes to the QuickFix window. I like this to be vertical for some things. However, YCM's resizing messes up the window layout even if you override it with the autocmd. This is a tiny change to allow YCM to not resise the QuickFix window.

---

This allows the quickfix to be made vertical, with

au FileType qf let b:ycm_no_resize = 1 <bar> wincmd L

Using the YcmQuickFixOpened/YcmLocationOpened can work (with wincmd _),
but this messes up the layout of split windows, e.g.:

:au User YcmQuickFixOpened wincmd _
:split
:YcmCOmpleter GoToSymbol User

This breaks the layout of the 2 splits (as YCM first resizes the
quickfix window with its own command, thust increasing cmdheight to
&lines - <new height>)

---

My vertical QuickFix : https://gist.github.com/puremourning/df3a231940ac2f206f8fc87e08ae235e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3783)
<!-- Reviewable:end -->
