### PR TITLE
[READY] Fix signature help traceback when using preview popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2341,6 +2341,20 @@ Default: `{'*': 1}`
 let g:ycm_filetype_whitelist = {'*': 1}
 ```
 
+** Completion in buffers with no filetype **
+
+There is one exception to the above rule. YCM supports completion in buffers
+with no filetype set, but this must be _explicitly_ whitelisted. To identify
+buffers with no filetype, we use the `ycm_nofiletype` pseudo-filetype. To enable
+completion in buffers with no filetype, set:
+
+```viml
+let g:ycm_filetype_whitelist = {
+  \ '*': 1,
+  \ 'ycm_nofiletype': 1
+  \ }
+```
+
 ### The `g:ycm_filetype_blacklist` option
 
 This option controls for which Vim filetypes (see `:h filetype`) should YCM be
@@ -2367,6 +2381,10 @@ let g:ycm_filetype_blacklist = {
       \ 'mail': 1
       \}
 ```
+
+In addition, `ycm_nofiletype` (representing buffers with no filetype set)
+is blacklisted if `ycm_nofiletype` is not _explicitly_ whitelisted (using
+`g:ycm_filetype_whitelist`).
 
 ### The `g:ycm_filetype_specific_completion_to_disable` option
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -63,7 +63,9 @@ let s:pollers = {
 let s:buftype_blacklist = {
       \   'help': 1,
       \   'terminal': 1,
-      \   'quickfix': 1
+      \   'quickfix': 1,
+      \   'popup': 1,
+      \   'nofile': 1,
       \ }
 let s:last_char_inserted_by_user = v:true
 let s:enable_hover = 0

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -93,6 +93,12 @@ let g:ycm_filetype_blacklist =
       \   'mail': 1
       \ } )
 
+" Blacklist empty buffers unless explicity whitelisted; workaround for
+" https://github.com/ycm-core/YouCompleteMe/issues/3781
+if !has_key( g:ycm_filetype_whitelist, 'ycm_nofiletype' )
+  let g:ycm_filetype_blacklist[ 'ycm_nofiletype' ] = 1
+endif
+
 let g:ycm_open_loclist_on_ycm_diags =
       \ get( g:, 'ycm_open_loclist_on_ycm_diags', 1 )
 

--- a/test/.vimspector.json
+++ b/test/.vimspector.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
+  "configurations": {
+    "Run vim test": {
+      "adapter": "vim-debug-adapter",
+      "configuration": {
+        "request": "launch",
+        "cwd": "${workspaceRoot}",
+        "args": [
+          "--clean",
+          "--not-a-term",
+          "-S", "lib/run_test.vim",
+          "${file}",
+          "${TestFunction}"
+        ]
+      }
+    }
+  }
+}

--- a/test/commands.test.vim
+++ b/test/commands.test.vim
@@ -10,40 +10,40 @@ function! Test_ToggleLogs()
   let bcount = len( getbufinfo() )
 
   " default - show
-  exe 'YcmToggleLogs' keys( log_files )[ 0 ]
+  silent exe 'YcmToggleLogs' keys( log_files )[ 0 ]
   call assert_equal( bcount + 1, len( getbufinfo() ) )
   let win = getbufinfo( keys( log_files )[ 0 ] )[ 0 ].windows[ 0 ]
   call assert_equal( &previewheight, winheight( win_id2win( win ) ) )
 
   " default - hide
-  exe 'YcmToggleLogs' keys( log_files )[ 0 ]
+  silent exe 'YcmToggleLogs' keys( log_files )[ 0 ]
   " buffer is wiped out
   call assert_equal( bcount, len( getbufinfo() ) )
   call assert_equal( [], getbufinfo( keys( log_files )[ 0 ] ) )
 
   " show - 10 lines
-  exe '10YcmToggleLogs' keys( log_files )[ 0 ]
+  silent exe '10YcmToggleLogs' keys( log_files )[ 0 ]
   call assert_equal( bcount + 1, len( getbufinfo() ) )
   let win = getbufinfo( keys( log_files )[ 0 ] )[ 0 ].windows[ 0 ]
   call assert_equal( 10, winheight( win_id2win( win ) ) )
 
   " hide
-  exe '10YcmToggleLogs' keys( log_files )[ 0 ]
+  silent exe '10YcmToggleLogs' keys( log_files )[ 0 ]
   call assert_equal( bcount, len( getbufinfo() ) )
   call assert_equal( [], getbufinfo( keys( log_files )[ 0 ] ) )
 
   " show - 15 cols
-  exe 'vertical 15YcmToggleLogs' keys( log_files )[ 0 ]
+  silent exe 'vertical 15YcmToggleLogs' keys( log_files )[ 0 ]
   call assert_equal( bcount + 1, len( getbufinfo() ) )
   let win = getbufinfo( keys( log_files )[ 0 ] )[ 0 ].windows[ 0 ]
   call assert_equal( 15, winwidth( win_id2win( win ) ) )
 
   " hide
-  exe 'YcmToggleLogs' keys( log_files )[ 0 ]
+  silent exe 'YcmToggleLogs' keys( log_files )[ 0 ]
   call assert_equal( bcount, len( getbufinfo() ) )
   call assert_equal( [], getbufinfo( keys( log_files )[ 0 ] ) )
 
-  %bwipeout!
+
 endfunction
 
 function! Test_GetCommandResponse()
@@ -84,7 +84,6 @@ function! Test_GetCommandResponse()
   call setpos( '.', [ 0, 1, 3 ] )
   call assert_equal( '', youcompleteme#GetCommandResponse( 'GetDoc' ) )
 
-  %bwipe!
 endfunction
 
 
@@ -96,15 +95,12 @@ function! Test_GetCommandResponse_FixIt()
   call assert_equal( '',
                    \ youcompleteme#GetCommandResponse( 'FixIt' ) )
 
-  %bwipe!
 endfunction
 
 function! Test_GetDefinedSubcommands_Native()
   call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/fixit.c', {} )
   call assert_equal( 1, count( youcompleteme#GetDefinedSubcommands(),
                              \ 'GetDoc' ) )
-
-  %bwipe!
 endfunction
 
 function! Test_GetDefinedSubcommands_NoNative()
@@ -112,5 +108,6 @@ function! Test_GetDefinedSubcommands_NoNative()
   setf not_a_filetype
   call assert_equal( [], youcompleteme#GetDefinedSubcommands() )
 
-  %bwipe!
+  " The above call prints ValueError: No semantic completer ...."
+  messages clear
 endfunction

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -149,11 +149,11 @@ function! Test_Enter_Delete_Chars_Updates_Filter()
 endfunction
 
 function! SetUp_Test_Compl_No_Filetype()
-  let g:ycm_filetype_whitelist = {
+  call youcompleteme#test#setup#PushGlobal( 'ycm_filetype_whitelist', {
         \ '*': 1,
         \ 'ycm_nofiletype': 1
-        \ }
-  silent! call remove( g:ycm_filetype_blacklist, 'ycm_nofiletype' )
+        \ } )
+  call youcompleteme#test#setup#PushGlobal( 'ycm_filetype_blacklist', {} )
 endfunction
 
 function! Test_Compl_No_Filetype()
@@ -190,8 +190,8 @@ function! Test_Compl_No_Filetype()
 endfunction
 
 function! TearDown_Test_Compl_No_Filetype()
-  call remove( g:ycm_filetype_whitelist, 'ycm_nofiletype' )
-  let g:ycm_filetype_blacklist[ 'ycm_nofiletype' ] = 1
+  call youcompleteme#test#setup#PopGlobal( 'ycm_filetype_whitelist' )
+  call youcompleteme#test#setup#PopGlobal( 'ycm_filetype_blacklist' )
 endfunction
 
 function! Test_Compl_No_Filetype_Blacklisted()
@@ -232,9 +232,9 @@ function! OmniFuncTester( findstart, query )
 endfunction
 
 function! SetUp_Test_OmniComplete_Filter()
-  let g:ycm_semantic_triggers = {
+  call youcompleteme#test#setup#PushGlobal( 'ycm_semantic_triggers', {
         \ 'omnifunc_test': [ ':', '.' ]
-        \ }
+        \ } )
 endfunction
 
 function! Test_OmniComplete_Filter()
@@ -279,7 +279,7 @@ function! Test_OmniComplete_Filter()
 endfunction
 
 function! TearDown_Test_OmniComplete_Filter()
-  unlet g:ycm_semantic_triggers
+  call youcompleteme#test#setup#PopGlobal( 'ycm_semantic_triggers' )
 endfunction
 
 function! Test_OmniComplete_Force()

--- a/test/completion.test.vim
+++ b/test/completion.test.vim
@@ -32,6 +32,4 @@ function! Test_Using_Upfront_Resolve()
   endfor
 
   call assert_report( "Didn't find the resolve type in the YcmDebugInfo" )
-
-  %bwipeout!
 endfunction

--- a/test/completion_info.test.vim
+++ b/test/completion_info.test.vim
@@ -46,7 +46,6 @@ function! Test_Using_Ondemand_Resolve()
 
   call assert_report( "Didn't find the resolve type in the YcmDebugInfo" )
 
-  %bwipeout!
 endfunction
 
 function! Test_ResolveCompletion_OnChange()
@@ -112,7 +111,6 @@ function! Test_ResolveCompletion_OnChange()
   call assert_equal( 1, found_getAString )
 
   call test_override( 'ALL', 0 )
-  %bwipeout!
 endfunction
 
 function! Test_DontResolveCompletion_AlreadyResolved()
@@ -162,5 +160,4 @@ function! Test_DontResolveCompletion_AlreadyResolved()
   call assert_false( pumvisible(), 'pumvisible()' )
 
   call test_override( 'ALL', 0 )
-  %bwipeout!
 endfunction

--- a/test/completion_noresolve.test.vim
+++ b/test/completion_noresolve.test.vim
@@ -32,6 +32,4 @@ function! Test_No_Resolve()
   endfor
 
   call assert_report( "Didn't find the resolve type in the YcmDebugInfo" )
-
-  %bwipeout!
 endfunction

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -31,7 +31,6 @@ function! Test_Changing_Filetype_Refreshes_Diagnostics()
   call assert_equal( 1, len( sign_getplaced()[ 0 ][ 'signs' ] ) )
   call assert_equal( 'YcmError', sign_getplaced()[ 0 ][ 'signs' ][ 0 ][ 'name' ] )
   call assert_false( empty( getloclist( 0 ) ) )
-  %bwipeout!
 endfunction
 
 function! Test_MessagePoll_After_LocationList()
@@ -47,7 +46,6 @@ function! Test_MessagePoll_After_LocationList()
   doautocmd TextChanged
   call WaitForAssert( {-> assert_true( empty( sign_getplaced() ) ) } )
   call assert_true( empty( getloclist( 0 ) ) )
-  %bwipeout!
 endfunction
 
 function! Test_MessagePoll_Multiple_Filetypes()
@@ -56,7 +54,7 @@ function! Test_MessagePoll_Multiple_Filetypes()
         \ '/src/com/test/TestLauncher.java', {} )
   call WaitForAssert( {-> assert_true( len( sign_getplaced( '%' )[ 0 ][ 'signs' ] ) ) } )
   let java_signs = sign_getplaced( '%' )[ 0 ][ 'signs' ]
-  vsplit testdata/diagnostics/foo.cpp
+  silent vsplit testdata/diagnostics/foo.cpp
   " Make sure we've left the java buffer
   call assert_equal( java_signs, sign_getplaced( '#' )[ 0 ][ 'signs' ] )
   " Clangd emits two diagnostics for foo.cpp.

--- a/test/filesize.test.vim
+++ b/test/filesize.test.vim
@@ -4,9 +4,6 @@ function! SetUp()
   let g:ycm_auto_trigger = 1
   let g:ycm_keep_logfiles = 1
   let g:ycm_always_populate_location_list = 1
-  let g:ycm_filetype_blacklist = {
-        \ 'ycm_nofiletype': 1
-        \ }
 
   " diagnostics take ages
   let g:ycm_test_min_delay = 7 
@@ -24,12 +21,10 @@ function! Test_Open_Unsupported_Filetype_Messages()
   let X = join( map( range( 0, 1000 * 1024 + 1 ), {->'X'} ), '' )
   call append( line( '$' ), X )
 
-  w! Xtest
+  silent w! Xtest
 
-  let l:stderr = substitute( execute( 'messages' ), '\n', '\t', 'g' )
+  let l:stderr = substitute( execute( '1messages' ), '\n', '\t', 'g' )
   call assert_notmatch( 'the file exceeded the max size', stderr )
-
-  %bwipeout!
   call delete( 'Xtest' )
 endfunction
 
@@ -39,14 +34,13 @@ function! Test_Open_Supported_Filetype_Messages()
   let X = join( map( range( 0, 1000 * 1024 + 1 ), {->'X'} ), '' )
   call append( line( '$' ), X )
 
-  w! Xtest
-  messages clear
+  silent w! Xtest
   setf cpp
 
-  let l:stderr = substitute( execute( 'messages' ), '\n', '\t', 'g' )
+  let l:stderr = substitute( execute( '1messages' ), '\n', '\t', 'g' )
   call assert_match( 'the file exceeded the max size', stderr )
   call assert_equal( 1, b:ycm_largefile )
+  messages clear
 
-  %bwipeout!
   call delete( 'Xtest' )
 endfunction

--- a/test/fixit.test.vim
+++ b/test/fixit.test.vim
@@ -34,7 +34,6 @@ function! Test_Ranged_Fixit_Works()
   call assert_match( '        String \(x\|string\) = "Did something useful: "' .
                      \ ' + w.getWidgetInfo();', getline( 34 ) )
   call assert_match( '\t\tSystem.out.println( \(x\|string\) );', getline( 35 ) )
-  %bwipeout!
   delfunction SelectEntry
 endfunction
 

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -134,7 +134,6 @@ function! Test_Hover_Uses_GetDoc()
   normal \D
   call s:CheckPopupVisible( 11, 4, s:python_oneline.GetDoc, '' )
   call popup_clear()
-  %bwipe!
 endfunction
 
 function! Test_Hover_Uses_GetHover()
@@ -159,7 +158,6 @@ EOPYTHON
   call s:CheckPopupNotVisible( 11, 4 )
   call popup_clear()
 
-  %bwipe!
 endfunction
 
 function! Test_Hover_Uses_None()
@@ -177,7 +175,6 @@ EOPYTHON
   call s:CheckPopupNotVisible( 11, 4, v:false )
 
   call popup_clear()
-  %bwipe!
 endfunction
 
 function! Test_Hover_Uses_GetType()
@@ -216,7 +213,6 @@ EOPYTHON
   call s:CheckPopupVisible( 11, 4, s:python_oneline.GetType, 'python' )
   call popup_clear()
 
-  %bwipe!
 endfunction
 
 function! Test_Hover_NonNative()
@@ -234,7 +230,6 @@ function! Test_Hover_NonNative()
   call assert_equal( messages_before, execute( 'messages' ) )
 
   call popup_clear()
-  %bwipe!
 endfunction
 
 function SetUp_Test_Hover_Disabled_NonNative()
@@ -245,13 +240,12 @@ function! Test_Hover_Disabled_NonNative()
   call youcompleteme#test#setup#OpenFile( '_not_a_file', { 'native_ft': 0 } )
   setfiletype NoASupportedFileType
   let messages_before = execute( 'messages' )
-  silent doautocmd CursorHold
+  silent! doautocmd CursorHold
   call s:CheckNoCommandRequest()
   call assert_false( exists( 'b:ycm_hover' ) )
   call assert_equal( messages_before, execute( 'messages' ) )
 
   call popup_clear()
-  %bwipe!
 endfunction
 
 function! SetUp_Test_AutoHover_Disabled()
@@ -266,7 +260,7 @@ function! Test_AutoHover_Disabled()
   call assert_false( exists( 'b:ycm_hover' ) )
 
   call setpos( '.', [ 0, 12, 3 ] )
-  silent doautocmd CursorHold
+  silent! doautocmd CursorHold
   call s:CheckPopupNotVisible( 11, 4, v:false )
   call assert_equal( messages_before, execute( 'messages' ) )
 
@@ -282,7 +276,6 @@ function! Test_AutoHover_Disabled()
   call assert_equal( messages_before, execute( 'messages' ) )
 
   call popup_clear()
-  %bwipeout!
 endfunction
 
 function! Test_Hover_MoveCursor()
@@ -315,7 +308,6 @@ function! Test_Hover_MoveCursor()
   call test_override( 'ALL', 0 )
 
   call popup_clear()
-  %bwipeout!
 endfunction
 
 function! Test_Hover_Dismiss()
@@ -336,7 +328,7 @@ function! Test_Hover_Dismiss()
   call s:CheckPopupNotVisible( 11, 3, v:false )
 
   " Make sure it doesn't come back
-  doautocmd CursorHold
+  silent! doautocmd CursorHold
   call s:CheckPopupNotVisible( 11, 3, v:false )
 
   " Move the cursor (again this is tricky). I couldn't find any tests in vim's
@@ -347,7 +339,6 @@ function! Test_Hover_Dismiss()
   call s:CheckPopupVisible( 11, 3, s:python_oneline.GetDoc, '' )
 
   call popup_clear()
-  %bwipeout!
 endfunction
 
 function! SetUp_Test_Hover_Custom_Syntax()
@@ -377,11 +368,10 @@ function! Test_Hover_Custom_Syntax()
   call s:CheckPopupNotVisibleScreenPos( { 'row': 7, 'col': 9 }, v:false )
 
   call popup_clear()
-  %bwipe!
 endfunction
 
 function! TearDown_Test_Hover_Custom_Syntax()
-  au! MyYCMCustom
+  silent! au! MyYCMCustom
 endfunction
 
 function! SetUp_Test_Hover_Custom_Command()
@@ -407,11 +397,10 @@ function! Test_Hover_Custom_Command()
   call s:CheckPopupVisible( 5, 9, s:cpp_lifetime.GetType, 'cpp' )
 
   call popup_clear()
-  %bwipe!
 endfunction
 
 function! TearDown_Test_Hover_Custom_Command()
-  au! MyYCMCustom
+  silent! au! MyYCMCustom
 endfunction
 
 function! Test_Long_Single_Line()
@@ -435,7 +424,6 @@ function! Test_Long_Single_Line()
   call s:CheckPopupVisible( 33, &columns, v:none, '' )
 
   call popup_clear()
-  %bwipe!
 endfunction
 
 function! Test_Long_Wrapped()
@@ -460,5 +448,4 @@ function! Test_Long_Wrapped()
   call s:CheckPopupNotVisible( 26, &columns, v:false )
 
   call popup_clear()
-  %bwipe!
 endfunction

--- a/test/lib/autoload/youcompleteme/test/setup.vim
+++ b/test/lib/autoload/youcompleteme/test/setup.vim
@@ -63,3 +63,34 @@ function! youcompleteme#test#setup#OpenFile( f, kwargs ) abort
 
   " FIXME: We need a much more robust way to wait for the server to be ready
 endfunction
+
+let s:g_stack = {}
+
+function! youcompleteme#test#setup#PushGlobal( name, value )
+  if !has_key( s:g_stack, a:name )
+    let s:g_stack[ a:name ] = []
+  endif
+
+  let old_value = get( g:, a:name, v:null )
+  call add( s:g_stack[ a:name ], old_value )
+  call extend( g:, { a:name: a:value  } )
+
+  return old_value
+endfunction
+
+function! youcompleteme#test#setup#PopGlobal( name )
+  if !has_key( s:g_stack, a:name ) || len( s:g_stack[ a:name ] ) == 0
+    return v:null
+  endif
+
+  let old_value = s:g_stack[ a:name ][ -1 ]
+  call remove( s:g_stack[ a:name ], -1 )
+
+  if old_value is v:null
+    silent! call remove( g:, a:name )
+  else
+    call extend( g:, { a:name: old_value  } )
+  endif
+
+  return old_value
+endfunction

--- a/test/lib/autoload/youcompleteme/test/setup.vim
+++ b/test/lib/autoload/youcompleteme/test/setup.vim
@@ -28,7 +28,7 @@ function! youcompleteme#test#setup#CleanUp() abort
 endfunction
 
 function! youcompleteme#test#setup#OpenFile( f, kwargs ) abort
-  execute 'edit '
+  silent execute 'edit '
         \ . g:ycm_test_plugin_dir
         \ . '/'
         \ . a:f

--- a/test/lib/plugin/completion.vim
+++ b/test/lib/plugin/completion.vim
@@ -1,0 +1,47 @@
+function! CheckCompletionItems( expected_props, ... )
+  let prop = 'abbr'
+  if a:0 > 0
+    let prop = a:1
+  endif
+
+  let items = complete_info( [ 'items' ] )[ 'items' ]
+  let abbrs = []
+  for item in items
+    call add( abbrs, get( item, prop ) )
+  endfor
+
+  call assert_equal( a:expected_props,
+        \ abbrs,
+        \ 'not matched: '
+        \ .. string( a:expected_props )
+        \ .. ' against '
+        \ .. prop
+        \ .. ' in '
+        \ .. string( items )
+        \ .. ' matching '
+        \ .. string( abbrs ) )
+endfunction
+
+function! FeedAndCheckMain( keys, func )
+  call timer_start( 500, a:func )
+  call feedkeys( a:keys, 'tx!' )
+endfunction
+
+function! FeedAndCheckAgain( keys, func )
+  call timer_start( 500, a:func )
+  call feedkeys( a:keys )
+endfunction
+
+function! WaitForCompletion()
+  call WaitForAssert( {->
+        \ assert_true( pyxeval( 'ycm_state.GetCurrentCompletionRequest() is not None' ) )
+        \ } )
+  call WaitForAssert( {->
+        \ assert_true( pyxeval( 'ycm_state.CompletionRequestReady()' ) )
+        \ } )
+  redraw
+  call WaitForAssert( {->
+        \ assert_true( pumvisible(), 'pumvisible()' )
+        \ }, 10000 )
+endfunction
+

--- a/test/lib/plugin/util.vim
+++ b/test/lib/plugin/util.vim
@@ -1,0 +1,4 @@
+function! CheckCurrentLine( expected_value )
+  return assert_equal( a:expected_value, getline( '.' ) )
+endfunction
+

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -574,7 +574,8 @@ endfunction
 
 function! SetUp_Test_Semantic_Completion_Popup_With_Sig_Help()
   set signcolumn=no
-  let g:ycm_add_preview_to_completeopt = 'popup'
+  call youcompleteme#test#setup#PushGlobal( 'ycm_add_preview_to_completeopt',
+                                          \ 'popup' )
 endfunction
 
 function! Test_Semantic_Completion_Popup_With_Sig_Help()
@@ -664,17 +665,18 @@ endfunction
 
 function! TearDown_Test_Semantic_Completion_Popup_With_Sig_Help()
   set signcolumn&
-  unlet! g:ycm_add_preview_to_completeopt
+  call youcompleteme#test#setup#PopGlobal( 'ycm_add_preview_to_completeopt' )
 endfunction
 
 function! SetUp_Test_Semantic_Completion_Popup_With_Sig_Help_EmptyBuf()
   set signcolumn=no
-  let g:ycm_filetype_whitelist = {
+  call youcompleteme#test#setup#PushGlobal( 'ycm_filetype_whitelist', {
         \ '*': 1,
         \ 'ycm_nofiletype': 1
-        \ }
-  silent! call remove( g:ycm_filetype_blacklist, 'ycm_nofiletype' )
-  let g:ycm_add_preview_to_completeopt = 'popup'
+        \ } )
+  call youcompleteme#test#setup#PushGlobal( 'ycm_filetype_blacklist', {} )
+  call youcompleteme#test#setup#PushGlobal( 'ycm_add_preview_to_completeopt',
+                                          \ 'popup' )
 endfunction
 
 function! Test_Semantic_Completion_Popup_With_Sig_Help_EmptyBuf()
@@ -775,7 +777,7 @@ endfunction
 
 function! TearDown_Test_Semantic_Completion_Popup_With_Sig_Help_EmptyBuf()
   set signcolumn&
-  unlet! g:ycm_add_preview_to_completeopt
-  call remove( g:ycm_filetype_whitelist, 'ycm_nofiletype' )
-  let g:ycm_filetype_blacklist[ 'ycm_nofiletype' ] = 1
+  call youcompleteme#test#setup#PopGlobal( 'ycm_filetype_whitelist' )
+  call youcompleteme#test#setup#PopGlobal( 'ycm_filetype_blacklist' )
+  call youcompleteme#test#setup#PopGlobal( 'ycm_add_preview_to_completeopt' )
 endfunction

--- a/test/testdata/cpp/complete_with_sig_help.cc
+++ b/test/testdata/cpp/complete_with_sig_help.cc
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+struct Test
+{
+  int this_is_a_thing; int that_is_a_thing;
+};
+
+int main() {
+  Test t;
+
+}


### PR DESCRIPTION
When we made YCM parse buffers with no filetype, this ended up including
the buffers within things like popups. Unfortuantely this leads to a
problem that we call "ClearSignatureHelp" from within
"FileReadyToParse". If the "FileReadyToParse" in question was within a
popup, we ge an error "Not valid in popup window" (referring to a call
to popup_close()) and vim gets in a very bad state.

it's not obvious how to solve this in the general case, but for now as
completion in non-filetype buffers is new and rare, we Blacklist enpty
buffers by default to work around the bug.

We allow users to explicitly enable it (and suffer this bug!) by
explicitly whiteliisting it again in ycm_filetype_whitelist.

Added a test which shows that it works when ycm_nofiletyp is
blacklisted, and another test which exercises the (still) broken
behaviour, when ycm_nofiletype is whitelisted.

Fixes #3781

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3785)
<!-- Reviewable:end -->
