### PR TITLE
Remove claims of 'ExecuteCommand' support for Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,6 @@ Quick Feature Summary
 * Type information for identifiers (`GetType`)
 * Renaming symbols (`RefactorRename <new name>`)
 * Code formatting (`Format`)
-* Execute custom server command (`ExecuteCommand <args>`)
 * Management of `rust-analyzer` server instance
 
 ### Java
@@ -1998,10 +1997,9 @@ flags.
 
 #### The `ExecuteCommand <args>` subcommand
 
-Some LSP completers (currently Rust and Java completers) support executing
-server specific commands. Consult the [rust-analyzer][] and [jdt.ls][] respective
-documentations to find out what commands are supported and which arguments are
-expected.
+Some LSP completers (currently only Java completers) support executing
+server specific commands. Consult the [jdt.ls][] documentation to find out
+what commands are supported and which arguments are expected.
 
 The support for `ExecuteCommand` was implemented to support plugins like
 [vimspector][] to debug java, but isn't limited to that specific use case.

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -923,7 +923,6 @@ Rust ~
 - Type information for identifiers (|GetType|)
 - Renaming symbols ('RefactorRename <new name>')
 - Code formatting (|Format|)
-- Execute custom server command ('ExecuteCommand <args>')
 - Management of 'rust-analyzer' server instance
 
 -------------------------------------------------------------------------------
@@ -2220,10 +2219,9 @@ flags.
                                                           *ExecuteCommand-args*
 The 'ExecuteCommand <args>' subcommand ~
 
-Some LSP completers (currently Rust and Java completers) support executing
-server specific commands. Consult the rust-analyzer [15] and jdt.ls [16]
-respective documentations to find out what commands are supported and which
-arguments are expected.
+Some LSP completers (currently only Java completers) support executing
+server specific commands. Consult the jdt.ls [16] documentation to find out
+what commands are supported and which arguments are expected.
 
 The support for 'ExecuteCommand' was implemented to support plugins like
 vimspector [73] to debug java, but isn't limited to that specific use case.


### PR DESCRIPTION
The :help pages and README claimed that rust-analyzer supports the
'ExecuteCommand <args>' subcommand, though this is not the case.
Fixes #3796 .

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The previous docs were misleading / incorrect.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3797)
<!-- Reviewable:end -->
