### PR TITLE
Allow built-in whole line completion (<C-X><C-L>)

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -824,7 +824,10 @@ function! s:OnTextChangedInsertMode( popup_is_visible )
     return
   endif
 
-  if a:popup_is_visible && ( !s:last_char_inserted_by_user || complete_info().mode == 'whole_line' )
+  if a:popup_is_visible && (
+              \ !s:last_char_inserted_by_user ||
+              \ complete_info().mode == 'whole_line'
+              \)
     " If the last "input" wasn't from a user typing (i.e. didn't come from
     " InsertCharPre, then ignore this change in the text. This prevents ctrl-n
     " or tab from causing us to re-filter the list based on the now-selected

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -824,11 +824,11 @@ function! s:OnTextChangedInsertMode( popup_is_visible )
     return
   endif
 
-  if a:popup_is_visible && !s:last_char_inserted_by_user
+  if a:popup_is_visible && ( !s:last_char_inserted_by_user || complete_info().mode == 'whole_line' )
     " If the last "input" wasn't from a user typing (i.e. didn't come from
     " InsertCharPre, then ignore this change in the text. This prevents ctrl-n
     " or tab from causing us to re-filter the list based on the now-selected
-    " item.
+    " item. Also don't override built-in whole line completion (C-X C-L).
     return
   endif
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.

 It is written in CONTRIBUTING.md that for vimscript they aren't necessary.

- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

ycm popup currently disrupts vim whole line completion

Whole line completion can also include spaces so any attempt to interfere with vim popup in this case should be prevented. This PR does this.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3791)
<!-- Reviewable:end -->
