### PR TITLE
Disable mergify smart mode; just let it keep trying

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: smart
+        strict: true
       comment:
         message: Thanks for sending a PR!
   - name: Manual merge on Azure Pipelines and Maintainer Override
@@ -22,6 +22,6 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: smart
+        strict: true
       comment:
         message: Thanks for sending a PR!


### PR DESCRIPTION
Smart mode sometimes leads to queues of PRs. Our CI time isn't really that much of a problem, particularly on this repo, so switch to simple strict mode, rather than smart strict mode:

the difference:

* Simple: The pull request will be merged only once up-to-date with its base branch. When multiple pull requests are ready to be merged, they will all be updated with their base branch at the same time, and the first ready to be merged will be merged; the remaining pull request will be updated once again.
* smart: enables Strict Merge but only update one pull request against its base branch at a time. This allows you to e.g., save CI time, as Mergify will queue the mergeable pull requests and update them serially, one at a time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3801)
<!-- Reviewable:end -->
