### PR TITLE
[READY] Fix auto imports when resolving completions on-demand

### DIFF
--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -65,7 +65,7 @@ function! Test_Select_Next_Previous()
     call WaitForCompletion()
 
     call CheckCurrentLine( '  foo.' )
-    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCompletionItemsContainsExactly( [ 'c', 'x', 'y' ] )
 
     call FeedAndCheckAgain( "\<Tab>", funcref( 'Check2' ) )
   endfunction
@@ -73,7 +73,7 @@ function! Test_Select_Next_Previous()
   function! Check2( id )
     call WaitForCompletion()
     call CheckCurrentLine( '  foo.c' )
-    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCompletionItemsContainsExactly( [ 'c', 'x', 'y' ] )
 
     call FeedAndCheckAgain( "\<Tab>", funcref( 'Check3' ) )
   endfunction
@@ -81,7 +81,7 @@ function! Test_Select_Next_Previous()
   function! Check3( id )
     call WaitForCompletion()
     call CheckCurrentLine( '  foo.x' )
-    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCompletionItemsContainsExactly( [ 'c', 'x', 'y' ] )
 
     call FeedAndCheckAgain( "\<BS>y", funcref( 'Check4' ) )
   endfunction
@@ -89,7 +89,7 @@ function! Test_Select_Next_Previous()
   function! Check4( id )
     call WaitForCompletion()
     call CheckCurrentLine( '  foo.y' )
-    call CheckCompletionItems( [ 'y' ] )
+    call CheckCompletionItemsContainsExactly( [ 'y' ] )
     call feedkeys( "\<ESC>" )
   endfunction
 
@@ -112,13 +112,13 @@ function! Test_Enter_Delete_Chars_Updates_Filter()
 
   function! Check1( id )
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'colourOfLine', 'lengthOfLine' ] )
+    call CheckCompletionItemsContainsExactly( [ 'colourOfLine', 'lengthOfLine' ] )
     call FeedAndCheckAgain( "\<BS>", funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
     call WaitForCompletion()
-    call CheckCompletionItems( [
+    call CheckCompletionItemsContainsExactly( [
           \ 'operator=(…)',
           \ 'colourOfLine',
           \ 'lengthOfLine',
@@ -128,7 +128,7 @@ function! Test_Enter_Delete_Chars_Updates_Filter()
 
   function! Check3( id )
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'RED_AND_YELLOW' ] )
+    call CheckCompletionItemsContainsExactly( [ 'RED_AND_YELLOW' ] )
     " now type something that doesnt match
     call FeedAndCheckAgain( 'this_does_not_match', funcref( 'Check4' ) )
   endfunction
@@ -137,7 +137,7 @@ function! Test_Enter_Delete_Chars_Updates_Filter()
     call WaitForAssert( { -> assert_false( pumvisible() ) } )
     call CheckCurrentLine(
           \ '  p->line.colourOfLine = Line::owthis_does_not_match' )
-    call CheckCompletionItems( [] )
+    call CheckCompletionItemsContainsExactly( [] )
     call feedkeys( "\<Esc>" )
   endfunction
 
@@ -248,28 +248,29 @@ function! Test_OmniComplete_Filter()
   function! Check1( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'te:te' )
-    call CheckCompletionItems( [ 'test', 'testy', 'testing' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'test', 'testy', 'testing' ],
+                                            \ 'word' )
     call FeedAndCheckAgain( 'y', funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'te:tey' )
-    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'testy' ], 'word' )
     call FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
   endfunction
 
   function! Check3( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'te:testy' )
-    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'testy' ], 'word' )
     call FeedAndCheckAgain( "\<C-p>", funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'te:tey' )
-    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'testy' ], 'word' )
     call feedkeys( "\<Esc>" )
   endfunction
 
@@ -293,28 +294,29 @@ function! Test_OmniComplete_Force()
   function! Check1( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'te' )
-    call CheckCompletionItems( [ 'test', 'testy', 'testing' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'test', 'testy', 'testing' ],
+                                            \ 'word' )
     call FeedAndCheckAgain( 'y', funcref( 'Check2' ) )
   endfunction
 
   function! Check2( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'tey' )
-    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'testy' ], 'word' )
     call FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
   endfunction
 
   function! Check3( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'testy' )
-    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'testy' ], 'word' )
     call FeedAndCheckAgain( "\<C-p>", funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'tey' )
-    call CheckCompletionItems( [ 'testy' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'testy' ], 'word' )
     call feedkeys( "\<Esc>" )
   endfunction
 
@@ -337,7 +339,7 @@ function! Test_Completion_FixIt()
   function Check1( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'do_a' )
-    call CheckCompletionItems( [ 'do_a_thing(Thing thing)',
+    call CheckCompletionItemsContainsExactly( [ 'do_a_thing(Thing thing)',
                                  \ 'do_another_thing()' ] )
     call FeedAndCheckAgain( "\<Tab>" , funcref( 'Check2' ) )
   endfunction
@@ -345,7 +347,7 @@ function! Test_Completion_FixIt()
   function Check2( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'do_a_thing' )
-    call CheckCompletionItems( [ 'do_a_thing(Thing thing)',
+    call CheckCompletionItemsContainsExactly( [ 'do_a_thing(Thing thing)',
                                  \ 'do_another_thing()' ] )
     call FeedAndCheckAgain( '(' , funcref( 'Check3' ) )
   endfunction
@@ -357,7 +359,6 @@ function! Test_Completion_FixIt()
     call assert_equal( '#include "auto_include.h"', getline( 1 ) )
     call feedkeys( "\<Esc>" )
   endfunction
-
 
   call setpos( '.', [ 0, 3, 1 ] )
   call FeedAndCheckMain( "Ado_a\<C-Space>", funcref( 'Check1' ) )
@@ -379,7 +380,7 @@ function! Test_Select_Next_Previous_InsertModeMapping()
     call WaitForCompletion()
 
     call CheckCurrentLine( '  foo.' )
-    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCompletionItemsContainsExactly( [ 'c', 'x', 'y' ] )
 
     call FeedAndCheckAgain( "\<C-n>", funcref( 'Check2' ) )
   endfunction
@@ -387,7 +388,7 @@ function! Test_Select_Next_Previous_InsertModeMapping()
   function! Check2( id )
     call WaitForCompletion()
     call CheckCurrentLine( '  foo.c' )
-    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCompletionItemsContainsExactly( [ 'c', 'x', 'y' ] )
 
     call FeedAndCheckAgain( "\<C-n>", funcref( 'Check3' ) )
   endfunction
@@ -395,14 +396,14 @@ function! Test_Select_Next_Previous_InsertModeMapping()
   function! Check3( id )
     call WaitForCompletion()
     call CheckCurrentLine( '  foo.x' )
-    call CheckCompletionItems( [ 'c', 'x', 'y' ] )
+    call CheckCompletionItemsContainsExactly( [ 'c', 'x', 'y' ] )
 
     call FeedAndCheckAgain( "\<BS>a", funcref( 'Check4' ) )
   endfunction
 
   function! Check4( id )
     call CheckCurrentLine( '  foo.a' )
-    call CheckCompletionItems( [] )
+    call CheckCompletionItemsContainsExactly( [] )
     call FeedAndCheckAgain( "\<C-n>", funcref( 'Check5' ) )
   endfunction
 
@@ -410,7 +411,7 @@ function! Test_Select_Next_Previous_InsertModeMapping()
     " The last ctrl-n moved to the next line
     call CheckCurrentLine( '}' )
     call assert_equal( [ 0, 12, 2, 0 ], getpos( '.' ) )
-    call CheckCompletionItems( [] )
+    call CheckCompletionItemsContainsExactly( [] )
     call feedkeys( "\<Esc>" )
   endfunction
 

--- a/test/completion_info.test.vim
+++ b/test/completion_info.test.vim
@@ -113,6 +113,45 @@ function! Test_ResolveCompletion_OnChange()
   call test_override( 'ALL', 0 )
 endfunction
 
+function! Test_Resolve_FixIt()
+  call SkipIf( !exists( '*popup_findinfo' ), 'no popup_findinfo' )
+
+  " Only the java completer actually uses the completion resolve
+  call youcompleteme#test#setup#OpenFile(
+        \ '/third_party/ycmd/ycmd/tests/java/testdata/simple_eclipse_project' .
+        \ '/src/com/test/TestWithDocumentation.java', { 'delay': 15 } )
+
+  " Required to trigger TextChangedI
+  " https://github.com/vim/vim/issues/4665#event-2480928194
+  call test_override( 'char_avail', 1 )
+
+  function! Check1( id )
+    call WaitForCompletion()
+    call CheckCurrentLine( '    Tes' )
+    call CheckCompletionItemsHasItems( [ 'Test - com.youcompleteme' ] )
+    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check2' ) )
+  endfunction
+
+  function! Check2( id )
+    call WaitForCompletion()
+    call CheckCompletionItemsHasItems( [ 'Test - com.youcompleteme' ] )
+    call CheckCurrentLine( '    Test' )
+    call FeedAndCheckAgain( "\<C-y>", funcref( 'Check3' ) )
+  endfunction
+
+  function! Check3( id )
+    call WaitForAssert( {-> assert_false( pumvisible(), 'pumvisible()' ) } )
+    call CheckCurrentLine( '    Test' )
+    call assert_equal( 'import com.youcompleteme.Test;', getline( 3 ) )
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+  call setpos( '.', [ 0, 7, 1 ] )
+  call FeedAndCheckMain( "oTes\<C-space>", funcref( 'Check1' ) )
+
+  call test_override( 'ALL', 0 )
+endfunction
+
 function! Test_DontResolveCompletion_AlreadyResolved()
   call SkipIf( !exists( '*popup_findinfo' ), 'no popup_findinfo' )
 
@@ -128,7 +167,7 @@ function! Test_DontResolveCompletion_AlreadyResolved()
 
   function! Check1( id )
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'hashCode' ], 'word' )
+    call CheckCompletionItemsContainsExactly( [ 'hashCode' ], 'word' )
     call s:AssertInfoPopupNotVisible()
     call assert_equal( -1, complete_info().selected )
 

--- a/test/lib/plugin/completion.vim
+++ b/test/lib/plugin/completion.vim
@@ -1,4 +1,4 @@
-function! CheckCompletionItems( expected_props, ... )
+function! CheckCompletionItemsContainsExactly( expected_props, ... )
   let prop = 'abbr'
   if a:0 > 0
     let prop = a:1
@@ -10,16 +10,44 @@ function! CheckCompletionItems( expected_props, ... )
     call add( abbrs, get( item, prop ) )
   endfor
 
-  call assert_equal( a:expected_props,
-        \ abbrs,
-        \ 'not matched: '
-        \ .. string( a:expected_props )
-        \ .. ' against '
-        \ .. prop
-        \ .. ' in '
-        \ .. string( items )
-        \ .. ' matching '
-        \ .. string( abbrs ) )
+  return assert_equal( a:expected_props,
+                     \ abbrs,
+                     \ 'not matched: '
+                     \ .. string( a:expected_props )
+                     \ .. ' against '
+                     \ .. prop
+                     \ .. ' in '
+                     \ .. string( items )
+                     \ .. ' matching '
+                     \ .. string( abbrs ) )
+endfunction
+
+function! CheckCompletionItemsHasItems( expected_props, ... )
+  let prop = 'abbr'
+  if a:0 > 0
+    let prop = a:1
+  endif
+
+  let items = complete_info( [ 'items' ] )[ 'items' ]
+  let abbrs = []
+  for item in items
+    call add( abbrs, get( item, prop ) )
+  endfor
+
+  let result = 0
+  for expected in a:expected_props
+    if index( abbrs, expected ) < 0
+      call assert_report( "Didn't find item with "
+                        \ .. prop
+                        \ .. '="'
+                        \ .. expected
+                        \ .. '" in completion list: '
+                        \ .. string( abbrs ) )
+      let result += 1
+    endif
+  endfor
+
+  return result
 endfunction
 
 function! FeedAndCheckMain( keys, func )

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -599,7 +599,8 @@ function! Test_Semantic_Completion_Popup_With_Sig_Help()
 
   function! Check2( ... )
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'that_is_a_thing', 'this_is_a_thing' ] )
+    call CheckCompletionItemsContainsExactly( [ 'that_is_a_thing',
+                                              \ 'this_is_a_thing' ] )
 
     call youcompleteme#test#popup#CheckPopupPosition(
           \ s:_GetSigHelpWinID(),
@@ -612,7 +613,8 @@ function! Test_Semantic_Completion_Popup_With_Sig_Help()
   function! Check3( ... )
     " Ensure that we didn't make an error?
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'that_is_a_thing', 'this_is_a_thing' ] )
+    call CheckCompletionItemsContainsExactly( [ 'that_is_a_thing',
+                                              \ 'this_is_a_thing' ] )
 
     call youcompleteme#test#popup#CheckPopupPosition(
           \ s:_GetSigHelpWinID(),
@@ -636,7 +638,8 @@ function! Test_Semantic_Completion_Popup_With_Sig_Help()
   function! Check4( ... )
     " Ensure that we didn't make an error?
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'that_is_a_thing', 'this_is_a_thing' ] )
+    call CheckCompletionItemsContainsExactly( [ 'that_is_a_thing',
+                                              \ 'this_is_a_thing' ] )
 
     call youcompleteme#test#popup#CheckPopupPosition(
           \ s:_GetSigHelpWinID(),
@@ -700,7 +703,8 @@ function! Test_Semantic_Completion_Popup_With_Sig_Help_EmptyBuf()
 
   function! Check2( ... )
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'that_is_a_thing', 'this_is_a_thing' ] )
+    call CheckCompletionItemsContainsExactly( [ 'that_is_a_thing',
+                                              \ 'this_is_a_thing' ] )
 
     call youcompleteme#test#popup#CheckPopupPosition(
           \ s:_GetSigHelpWinID(),
@@ -713,7 +717,8 @@ function! Test_Semantic_Completion_Popup_With_Sig_Help_EmptyBuf()
   function! Check3( ... )
     " Ensure that we didn't make an error?
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'that_is_a_thing', 'this_is_a_thing' ] )
+    call CheckCompletionItemsContainsExactly( [ 'that_is_a_thing',
+                                              \ 'this_is_a_thing' ] )
 
     " XFAIL: Currently the test fails here because the signature help popup
     " disappears when the info_popup is displayed. This seems to be because we
@@ -744,7 +749,8 @@ function! Test_Semantic_Completion_Popup_With_Sig_Help_EmptyBuf()
   function! Check4( ... )
     " Ensure that we didn't make an error?
     call WaitForCompletion()
-    call CheckCompletionItems( [ 'that_is_a_thing', 'this_is_a_thing' ] )
+    call CheckCompletionItemsContainsExactly( [ 'that_is_a_thing',
+                                              \ 'this_is_a_thing' ] )
 
     call youcompleteme#test#popup#CheckPopupPosition(
           \ s:_GetSigHelpWinID(),


### PR DESCRIPTION
When we resolve completion items on-demand, we re-use the latest
completion request object to do the resolve request. This not only makes
sure that we only have one such request outstanding, but also that the
original request data items and query never change (as required by the
ycmd protocol).

The problem with this is that the complete done handling is implemented
by the CompletionRequest object. If we do a resolve, then we have lost
the completion request object to do the complete done handling. So to
resolve this we just delegate that handling back to the original
completion request when the latest "completion" request is actually a
resolve request.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3858)
<!-- Reviewable:end -->
