### PR TITLE
Fix refactoring bug

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -610,6 +610,19 @@ def ReplaceChunk_BeyondEndOfFile_test():
   AssertBuffersAreEqualAsBytes( [ 'first line' ], result_buffer )
 
 
+@patch( 'vim.current.window.cursor', ( 1, 1 ) )
+def ReplaceChunk_FileAppend_test():
+  result_buffer = VimBuffer( 'buffer', contents = [ 'first line',
+                                                    'second line' ] )
+  start, end = _BuildLocations( 4, 11, 4, 1 )
+  vimsupport.ReplaceChunk( start, end, 'third line', result_buffer )
+
+  AssertBuffersAreEqualAsBytes( [ 'first line',
+                                   'second line',
+                                   '',
+                                   'third line' ], result_buffer )
+
+
 @patch( 'vim.current.window.cursor', ( 1, 3 ) )
 def ReplaceChunk_CursorPosition_test():
   result_buffer = VimBuffer( 'buffer', contents = [ 'bar' ] )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -987,13 +987,21 @@ def ReplaceChunk( start, end, replacement_text, vim_buffer ):
   # so we convert to bytes
   replacement_lines = SplitLines( ToBytes( replacement_text ) )
 
-  # NOTE: Vim buffers are a list of unicode objects on Python 3.
-  start_existing_text = ToBytes( vim_buffer[ start_line ] )[ : start_column ]
-  end_line_text = ToBytes( vim_buffer[ end_line ] )
-  end_existing_text = end_line_text[ end_column : ]
+  # Ensure the Vim buffer has the required line numbers in case text should be
+  # placed on line numbers beyond the current boundaries (typically when text
+  # needs to be appended to the buffer).
+  if start_line >= len( vim_buffer ):
+    end_line = start_line
+    padding = start_line - len( vim_buffer )
+    vim_buffer[ len( vim_buffer ) : ] = [ '' ] * padding
+  else:
+    # NOTE: Vim buffers are a list of unicode objects on Python 3.
+    start_existing_text = ToBytes( vim_buffer[ start_line ] )[ : start_column ]
+    end_line_text = ToBytes( vim_buffer[ end_line ] )
+    end_existing_text = end_line_text[ end_column : ]
 
-  replacement_lines[ 0 ] = start_existing_text + replacement_lines[ 0 ]
-  replacement_lines[ -1 ] = replacement_lines[ -1 ] + end_existing_text
+    replacement_lines[ 0 ] = start_existing_text + replacement_lines[ 0 ]
+    replacement_lines[ -1 ] = replacement_lines[ -1 ] + end_existing_text
 
   cursor_line, cursor_column = CurrentLineAndColumn()
 

--- a/test/fixit.test.vim
+++ b/test/fixit.test.vim
@@ -53,3 +53,36 @@ function! Test_Unresolved_Fixit_Works()
   %bwipeout!
   delfunction SelectEntry
 endfunction
+
+function! Test_Move_Out_Of_Line_Fixit_Works()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/move_out_of_line_fixit.cpp', {} )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/move_out_of_line_fixit.hpp', {} )
+
+  call setpos( '.', [ 0, 1, 6 ] )
+  call assert_equal( 'void f() {', getline( '.' ) )
+  function! SelectEntry( id ) closure
+    redraw
+    call test_feedinput( "2\<CR>" )
+  endfunction
+  function! ConfirmOpen( id ) closure
+    redraw
+    call test_feedinput( "O\<CR>" )
+  endfunction
+  call timer_start( 5000, funcref( 'SelectEntry' ) )
+  call timer_start( 7000, funcref( 'ConfirmOpen' ) )
+  YcmCompleter FixIt
+  redraw
+  call assert_equal( 'void f();', getline( 1 ) )
+
+  bnext!
+
+  call assert_equal( 'void f() {', getline( 2 ) )
+  call assert_equal( '  // hey im a function', getline( 3 ) )
+  call assert_equal( '}', getline( 4 ) )
+  %bwipeout!
+  %bwipeout!
+  messages clear
+
+  delfunction SelectEntry
+  delfunction ConfirmOpen
+endfunction

--- a/test/testdata/cpp/move_out_of_line_fixit.cpp
+++ b/test/testdata/cpp/move_out_of_line_fixit.cpp
@@ -1,0 +1,1 @@
+#include "move_out_of_line_fixit.hpp"

--- a/test/testdata/cpp/move_out_of_line_fixit.hpp
+++ b/test/testdata/cpp/move_out_of_line_fixit.hpp
@@ -1,0 +1,3 @@
+void f() {
+    // hey im a function
+}


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

Hi, just wanted to submit a patch for the FixIt refactoring. To be more specific, clangd will provide a FixIt suggestion labeled "Move function body to out-of-line" when a class function is defined in a header and is eligible to move to the implementation file. Which is very useful when writing C++ and is found in most other editors. However this FixIt suggestion throws an "IndexError" exception upon use in vimsupport.py:ReplaceChunk because clangd issues the content to be placed at the end of the buffer on a line that doesn't exist yet. My patch just creates empty lines up until the line requested in this event so that the line number / index can be valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3850)
<!-- Reviewable:end -->
