### PR TITLE
[RFC/WIP] Use vim channels instead of requests

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -44,6 +44,21 @@
           "YCM_TEST_NO_RETRY": "1"
         }
       }
+    },
+    "Vimscript Run Dev YCM": {
+      "adapter": {
+        "command": [ "node",
+                     "/Users/ben/Development/vim-debug-adapter/dist/index.js" ]
+      },
+      "configuration": {
+        "type": "vim",
+        "request": "launch",
+        "vim": "/Users/ben/Development/vim/src/vim",
+        "args": [ "--cmd", "let g:benj_test_ycm=1" ],
+        "trace": {
+          "level": "Verbose"
+        }
+      }
     }
   }
 }

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -46,10 +46,6 @@ let s:requests = {
       \   },
       \ }
 let s:pollers = {
-      \   'file_parse_response': {
-      \     'id': -1,
-      \     'wait_milliseconds': 100
-      \   },
       \   'server_ready': {
       \     'id': -1,
       \     'wait_milliseconds': 100
@@ -770,26 +766,6 @@ function! s:OnFileReadyToParse( ... )
     " FIXME: sig hekp should be buffer local?
     call s:ClearSignatureHelp()
     py3 ycm_state.OnFileReadyToParse()
-
-    call s:StopPoller( s:pollers.file_parse_response )
-    let s:pollers.file_parse_response.id = timer_start(
-          \ s:pollers.file_parse_response.wait_milliseconds,
-          \ function( 's:PollFileParseResponse' ) )
-  endif
-endfunction
-
-
-function! s:PollFileParseResponse( ... )
-  if !py3eval( "ycm_state.FileParseRequestReady()" )
-    let s:pollers.file_parse_response.id = timer_start(
-          \ s:pollers.file_parse_response.wait_milliseconds,
-          \ function( 's:PollFileParseResponse' ) )
-    return
-  endif
-
-  py3 ycm_state.HandleFileParseRequest()
-  if py3eval( "ycm_state.ShouldResendFileParseRequest()" )
-    call s:OnFileReadyToParse( 1 )
   endif
 endfunction
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1225,7 +1225,7 @@ function! youcompleteme#GetRawCommandResponseAsync( callback, ... ) abort
     return
   endif
 
-  if s:pollers.command.id != -1
+  if s:requests.command.id != -1
     eval a:callback( { 'error': 'request in progress' } )
     return
   endif

--- a/autoload/youcompleteme/http.vim
+++ b/autoload/youcompleteme/http.vim
@@ -1,0 +1,123 @@
+" Copyright (C) 2020 YouCompleteMe contributors
+"
+" This file is part of YouCompleteMe.
+"
+" YouCompleteMe is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" YouCompleteMe is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+" This is basic vim plugin boilerplate
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! youcompleteme#http#GET( host, port, uri, query_string, headers )
+  let uri = a:uri
+  if a:query_string != ''
+    let uri .= '?' . a:query_string
+  endif
+  return s:Write( 'GET', a:host, a:port, uri, a:headers, v:none )
+endfunction
+
+function! youcompleteme#http#POST( host, port, uri, headers, data )
+  return s:Write( 'POST', a:host, a:port, a:uri, a:headers, a:data )
+endfunction
+
+" Insernal {{{
+
+let s:request_state = {}
+let s:CRLF = "\r\n"
+
+function! s:OnData( channel, msg )
+    let s:request_state[ ch_info( a:channel ).id ].data .= a:msg
+endfunction
+
+function! s:OnClose( channel )
+  let id = ch_info( a:channel ).id
+  let data = s:request_state[ id ].data
+  unlet s:request_state[ id ]
+  let bounary = match( data, s:CRLF . s:CRLF )
+  if bounary < 0
+    call s:Reject( id, "Invalid message received" )
+    return
+  endif
+
+  let header = data[ 0:(bounary - 1) ]
+  let body = data[ bounary + 2*len( s:CRLF ): ]
+
+  let headers = split( header, s:CRLF )
+  let status_line = headers[ 0 ]
+  let headers = headers[ 1: ]
+
+  let header_map = {}
+  for header in headers
+    let colon = match( header, ':' )
+    let header_map[ tolower( header[ : colon-1 ] ) ] = trim( header[ colon+1: ] )
+  endfor
+
+  let status_code = split( status_line )[ 1 ]
+
+  call s:Resolve( id, status_code, header_map, body )
+endfunction
+
+function! s:Reject( id, why )
+  py3 << EOF
+from ycm.client import base_request
+base_request.Future.requests.pop( vim.eval( 'a:id' ) ).reject(
+  vim.eval( 'a:why' ) )
+EOF
+endfunction
+
+function! s:Resolve( id, status_code, header_map, body )
+  py3 << EOF
+from ycm.client import base_request
+base_request.Future.requests.pop( vim.eval( 'a:id' ) ).resolve(
+  int( vim.eval( 'a:status_code' ) ),
+  vim.eval( 'a:header_map' ),
+  vim.eval( 'a:body' ) )
+EOF
+endfunction
+
+function! s:Write( method, host, port, uri, headers, data )
+  let ch = ch_open( a:host . ':' . a:port, #{
+        \ mode: 'raw',
+        \ callback: funcref( 's:OnData' ),
+        \ close_cb: funcref( 's:OnClose' ),
+        \ waittime: 1000,
+        \ } )
+  let id = ch_info( ch ).id
+  let s:request_state[ id ] = #{ data: '' }
+
+  let a:headers[ 'Host' ] = a:host
+  let a:headers[ 'Connection' ] = 'close'
+  let a:headers[ 'Accept' ] = 'application/json'
+  if a:data != v:none
+    let a:headers[ 'Content-Length' ] = string( len( a:data ) )
+  endif
+
+  call ch_sendraw( ch, a:method . ' '. a:uri . ' HTTP/1.1' . s:CRLF )
+  for h in keys( a:headers )
+    call ch_sendraw( ch, h . ':' . a:headers[ h ] . s:CRLF )
+  endfor
+  call ch_sendraw( ch, s:CRLF )
+  if a:data != v:none
+    call ch_sendraw( ch, a:data )
+  endif
+  return id
+endfunction
+
+" }}}
+
+" This is basic vim plugin boilerplate
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: filetype=vim.python foldmethod=marker

--- a/autoload/youcompleteme/http.vim
+++ b/autoload/youcompleteme/http.vim
@@ -39,7 +39,7 @@ function! youcompleteme#http#Block( id, timeout )
   let ch = s:request_state[ a:id ].handle
   call ch_setoptions( ch, { 'close_cb': funcref( 's:NullClose' ) } )
   while count( [ 'open', 'buffered' ],  ch_status( ch ) ) == 1
-    let data = ch_read( ch, { 'timeout': 1000 } )
+    let data = ch_read( ch, { 'timeout': a:timeout } )
     let s:request_state[ a:id ].data .= data
   endwhile
   call s:OnClose( ch )
@@ -49,7 +49,7 @@ let s:request_state = {}
 let s:CRLF = "\r\n"
 
 function! s:OnData( channel, msg )
-  let id =  ch_info( a:channel ).id 
+  let id =  ch_info( a:channel ).id
   let s:request_state[ id ].data .= a:msg
 endfunction
 
@@ -76,7 +76,8 @@ function! s:OnClose( channel )
   let header_map = {}
   for header in headers
     let colon = match( header, ':' )
-    let header_map[ tolower( header[ : colon-1 ] ) ] = trim( header[ colon+1: ] )
+    let header_map[ tolower( header[ : colon-1 ] ) ]
+          \ = trim( header[ colon+1: ] )
   endfor
 
   let status_code = split( status_line )[ 1 ]

--- a/autoload/youcompleteme/http.vim
+++ b/autoload/youcompleteme/http.vim
@@ -31,8 +31,6 @@ function! youcompleteme#http#POST( host, port, uri, headers, data )
   return s:Write( 'POST', a:host, a:port, a:uri, a:headers, a:data )
 endfunction
 
-" Insernal {{{
-
 let s:request_state = {}
 let s:CRLF = "\r\n"
 
@@ -103,18 +101,17 @@ function! s:Write( method, host, port, uri, headers, data )
     let a:headers[ 'Content-Length' ] = string( len( a:data ) )
   endif
 
-  call ch_sendraw( ch, a:method . ' '. a:uri . ' HTTP/1.1' . s:CRLF )
+  let msg = a:method . ' '. a:uri . ' HTTP/1.1' . s:CRLF
   for h in keys( a:headers )
-    call ch_sendraw( ch, h . ':' . a:headers[ h ] . s:CRLF )
+    let msg .= h . ':' . a:headers[ h ] . s:CRLF
   endfor
-  call ch_sendraw( ch, s:CRLF )
+  let msg .= s:CRLF
   if a:data != v:none
-    call ch_sendraw( ch, a:data )
+    let msg .= a:data
   endif
+  call ch_sendraw( ch, msg )
   return id
 endfunction
-
-" }}}
 
 " This is basic vim plugin boilerplate
 let &cpo = s:save_cpo

--- a/autoload/youcompleteme/http.vim
+++ b/autoload/youcompleteme/http.vim
@@ -37,7 +37,7 @@ endfunction
 " callback on the channel, as this is raised, _after_ this function returns.
 function! youcompleteme#http#Block( id, timeout )
   let ch = s:request_state[ a:id ].handle
-  call ch_setoptions( ch, { 'close_cb': funcref( 's:NullClose' ) } )
+  call ch_setoptions( ch, { 'close_cb': '' } )
   while count( [ 'open', 'buffered' ],  ch_status( ch ) ) == 1
     let data = ch_read( ch, { 'timeout': a:timeout } )
     let s:request_state[ a:id ].data .= data
@@ -51,9 +51,6 @@ let s:CRLF = "\r\n"
 function! s:OnData( channel, msg )
   let id =  ch_info( a:channel ).id
   let s:request_state[ id ].data .= a:msg
-endfunction
-
-function! s:NullClose( channel )
 endfunction
 
 function! s:OnClose( channel )

--- a/autoload/youcompleteme/http9.vim
+++ b/autoload/youcompleteme/http9.vim
@@ -115,11 +115,11 @@ def Reject( id: number, why: string )
         \ vim.eval( 'g:ycm_http9_vars.why' ) )
 enddef
 
-def youcompleteme#http9#GET( host: string,
-                             port: number,
-                             uri: string,
-                             query_string: string,
-                             headers: dict< any  > ): number
+export def GET( host: string,
+                port: number,
+                uri: string,
+                query_string: string,
+                headers: dict< any  > ): number
   return Write( 'GET',
                 host,
                 port,
@@ -129,15 +129,15 @@ def youcompleteme#http9#GET( host: string,
 enddef
 
 
-def youcompleteme#http9#POST( host: string,
-                              port: number,
-                              uri: string,
-                              headers: dict< any >,
-                              data: string ): number
+export def POST( host: string,
+                 port: number,
+                 uri: string,
+                 headers: dict< any >,
+                 data: string ): number
   return Write( 'POST', host, port, uri, headers, data )
 enddef
 
-def youcompleteme#http9#Block( id: number, timeout: number )
+export def Block( id: number, timeout: number )
   const ch = request_state[id].handle
   ch_setoptions( ch, { 'close_cb': '' } )
   while count( [ 'open', 'buffered' ],  ch_status( ch ) ) == 1

--- a/autoload/youcompleteme/http9.vim
+++ b/autoload/youcompleteme/http9.vim
@@ -25,17 +25,14 @@ def Write( method: string,
   const id = ch_info( ch ).id
   request_state[ id ] = { data: '', handle: ch }
 
-  var all_headers = copy( headers )
-  all_headers->extend( {
-    'Host': host,
-    'Connection': 'close',
-    'Accept': 'application/json',
+  var all_headers = copy( headers )->extend( {
+    Host: host,
+    Connection: 'close',
+    Accept: 'application/json',
   } )
 
   if !empty( data )
-    all_headers->extend( {
-      'Content-Length': string( len( data ) )
-    } )
+    all_headers['Content-Length'] = string( len( data ) )
   endif
 
   var msg = method .. ' ' .. uri .. ' HTTP/1.1' .. CRLF
@@ -44,16 +41,13 @@ def Write( method: string,
   endfor
   msg ..= s:CRLF
   msg ..= data
-  call ch_sendraw( ch, msg )
+  ch_sendraw( ch, msg )
   return id
 enddef
 
 def OnData( channel: channel, msg: string )
   const id = ch_info( channel ).id
-  const data = request_state[id].data
-  request_state[id]->extend( {
-    data: data .. msg
-  } )
+  request_state[ id ].data = request_state[ id ].data .. msg
 enddef
 
 def OnClose( channel: channel )
@@ -92,14 +86,14 @@ def Resolve( id: number,
              header_map: dict< string >,
              body: string )
 
-  g:ycm_http9_vars->extend( {
+  g:ycm_http9_vars = {
     id: id,
     status_code: status_code,
     header_map: header_map,
     body: body
-  } )
+  }
 
-  call ch_log( 'Resolve! ' .. string( g:ycm_http9_vars ) )
+  ch_log( 'Resolve! ' .. string( g:ycm_http9_vars ) )
 
   py3 from ycm.client import base_request
   py3 base_request.Future.requests.pop(
@@ -110,10 +104,10 @@ def Resolve( id: number,
 enddef
 
 def Reject( id: number, why: string )
-  g:ycm_http9_vars->extend( {
+  g:ycm_http9_vars = {
     id: id,
     why: why
-  } )
+  }
 
   py3 from ycm.client import base_request
   py3 base_request.Future.requests.pop(
@@ -152,5 +146,3 @@ def youcompleteme#http9#Block( id: number, timeout: number )
   endwhile
   OnClose( ch )
 enddef
-
-defcompile

--- a/autoload/youcompleteme/http9.vim
+++ b/autoload/youcompleteme/http9.vim
@@ -1,0 +1,156 @@
+vim9script
+
+const CRLF = "\r\n"
+let request_state: dict< dict< any > > = {}
+
+
+def Write( method: string,
+           host: string,
+           port: number,
+           uri: string,
+           headers: dict< any  >,
+           data: string ): number
+
+  let ch = ch_open( host .. ':' .. string( port ), #{
+    mode: 'raw',
+    callback: funcref( 's:OnData' ),
+    close_cb: funcref( 's:OnClose' ),
+    waittime: 100,
+  } )
+
+  if ch_status( ch ) != 'open'
+    return 0
+  endif
+
+  let id = ch_info( ch ).id
+  request_state[ id ] = #{ data: '', handle: ch }
+
+  let all_headers = copy( headers )
+  all_headers->extend( {
+    'Host': host,
+    'Connection': 'close',
+    'Accept': 'application/json',
+  } )
+
+  if !empty( data )
+    all_headers->extend( {
+      'Content-Length': string( len( data ) )
+    } )
+  endif
+
+  let msg = method .. ' ' .. uri .. ' HTTP/1.1' .. CRLF
+  for h in keys( all_headers )
+    msg ..= h .. ':' .. all_headers[h] .. CRLF
+  endfor
+  msg ..= s:CRLF
+  msg ..= data
+  call ch_sendraw( ch, msg )
+  return id
+enddef
+
+def OnData( channel: channel, msg: string )
+  let id = ch_info( channel ).id
+  let data = request_state[id].data
+  request_state[id]->extend( #{
+    data: data .. msg
+  } )
+enddef
+
+def OnClose( channel: channel )
+  let id = ch_info( channel ).id
+  let data = request_state[id].data
+  remove( request_state, id )
+
+  let boundary = match( data, CRLF .. CRLF )
+  if boundary < 0
+    Reject( id, "Invalid message received" )
+    return
+  endif
+
+  let header_data = data->strpart( 0, boundary )
+  let body = data->strpart( boundary + 2 * len( CRLF ) )
+
+  let headers = split( header_data, CRLF )
+  let status_line = headers[0]
+  remove( headers, 0 )
+
+  let header_map: dict< string > = {}
+  for header in headers
+    let colon = match( header, ':' )
+    let key = header->strpart( 0, colon )
+    let value = header->strpart( colon + 1 )
+    header_map[ tolower( key ) ] = trim( value )
+  endfor
+
+  let status_code = split( status_line )[1]
+
+  Resolve( id, status_code, header_map, body )
+enddef
+
+def Resolve( id: number,
+             status_code: string,
+             header_map: dict< string >,
+             body: string )
+
+  g:ycm_http9_vars->extend( #{
+    id: id,
+    status_code: status_code,
+    header_map: header_map,
+    body: body
+  } )
+
+  call ch_log( 'Resolve! ' .. string( g:ycm_http9_vars ) )
+
+  py3 from ycm.client import base_request
+  py3 base_request.Future.requests.pop(
+        \ vim.eval( 'g:ycm_http9_vars.id' ) ).resolve(
+          \ int( vim.eval( 'g:ycm_http9_vars.status_code' ) ),
+          \ vim.eval( 'g:ycm_http9_vars.header_map' ),
+          \ vim.eval( 'g:ycm_http9_vars.body' ) )
+enddef
+
+def Reject( id: number, why: string )
+  g:ycm_http9_vars->extend( #{
+    id: id,
+    why: why
+  } )
+
+  py3 from ycm.client import base_request
+  py3 base_request.Future.requests.pop(
+        \ vim.eval( 'g:ycm_http9_vars.id' ) ).reject(
+        \ vim.eval( 'g:ycm_http9_vars.why' ) )
+enddef
+
+def youcompleteme#http9#GET( host: string,
+                             port: number,
+                             uri: string,
+                             query_string: string,
+                             headers: dict< any  > ): number
+  return Write( 'GET',
+                host,
+                port,
+                empty( query_string ) ? uri : uri .. '?' .. query_string,
+                headers,
+                '' )
+enddef
+
+
+def youcompleteme#http9#POST( host: string,
+                              port: number,
+                              uri: string,
+                              headers: dict< any >,
+                              data: string ): number
+  return Write( 'POST', host, port, uri, headers, data )
+enddef
+
+def youcompleteme#http9#Block( id: number, timeout: number )
+  let ch = request_state[id].handle
+  ch_setoptions( ch, { 'close_cb': '' } )
+  while count( [ 'open', 'buffered' ],  ch_status( ch ) ) == 1
+    let data  = ch_read( ch, { 'timeout': timeout } )
+    OnData( ch, data )
+  endwhile
+  OnClose( ch )
+enddef
+
+defcompile

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -71,6 +71,7 @@ elseif &encoding !~? 'utf-\?8'
 endif
 
 let g:loaded_youcompleteme = 1
+let g:ycm_http9_vars = {}
 
 "
 " List of YCM options.

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -43,7 +43,7 @@ class Buffer:
                  ( block or self._parse_request.Done() ) )
 
 
-  def SendParseRequest( self, extra_data ):
+  def SendParseRequest( self, extra_data, handler ):
     # Don't send a parse request if one is in progress
     if self._parse_request is not None and not self._parse_request.Done():
       self._should_resend = True
@@ -53,7 +53,7 @@ class Buffer:
 
     self._parse_request = EventNotification( 'FileReadyToParse',
                                              extra_data = extra_data )
-    self._parse_request.Start()
+    self._parse_request.Start( lambda request_id, request: handler( self ) )
     # Decrement handled tick to ensure correct handling when we are forcing
     # reparse on buffer visit and changed tick remains the same.
     self._handled_tick -= 1

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -161,7 +161,7 @@ class BaseRequest:
                                            request_uri,
                                            sent_data )
       _logger.debug( 'POST %s\n%s\n%s', request_uri, headers, sent_data )
-      request_id  = vimsupport.Call( 'youcompleteme#http#POST',
+      request_id  = vimsupport.Call( 'youcompleteme#http9#POST',
                                      BaseRequest.server_host,
                                      BaseRequest.server_port,
                                      request_uri,
@@ -174,7 +174,7 @@ class BaseRequest:
 
       headers = BaseRequest._ExtraHeaders( method, request_uri )
       _logger.debug( 'GET %s (%s)\n%s', request_uri, query_string, headers )
-      request_id  = vimsupport.Call( 'youcompleteme#http#GET',
+      request_id  = vimsupport.Call( 'youcompleteme#http9#GET',
                                      BaseRequest.server_host,
                                      BaseRequest.server_port,
                                      request_uri,
@@ -227,9 +227,8 @@ class Future:
 
   def result( self ):
     if not self.done():
-      vimsupport.Call( 'youcompleteme#http#Block',
-                       self.request_id,
-                       self._timeout * 1000 )
+      vim.eval( f'youcompleteme#http9#Block( { self.request_id }, '
+                f'                           { self._timeout * 1000 } )' )
 
     assert self.done()
 
@@ -248,6 +247,7 @@ class Future:
 
   def resolve( self, status_code, header_map, data ):
     self._result = Response( status_code, header_map, data )
+    vimsupport.Log( f'Result! { self._result }' )
     self._done = True
     for f in self._on_complete_handlers:
       f( self )
@@ -340,7 +340,10 @@ def _JsonFromFuture( future ):
   response.raise_for_status()
 
   if response.text:
+    vimsupport.Log( 'To JSON!!' )
     return response.json()
+
+  vimsupport.Log( 'NONE!' )
   return None
 
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -33,8 +33,10 @@ _READ_TIMEOUT_SEC = 5
 _HMAC_HEADER = 'x-ycm-hmac'
 _logger = logging.getLogger( __name__ )
 
-_HTTP_INTERFACE = 'http9'
-# _HTTP_INTERFACE = 'http'
+import os
+
+# _HTTP_INTERFACE = 'http9'
+_HTTP_INTERFACE = os.environ.get( 'YCM_HTTP_INTERFACE', 'http' )
 
 
 class YCMConnectionError( Exception ):

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -36,6 +36,7 @@ _logger = logging.getLogger( __name__ )
 # _HTTP_INTERFACE = 'http9'
 _HTTP_INTERFACE = 'http'
 
+
 class YCMConnectionError( Exception ):
   pass
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -33,8 +33,8 @@ _READ_TIMEOUT_SEC = 5
 _HMAC_HEADER = 'x-ycm-hmac'
 _logger = logging.getLogger( __name__ )
 
-# _HTTP_INTERFACE = 'http9'
-_HTTP_INTERFACE = 'http'
+_HTTP_INTERFACE = 'http9'
+# _HTTP_INTERFACE = 'http'
 
 
 class YCMConnectionError( Exception ):

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -33,6 +33,9 @@ _READ_TIMEOUT_SEC = 5
 _HMAC_HEADER = 'x-ycm-hmac'
 _logger = logging.getLogger( __name__ )
 
+# _HTTP_INTERFACE = 'http9'
+_HTTP_INTERFACE = 'http'
+
 class YCMConnectionError( Exception ):
   pass
 
@@ -161,7 +164,7 @@ class BaseRequest:
                                            request_uri,
                                            sent_data )
       _logger.debug( 'POST %s\n%s\n%s', request_uri, headers, sent_data )
-      request_id  = vimsupport.Call( 'youcompleteme#http9#POST',
+      request_id  = vimsupport.Call( f'youcompleteme#{_HTTP_INTERFACE}#POST',
                                      BaseRequest.server_host,
                                      BaseRequest.server_port,
                                      request_uri,
@@ -174,7 +177,7 @@ class BaseRequest:
 
       headers = BaseRequest._ExtraHeaders( method, request_uri )
       _logger.debug( 'GET %s (%s)\n%s', request_uri, query_string, headers )
-      request_id  = vimsupport.Call( 'youcompleteme#http9#GET',
+      request_id  = vimsupport.Call( f'youcompleteme#{_HTTP_INTERFACE}#GET',
                                      BaseRequest.server_host,
                                      BaseRequest.server_port,
                                      request_uri,
@@ -227,8 +230,12 @@ class Future:
 
   def result( self ):
     if not self.done():
-      vim.eval( f'youcompleteme#http9#Block( { self.request_id }, '
-                f'                           { self._timeout * 1000 } )' )
+      # We have to use this to make sure they are passed as ints, as
+      # vimsupport.Call will pass ints as strings due to annoying if_python
+      # behaviour
+      vim.eval( f'youcompleteme#{_HTTP_INTERFACE}#Block( '
+                f'  { self.request_id }, '
+                f'  { self._timeout * 1000 } )' )
 
     assert self.done()
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -29,7 +29,7 @@ from ycmd.responses import ServerError, UnknownExtraConf
 HTTP_SERVER_ERROR = 500
 
 _HEADERS = { 'content-type': 'application/json' }
-_READ_TIMEOUT_SEC = 30
+_READ_TIMEOUT_SEC = 5
 _HMAC_HEADER = 'x-ycm-hmac'
 _logger = logging.getLogger( __name__ )
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -392,7 +392,7 @@ def _ValidateResponseObject( response, response_text ):
 
 
 def _BuildUri( handler ):
-  return ToBytes( urljoin( BaseRequest.server_location, handler ) )
+  return ToBytes( '/' + handler )
 
 
 def MakeServerException( data ):

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -34,9 +34,12 @@ class CompletionRequest( BaseRequest ):
     self._response_future = None
 
 
-  def Start( self ):
+  def Start( self, request_handler ):
     self._response_future = self.PostDataToHandlerAsync( self.request_data,
                                                          'completions' )
+    self._response_future.add_complete_handler(
+      lambda future: request_handler( future.request_id, self ) )
+    return self._response_future.request_id
 
 
   def Done( self ):

--- a/python/ycm/client/event_notification.py
+++ b/python/ycm/client/event_notification.py
@@ -28,7 +28,7 @@ class EventNotification( BaseRequest ):
     self._cached_response = None
 
 
-  def Start( self ):
+  def Start( self, handler = None ):
     request_data = BuildRequestData( self._buffer_number )
     if self._extra_data:
       request_data.update( self._extra_data )
@@ -36,6 +36,9 @@ class EventNotification( BaseRequest ):
 
     self._response_future = self.PostDataToHandlerAsync( request_data,
                                                          'event_notification' )
+    if handler:
+      self._response_future.add_complete_handler(
+        lambda future: handler( future.request_id, self ) )
 
 
   def Done( self ):

--- a/python/ycm/client/omni_completion_request.py
+++ b/python/ycm/client/omni_completion_request.py
@@ -24,8 +24,10 @@ class OmniCompletionRequest( CompletionRequest ):
     self._omni_completer = omni_completer
 
 
-  def Start( self ):
+  def Start( self, handler ):
     self._results = self._omni_completer.ComputeCandidates( self.request_data )
+    handler( 0, self )
+    return 0
 
 
   def Done( self ):

--- a/python/ycm/client/signature_help_request.py
+++ b/python/ycm/client/signature_help_request.py
@@ -37,9 +37,12 @@ class SignatureHelpRequest( BaseRequest ):
     self._response = None
 
 
-  def Start( self ):
+  def Start( self, handler ):
     self._response_future = self.PostDataToHandlerAsync( self.request_data,
                                                          'signature_help' )
+    self._response_future.add_complete_handler(
+      lambda future: handler( future.request_id, self ) )
+    return self._response_future.request_id
 
 
   def Done( self ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1388,3 +1388,17 @@ def BuildQfListItem( goto_data_item ):
     qf_item[ 'col' ] = goto_data_item[ 'column_num' ]
 
   return qf_item
+
+
+def Call( vimscript_function, *args ):
+  call = vimscript_function + '('
+  for index, arg in enumerate( args ):
+    if index > 0:
+      call += ', '
+
+    arg_name = f'_ycm_internal_arg_{ index }'
+    vim.vars[ arg_name ] = arg
+    call += 'g:' + arg_name
+
+  call += ')'
+  return vim.eval( call )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1402,3 +1402,7 @@ def Call( vimscript_function, *args ):
 
   call += ')'
   return vim.eval( call )
+
+
+def Log( message ):
+  Call( 'ch_log', message )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -426,35 +426,45 @@ class YouCompleteMe:
                           has_range,
                           start_line,
                           end_line ):
-    final_arguments, extra_data = self._GetCommandRequestArguments(
-      arguments,
-      has_range,
-      start_line,
-      end_line )
-    return SendCommandRequest(
-      final_arguments,
-      modifiers,
-      self._user_options[ 'goto_buffer_command' ],
-      extra_data )
+    final_arguments, extra_data = self._GetCommandRequestArguments( arguments,
+                                                                    has_range,
+                                                                    start_line,
+                                                                    end_line )
+    return SendCommandRequest( final_arguments,
+                               modifiers,
+                               self._user_options[ 'goto_buffer_command' ],
+                               extra_data )
 
 
   def GetCommandResponse( self, arguments ):
-    final_arguments, extra_data = self._GetCommandRequestArguments(
-      arguments,
-      False,
-      0,
-      0 )
+    final_arguments, extra_data = self._GetCommandRequestArguments( arguments,
+                                                                    False,
+                                                                    0,
+                                                                    0 )
     return GetCommandResponse( final_arguments, extra_data )
 
 
-  def SendCommandRequestAsync( self, arguments ):
-    final_arguments, extra_data = self._GetCommandRequestArguments(
-      arguments,
-      False,
-      0,
-      0 )
-    self._latest_command_reqeust = SendCommandRequestAsync( final_arguments,
-                                                            extra_data )
+  def SendCommandRequestAsync( self, raw, arguments ):
+    final_arguments, extra_data = self._GetCommandRequestArguments( arguments,
+                                                                    False,
+                                                                    0,
+                                                                    0 )
+
+    def handler( request_id, request ):
+      if raw:
+        result = request.Response()
+      else:
+        result = request.StringResponse()
+
+      vimsupport.Call( 'youcompleteme#OnCommandRequestDone',
+                       request_id,
+                       result )
+
+    request_id, _ = SendCommandRequestAsync( final_arguments,
+                                             handler = handler,
+                                             extra_data = extra_data,
+                                             silent = True )
+    return request_id
 
 
   def GetCommandRequest( self ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -142,6 +142,8 @@ class YouCompleteMe:
     server_port = utils.GetUnusedLocalhostPort()
 
     BaseRequest.server_location = 'http://127.0.0.1:' + str( server_port )
+    BaseRequest.server_host = '127.0.0.1'
+    BaseRequest.server_port = server_port
     BaseRequest.hmac_secret = hmac_secret
 
     try:

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -227,6 +227,7 @@ class YouCompleteMe:
     if not self._server_is_ready_with_cache and self.IsServerAlive():
       self._server_is_ready_with_cache = BaseRequest().GetDataFromHandler(
           'ready', display_message = False )
+      vimsupport.Log( f'ready? { self._server_is_ready_with_cache }' )
     return self._server_is_ready_with_cache
 
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -346,7 +346,7 @@ class YouCompleteMe:
     """Send a signature help request, if we're ready to. Return whether or not a
     request was sent (and should be checked later)"""
     if not self.NativeFiletypeCompletionUsable():
-      return False
+      return -1
 
     for filetype in vimsupport.CurrentFiletypes():
       if not self.SignatureHelpAvailableRequestComplete( filetype ):
@@ -363,7 +363,7 @@ class YouCompleteMe:
         continue
 
       if not self._latest_completion_request:
-        return False
+        return -1
 
       request_data = self._latest_completion_request.request_data.copy()
       request_data[ 'signature_help_state' ] = self._signature_help_state.state
@@ -371,19 +371,13 @@ class YouCompleteMe:
       self._AddExtraConfDataIfNeeded( request_data )
 
       self._latest_signature_help_request = SignatureHelpRequest( request_data )
-      self._latest_signature_help_request.Start()
-      return True
+      return self._latest_signature_help_request.Start(
+        lambda request_id, request: vimsupport.Call(
+          'youcompleteme#OnSignatureHelpRequestDone',
+          request_id,
+          request.Response() ) )
 
-    return False
-
-
-  def SignatureHelpRequestReady( self ):
-    return bool( self._latest_signature_help_request and
-                 self._latest_signature_help_request.Done() )
-
-
-  def GetSignatureHelpResponse( self ):
-    return self._latest_signature_help_request.Response()
+    return -1
 
 
   def ClearSignatureHelp( self ):

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -114,7 +114,7 @@ function! Test_MessagePoll_After_LocationList()
   call setline( 1, '' )
   " Wait for the parse request to be complete otherwise we won't send another
   " one when the TextChanged event fires
-  call WaitFor( {-> pyxeval( 'ycm_state.FileParseRequestReady()' ) } )
+  call WaitFor( {-> pyxeval( 'ycm_state.CurrentBuffer().FileParseRequestReady()' ) } )
   doautocmd TextChanged
   call WaitForAssert( {-> assert_true( empty( sign_getplaced(
                         \ '%',

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -91,7 +91,7 @@ endfunction
 function! TearDown()
   let g:ycm_auto_hover='CursorHold'
 
-  call assert_equal( -1, youcompleteme#Test_GetPollers().command.id )
+  call s:WaitForCommandRequestComplete()
 endfunction
 
 function! Test_Hover_Uses_GetDoc()

--- a/test/lib/autoload/youcompleteme/test/commands.vim
+++ b/test/lib/autoload/youcompleteme/test/commands.vim
@@ -1,26 +1,17 @@
 function! youcompleteme#test#commands#WaitForCommandRequestComplete() abort
   call WaitForAssert( { ->
-        \ assert_true( py3eval(
-        \     'ycm_state.GetCommandRequest() is not None and '
-        \   . 'ycm_state.GetCommandRequest().Done()' ) )
-        \ } )
-
-  call WaitForAssert( { ->
-        \ assert_equal( -1,
-        \               youcompleteme#Test_GetPollers().command.id )
+        \ assert_false( youcompleteme#IsRequestPending( 'command' ) )
         \ } )
 endfunction
 
 function! youcompleteme#test#commands#CheckNoCommandRequest() abort
   call WaitForAssert( { ->
-        \ assert_true( py3eval(
-        \     'ycm_state.GetCommandRequest() is None or '
-        \   . 'ycm_state.GetCommandRequest().Done()' ) )
+        \ assert_false( youcompleteme#IsRequestPending( 'command' ) )
         \ } )
 
   call WaitForAssert( { ->
-        \ assert_equal( -1,
-        \               youcompleteme#Test_GetPollers().command.id )
+        \ assert_equal( v:null,
+        \               youcompleteme#Test_GetRequests().command.callback )
         \ } )
 endfunction
 

--- a/test/lib/plugin/completion.vim
+++ b/test/lib/plugin/completion.vim
@@ -85,12 +85,8 @@ endfunction
 
 function! WaitForCompletion()
   call WaitForAssert( {->
-        \ assert_true( pyxeval( 'ycm_state.GetCurrentCompletionRequest() is not None' ) )
-        \ } )
-  call WaitForAssert( {->
-        \ assert_true( pyxeval( 'ycm_state.CompletionRequestReady()' ) )
-        \ } )
-  redraw
+        \ assert_false( youcompleteme#IsCompletionPending_() )
+        \ }, 10000 )
   call WaitForAssert( {->
         \ assert_true( pumvisible(), 'pumvisible()' )
         \ }, 10000 )

--- a/test/lib/plugin/completion.vim
+++ b/test/lib/plugin/completion.vim
@@ -85,10 +85,9 @@ endfunction
 
 function! WaitForCompletion()
   call WaitForAssert( {->
-        \ assert_false( youcompleteme#IsCompletionPending_() )
+        \ assert_false( youcompleteme#IsRequestPending( 'completion' ) )
         \ }, 10000 )
   call WaitForAssert( {->
         \ assert_true( pumvisible(), 'pumvisible()' )
         \ }, 10000 )
 endfunction
-

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -31,12 +31,7 @@ endfunction
 
 function s:_GetSigHelpWinID()
   call WaitForAssert( {->
-        \   assert_true(
-        \     pyxeval(
-        \       'ycm_state.SignatureHelpRequestReady()'
-        \     ),
-        \     'sig help request reqdy'
-        \   )
+        \   assert_false( youcompleteme#IsRequestPending( 'signature_help' ) )
         \ } )
   call WaitForAssert( {->
         \   assert_true(
@@ -126,20 +121,7 @@ function! Test_Signatures_After_Trigger()
   " neater in many contexts).
   function! Check( id ) closure
     call WaitForAssert( {->
-          \   assert_true(
-          \     pyxeval(
-          \       'ycm_state.SignatureHelpRequestReady()'
-          \     ),
-          \     'sig help request ready'
-          \   )
-          \ } )
-    call WaitForAssert( {->
-          \   assert_true(
-          \     pyxeval(
-          \       "bool( ycm_state.GetSignatureHelpResponse()[ 'signatures' ] )"
-          \     ),
-          \     'sig help request has signatures'
-          \   )
+          \   assert_false( youcompleteme#IsRequestPending( 'signature_help' ) )
           \ } )
     call WaitForAssert( {->
           \   assert_true(
@@ -159,7 +141,7 @@ function! Test_Signatures_After_Trigger()
     call feedkeys( "\<ESC>" )
   endfunction
 
-  call assert_false( pyxeval( 'ycm_state.SignatureHelpRequestReady()' ) )
+  call assert_false( youcompleteme#IsRequestPending( 'signature_help' ) )
   call timer_start( s:timer_interval, funcref( 'Check' ) )
   call feedkeys( 'cl(', 'ntx!' )
   call assert_false( pumvisible(), 'pumvisible()' )
@@ -235,7 +217,7 @@ function! Test_Signatures_With_PUM_NoSigns()
     call feedkeys( ' TypeOfD', 't' )
   endfunction
 
-  call assert_false( pyxeval( 'ycm_state.SignatureHelpRequestReady()' ) )
+  call assert_false( youcompleteme#IsRequestPending( 'signature_help' ) )
   call timer_start( s:timer_interval, funcref( 'Check' ) )
   call feedkeys( 'C(', 'ntx!' )
 
@@ -314,7 +296,7 @@ function! Test_Signatures_With_PUM_Signs()
     call feedkeys( ' TypeOfD', 't' )
   endfunction
 
-  call assert_false( pyxeval( 'ycm_state.SignatureHelpRequestReady()' ) )
+  call assert_false( youcompleteme#IsRequestPending( 'signature_help' ) )
   call timer_start( s:timer_interval, funcref( 'Check' ) )
   call feedkeys( 'C(', 'ntx!' )
 


### PR DESCRIPTION
## Summary 

This change:

- removes the requests library and its dependencies
- removes the poll timers for most things (including completion, signature help, etc.)
- replaces their use with a simple http implementation using a vim channel and some callbacks

There's both a legacy vimscript and vim9script implementation of http layer. The vim9script is too buggy to use right now (does't work with if_python3), but this is still an experiment so keeping anything that might be useful. e.g. we might support both _shrug_.

## Advantages

- no more polling means that we don't have to wake up and do "stuff" every 10ms/100ms just to check for new messages, completions, etc. this is not only better for performance, but it's better for power usage, battery life etc, and will likely prevent some issues related to popups and things we've seen recently.
- fewer dependencies
- smaller repo/install size

## Caveats

- doesn't work in neovim
- there are some random vim `s:` (script context) misfires that happen if you leave vim running overnight. it leads to largely harmless tracebacks
- not all pollers have been removed

## Detail

### HTTP implementation

This is a very simple, asynchronous, minimal implementation required to communicate with ycmd based on this test lib: https://github.com/puremourning/restful.vim.

It has a simple API of `GET` and `POST` requests, returning a request ID token. You can also call `Block` to wait synchronously for a response given an ID.

### Response handling

In order to minimise the code changes, the python layer mocks up the future types returned from requests. The vimscript layer calls into that to "resolve" the future (or "reject" it), and this in turn triggers a callback in the calling code:

```viml
function! s:Resolve( id, status_code, header_map, body )
  py3 << EOF
from ycm.client import base_request
base_request.Future.requests.pop( vim.eval( 'a:id' ) ).resolve(
  int( vim.eval( 'a:status_code' ) ),
  vim.eval( 'a:header_map' ),
  vim.eval( 'a:body' ) )
EOF
endfunction
```

This interacts with a `Future` class in `base_request` which contains a map of outstanding requests, each of which having a list of callbacks to call on completion. It basically implements the same API as `concurrent.futures`.

### How this is used

Previously to make an async call we would:

* Make the call
* Create a timer to poll for a result
* Poll by asking if the `future.done()`
* If we want to block for the result, call `future.result()`

Now, instead:

* Make the call, passing a callable to be called when the response is ready.
* If we want to block for the result, call `future.result()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3792)
<!-- Reviewable:end -->
