### PR TITLE
[READY] Avoid a race condition between async diagnostics and FileReadyToParse

### DIFF
--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -19,9 +19,6 @@ from ycm import vimsupport
 from ycm.client.event_notification import EventNotification
 from ycm.diagnostic_interface import DiagnosticInterface
 
-DIAGNOSTIC_UI_FILETYPES = { 'cpp', 'cs', 'c', 'objc', 'objcpp', 'cuda',
-                            'javascript', 'typescript', 'typescriptreact' }
-
 
 # Emulates Vim buffer
 # Used to store buffer related information like diagnostics, latest parse
@@ -73,7 +70,7 @@ class Buffer:
 
   def UpdateDiagnostics( self, force = False ):
     if force or not self._async_diags:
-      self.UpdateWithNewDiagnostics( self._parse_request.Response() )
+      self.UpdateWithNewDiagnostics( self._parse_request.Response(), False )
     else:
       # We need to call the response method, because it might throw an exception
       # or require extra config confirmation, even if we don't actually use the
@@ -81,7 +78,8 @@ class Buffer:
       self._parse_request.Response()
 
 
-  def UpdateWithNewDiagnostics( self, diagnostics ):
+  def UpdateWithNewDiagnostics( self, diagnostics, async_message ):
+    self._async_diags = async_message
     self._diag_interface.UpdateWithNewDiagnostics( diagnostics )
 
 
@@ -119,8 +117,8 @@ class Buffer:
 
   def UpdateFromFileTypes( self, filetypes ):
     self._filetypes = filetypes
-    self._async_diags = not any( x in DIAGNOSTIC_UI_FILETYPES
-      for x in filetypes )
+    # We will set this to true if we ever receive any diagnostics asyncronously.
+    self._async_diags = False
 
 
   def _ChangedTick( self ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -491,7 +491,7 @@ class YouCompleteMe:
       # Note: We only update location lists, etc. for visible buffers, because
       # otherwise we default to using the current location list and the results
       # are that non-visible buffer errors clobber visible ones.
-      self._buffers[ bufnr ].UpdateWithNewDiagnostics( diagnostics )
+      self._buffers[ bufnr ].UpdateWithNewDiagnostics( diagnostics, True )
     else:
       # The project contains errors in file "filepath", but that file is not
       # open in any buffer. This happens for Language Server Protocol-based
@@ -674,7 +674,9 @@ class YouCompleteMe:
       if self._user_options[ 'show_diagnostics_ui' ]:
         # Forcefuly update the location list, etc. from the parse request when
         # doing something like :YcmDiags
-        current_buffer.UpdateDiagnostics( block )
+        async_diags = any( self._message_poll_requests.get( filetype )
+                           for filetype in vimsupport.CurrentFiletypes() )
+        current_buffer.UpdateDiagnostics( block or not async_diags )
       else:
         # If the user disabled diagnostics, we just want to check
         # the _latest_file_parse_request for any exception or UnknownExtraConf

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -21,7 +21,7 @@ function! Test_Changing_Filetype_Refreshes_Diagnostics()
         \ { 'native_ft': 0 } )
 
   call assert_equal( 'xml', &ft )
-  call assert_true( pyxeval( 'ycm_state._buffers[' . bufnr( '%' ) . ']._async_diags' ) )
+  call assert_false( pyxeval( 'ycm_state._buffers[' . bufnr( '%' ) . ']._async_diags' ) )
   call assert_equal( [], sign_getplaced() )
   setf typescript
   call assert_equal( 'typescript', &ft )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Previously it was possible for the following scenario to happen:

1. Async message: `[diags]`
2. Async message: `[]`
3. FileReadyToParse: `[diags]`

In this case, YCM would show stale diagnostics that don't correspond to
the current state of the buffer any more.

No tests because... how do I test a race condition?

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3845)
<!-- Reviewable:end -->
