### PR TITLE
Disable YCM in prompt buffers as well

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -65,6 +65,7 @@ let s:buftype_blacklist = {
       \   'terminal': 1,
       \   'quickfix': 1,
       \   'popup': 1,
+      \   'prompt': 1,
       \   'nofile': 1,
       \ }
 let s:last_char_inserted_by_user = v:true


### PR DESCRIPTION
In my usecase this is a REPL buffer that's often updated, and so
UpdateMatches() causes quite some CPU load that can be avoided.

No test included; extended a configuration dictionary, the
performance changes aren't a 10-line-test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3810)
<!-- Reviewable:end -->
