### PR TITLE
[READY] Handle None response in case of error

### DIFF
--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -170,6 +170,8 @@ class CommandRequest( BaseRequest ):
           self._request_data.update( { 'fixit': chosen_fixit } )
           response = self.PostDataToHandler( self._request_data,
                                              'resolve_fixit' )
+          if response is None:
+            return
           fixits = response[ 'fixits' ]
           assert len( fixits ) == 1
           chosen_fixit = fixits[ 0 ]


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

@Aster89 showed that we're not handling `None` in this case.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3847)
<!-- Reviewable:end -->
