### PR TITLE
[READY] Interactive symbol search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       run: sudo -H pip3 install -r python/test_requirements.txt
     - name: Build ycmd
       run: python3 ./install.py --ts-completer --clangd-completer --java-completer
-    - name: Run tests in new vim
+    - name: Run tests in old vim
       # System vim should be oldest supported.
       if: matrix.vim == 'old'
       run: ./test/run_vim_tests --vim /usr/bin/vim

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Contents
     - [Client-Server Architecture](#client-server-architecture)
     - [Completion String Ranking](#completion-string-ranking)
     - [General Semantic Completion](#general-semantic-completion)
+    - [Signature Help](#signature-help)
     - [C-family Semantic Completion](#c-family-semantic-completion)
     - [Java Semantic Completion](#java-semantic-completion)
-	- [C# Semantic Completion](#c-semantic-completion)
+    - [C# Semantic Completion](#c-semantic-completion)
     - [Python Semantic Completion](#python-semantic-completion)
     - [Rust Semantic Completion](#rust-semantic-completion)
     - [Go Semantic Completion](#go-semantic-completion)
@@ -80,6 +81,7 @@ Contents
     - [Writing New Semantic Completers](#writing-new-semantic-completers)
     - [Diagnostic Display](#diagnostic-display)
         - [Diagnostic Highlighting Groups](#diagnostic-highlighting-groups)
+    - [Symbol Search](#symbol-search)
 - [Commands](#commands)
     - [YcmCompleter subcommands](#ycmcompleter-subcommands)
         - [GoTo Commands](#goto-commands)
@@ -175,7 +177,7 @@ number of languages, including:
 - displaying signature help (argument hints) when entering the arguments to a
   function call (Vim only)
 - [finding declarations, definitions, usages](#goto-commands), etc.
-  of identifiers,
+  of identifiers, and an [interactive symbol finder](#symbol-search)
 - [displaying type information](#the-gettype-subcommand) for classes,
   variables, functions etc.,
 - displaying documentation for methods, members, etc. in the [preview
@@ -705,8 +707,8 @@ Quick Feature Summary
 * Signature help
 * Real-time diagnostic display
 * Go to include/declaration/definition (`GoTo`, etc.)
-* Find Symbol (`GoToSymbol`)
-* Document outline (`GoToDocumentOutline`)
+* Find Symbol (`GoToSymbol`), with interactive search
+* Document outline (`GoToDocumentOutline`), with interactive search
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
 * Automatically fix certain errors (`FixIt`)
@@ -721,7 +723,7 @@ Quick Feature Summary
 * Real-time diagnostic display
 * Go to declaration/definition (`GoTo`, etc.)
 * Go to implementation (`GoToImplementation`)
-* Find Symbol (`GoToSymbol`)
+* Find Symbol (`GoToSymbol`), with interactive search
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
 * Automatically fix certain errors (`FixIt`)
@@ -734,7 +736,7 @@ Quick Feature Summary
 * Semantic auto-completion
 * Signature help
 * Go to definition (`GoTo`)
-* Find Symbol (`GoToSymbol`)
+* Find Symbol (`GoToSymbol`), with interactive search
 * Reference finding (`GoToReferences`)
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
@@ -748,7 +750,7 @@ Quick Feature Summary
 * Go to declaration/definition (`GoTo`, etc.)
 * Go to type definition (`GoToType`)
 * Go to implementation (`GoToImplementation`)
-* Document outline (`GoToDocumentOutline`)
+* Document outline (`GoToDocumentOutline`), with interactive search
 * Automatically fix certain errors (`FixIt`)
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
@@ -764,7 +766,7 @@ Quick Feature Summary
   identical)
 * Go to type definition (`GoToType`)
 * Go to implementation (`GoToImplementation`)
-* Find Symbol (`GoToSymbol`)
+* Find Symbol (`GoToSymbol`), with interactive search
 * Reference finding (`GoToReferences`)
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
@@ -781,7 +783,7 @@ Quick Feature Summary
 * Go to declaration/definition (`GoTo`, etc.)
 * Go to implementation (`GoToImplementation`)
 * Reference finding (`GoToReferences`)
-* Document outline (`GoToDocumentOutline`)
+* Document outline (`GoToDocumentOutline`), with interactive search
 * View documentation comments for identifiers (`GetDoc`)
 * Automatically fix certain errors (`FixIt`)
 * Type information for identifiers (`GetType`)
@@ -798,9 +800,9 @@ Quick Feature Summary
   identical)
 * Go to type definition (`GoToType`)
 * Go to implementation (`GoToImplementation`)
-* Find Symbol (`GoToSymbol`)
+* Find Symbol (`GoToSymbol`), with interactive search
 * Reference finding (`GoToReferences`)
-* Document outline (`GoToDocumentOutline`)
+* Document outline (`GoToDocumentOutline`), with interactive search
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
 * Automatically fix certain errors including code generation (`FixIt`)
@@ -913,9 +915,8 @@ string.
 
 ### Signature Help
 
-Signature help is an **experimental** feature for which we value your feedback.
 Valid signatures are displayed in a second popup menu and the current signature
-is highlighed along with the current arguemnt.
+is highlighted along with the current argument.
 
 Signature help is triggered in insert mode automatically when
 `g:ycm_auto_trigger` is enabled and is not supported when it is not enabled.
@@ -1647,6 +1648,61 @@ Here's how you'd change the style for a group:
 highlight YcmErrorLine guibg=#3f0000
 ```
 
+### Symbol Search
+
+***This feature requires Vim and does not work in Neovim***
+
+YCM provides a way to search for and jump to a symbol in the current project or
+document when using supported languages.
+
+You can search for symbols in the current workspace when the `GoToSymbol`
+request is supported and the current document when `GoToDocumentOutline` is
+supported.
+
+Here's a quick demo: 
+
+[![asciicast](https://asciinema.org/a/4JmYLAaz5hOHbZDD0hbsQpY8C.svg)](https://asciinema.org/a/4JmYLAaz5hOHbZDD0hbsQpY8C)
+
+As you can see, you can type and YCM filters down the list as you type. The
+current set of matches are displayed in a popup window in the centre of the
+screen and you can select an entry with the keyboard, to jump to that position.
+Any matches are then added to the quickfix list.
+
+To enable:
+
+* `nmap <something> <Plug>(YCMFindSymbolInWorkspace)`
+* `nmap <something> <Plug>(YCMFindSymbolInDocument)`
+
+e.g.
+
+* `nmap <leader>yfw <Plug>(YCMFindSymbolInWorkspace)`
+* `nmap <leader>yfd <Plug>(YCMFindSymbolInDocument)`
+
+When searching, YCM opens a prompt buffer at the top of the screen for the
+input, and puts you in insert mode. This means that you can hit `<Esc>` to go
+into normal mode and use any other input commands that are supported in prompt
+buffers. As you type characters, the serch is updated.
+
+While the popup is open, the following keys are intercepted:
+
+* `<C-j>`, `<Down>`, `<C-n>`, `<Tab>` - select the next item
+* `<C-k>`, `<Up>`, `<C-p>`, `<S-Tab>` - select the previous item
+* `<PageUp>`, `<kPageUp>` - jump up one screenful of items 
+* `<PageDown>`, `<kPageDown>` - jump down one screenful of items
+* `<Home>`, `<kHome>` - jump to first item
+* `<End>`, `<kEnd>` - jump to last item
+* `<CR>` - jump to the selected item
+* `<C-c>` cancel/dismiss the popup
+
+The search is also cancelled if you leave the prompt buffer window at any time,
+so you can use window commands `<C-w>...` for example.
+
+#### Closing the popup
+
+***NOTE***: Pressing `<Esc>` does not close the popup - you must use `Ctrl-c`
+for that, or use a window command (e.g. `<Ctrl-w>j`) or the mouse to leave the
+prompt buffer window.
+
 Commands
 --------
 
@@ -1803,7 +1859,8 @@ Supported in filetypes: `c, cpp, objc, objcpp, cuda`
 #### The `GoToSymbol <symbol query>` subcommand
 
 Finds the definition of all symbols matching a specified string. Note that this
-does not use any sort of smart/fuzzy matching.
+does not use any sort of smart/fuzzy matching. However, an [interactive symbol
+search](#symbol-search) is also available.
 
 Supported in filetypes: `c, cpp, objc, objcpp, cuda, cs, java, javascript, python, typescript`
 
@@ -1840,7 +1897,8 @@ Supported in filetypes: `go, java, javascript, typescript`
 
 #### The `GoToDocumentOutline` subcommand
 
-Provides a list of symbols in current scope, in the quickfix list.
+Provides a list of symbols in current document, in the quickfix list. See also
+[interactive symbol search](#symbol-search).
 
 Supported in filetypes: `c, cpp, objc, objcpp, cuda, go, java, rust`
 

--- a/autoload/youcompleteme/finder.vim
+++ b/autoload/youcompleteme/finder.vim
@@ -1,0 +1,713 @@
+" Copyright (C) 2021 YouCompleteMe contributors
+"
+" This file is part of YouCompleteMe.
+"
+" YouCompleteMe is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" YouCompleteMe is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+" This is basic vim plugin boilerplate
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+scriptencoding utf-8
+
+"
+" Explanation for how this module works:
+"
+" The entry point is youcompleteme#finder#FindSymbol, which takes a scope
+" argument:
+"
+" * 'document' scope - search document symbols - GoToDocumentOutline
+" * 'workspace' scope - search workspace symbols - GoToSymbol
+"
+" In general, the approach is:
+" - create a prompt buffer, and display it to use for input of a query
+" - open up a popup to display the results in the middle of the screen
+" - as the query changes, re-query the server to get the newly filtered results
+" - as the server returns results, update the contents of the results-popup
+" - use a popup-filter to implement some interractivity with the results, such
+"   as down/up, and select item
+" - when an item is selected, open its buffer in the window that was current
+"   when the search started and jump to the selected item.
+" - then populate the quickfix list with any matching results and close the
+"   popup and prompt buffer.
+"
+" However, there is an important wrinke/distinction that leads to the code being
+" a little more complicated than that: the 'search' mechanism for workspace and
+" document symbols is different.
+"
+" The reaosn for this differece is what the servers provide in response to the 2
+" requests:
+"
+" * 'document' scope - we use ycmd's filtering and sorting.
+"    GoToDocumentOutline (LSP documentSymbol) request does not take any filter
+"    argument. It returns all symbols in the current document. Therefore, we use
+"    ycmd's filter_and_sort_candidates endpoint to use our own fuzzy search on
+"    the results. This is a _great_ experience, it's _super_ fast and familar to
+"    YCM users.
+" * 'workspace' scope - we have to rely on the downstream server's filtering and
+"   sorting.
+"   GoToSymbol (LSP workspaceSymbol) request takes a query parameter to search
+"   with. While the LSP spec states that an empty query means 'return
+"   everything', no servers actually implement that, so we have to pass our
+"   query down to the server.
+"
+" The result of this is that while a lot of the code is shared, there are
+" slightly different steps involved in the process:
+"
+" * for 'document' requests, as soon as the popup is opened, we issue a
+"   GoToDocumentOutline request, storing the results as `raw_results`, then
+"   then immediately start filtering it with filter_and_sort_candidates, storing
+"   the filtered results in `results`
+" * for 'workspace' requests, as soon as the popup is opened, we issue a
+"   GoToSymbol request with an empty query. This usually returns nothing, but if
+"   any servers return anything then it would be stored in 'results'. As the
+"   user types, we repeat the GoToSymbol request and update the 'results'
+"
+" In order to simplify the re-query code, we put the function used to filter
+" results in the state variable as 'query_func'.
+"
+" As the expereince of completely different filtering and sorting for workspace
+" vs document is so jarring, by default we actually pass all restuls from
+" 'workspace' search through filter_and_sort_candidates too. This isn't perfect
+" because it breaks the mental model when the server's filtering is dumb, but it
+" at least means that sorting is consistent. This can be disabled by setting
+" g:ycm_refilter_workspace_symbols to 0.
+"
+" The key functions are:
+"
+"  - FindSymbol - initiate the request - open the popup/prompt buffer, set up
+"  the state object to defaults and initiate the first request
+"  (RequestDocumentSymbols for 'documnt' and SearchWorkspace for 'workspace' )
+"
+"  - RequestDocumentSymbols - perform the GoToDocumentOutline request and store
+"    the results in 'raw_results'
+"
+"  - SearchDocument - perform filter_and_sort_candidates request on the
+"    'raw_results', and store the results in 'results', then call
+"    "HandleSymbolSearchResults"
+"
+"  - SearchWorkspace - perform GoToSymbol request, and store the results in
+"    'results', then call "HandleSymbolSearchResults"
+"
+"  - HandleSymbolSearchResults - redraw the popup with the 'results'
+"
+"  - HandleKeyPress - handle a keypress while the popup is visible, intercepts
+"    things to handle interractivity
+"
+"  - PopupClosed - callback when the popup is closed. This openes the result in
+"    the original window.
+"
+" The other functions are utility for the most part and handle things like
+" TextChangedI event, starting/stopping drawing the spinner and such.
+
+let s:highlight_group_for_symbol_kind = {
+      \ 'Array': 'Identifier',
+      \ 'Boolean': 'Boolean',
+      \ 'Class': 'Structure',
+      \ 'Constant': 'Constant',
+      \ 'Constructor': 'Function',
+      \ 'Enum': 'Structure',
+      \ 'EnumMember': 'Identifier',
+      \ 'Event': 'Identifier',
+      \ 'Field': 'Identifier',
+      \ 'Function': 'Function',
+      \ 'Interface': 'Structure',
+      \ 'Key': 'Identifier',
+      \ 'Method': 'Function',
+      \ 'Module': 'Include',
+      \ 'Namespace': 'Type',
+      \ 'Null': 'Keyword',
+      \ 'Number': 'Number',
+      \ 'Object': 'Structure',
+      \ 'Operator': 'Operator',
+      \ 'Package': 'Include',
+      \ 'Property': 'Identifier',
+      \ 'String': 'String',
+      \ 'Struct': 'Structure',
+      \ 'TypeParameter': 'Typedef',
+      \ 'Variable': 'Identifier',
+      \ }
+let s:initialized_text_properties = v:false
+
+let s:icon_spinner = [ '/', '-', '\', '|', '/', '-', '\', '|' ]
+let s:icon_done = 'X'
+let s:spinner_delay = 100
+let s:prompt = 'Find Symbol: '
+
+" Entry point {{{
+
+function! youcompleteme#finder#FindSymbol( scope ) abort
+  if !py3eval( 'vimsupport.VimSupportsPopupWindows()' )
+    echo 'Sorry, this feature is not supported in your editor'
+    return
+  endif
+
+  if !s:initialized_text_properties
+    call prop_type_add( 'YCM-symbol-Normal', { 'highlight': 'Normal' } )
+    for k in keys( s:highlight_group_for_symbol_kind )
+      call prop_type_add(
+            \ 'YCM-symbol-' . k,
+            \ { 'highlight': s:highlight_group_for_symbol_kind[ k ] } )
+    endfor
+    call prop_type_add( 'YCM-symbol-file', { 'highlight': 'Comment' } )
+    call prop_type_add( 'YCM-symbol-line-num', { 'highlight': 'Number' } )
+    let s:initialized_text_properties = v:true
+  endif
+
+  let s:find_symbol_status = {
+        \ 'selected': -1,
+        \ 'query': '',
+        \ 'results': [],
+        \ 'raw_results': v:none,
+        \ 'waiting': 0,
+        \ 'pending': 0,
+        \ 'winid': win_getid(),
+        \ 'bufnr': bufnr(),
+        \ 'prompt_bufnr': -1,
+        \ 'prompt_winid': -1,
+        \ 'filter': v:none,
+        \ 'id': v:none,
+        \ 'cursorline_match': v:none,
+        \ 'spinner': 0,
+        \ 'spinner_timer': -1,
+        \ }
+
+  let opts = {
+        \ 'padding': [ 1, 2, 1, 2 ],
+        \ 'wrap': 0,
+        \ 'minwidth': &columns / 3 * 2,
+        \ 'minheight': &lines / 3 * 2,
+        \ 'maxwidth': &columns / 3 * 2,
+        \ 'maxheight': &lines / 3 * 2,
+        \ 'line': &lines / 6,
+        \ 'col': &columns / 6,
+        \ 'pos': 'topleft',
+        \ 'drag': 1,
+        \ 'resize': 1,
+        \ 'close': 'button',
+        \ 'border': [],
+        \ 'mapping': 0,
+        \ 'callback': function( 's:PopupClosed' ),
+        \ 'filter': function( 's:HandleKeyPress' ),
+        \ 'highlight': 'Normal',
+        \ }
+
+  if &ambiwidth ==# 'single' && &encoding ==? 'utf-8'
+    let opts[ 'borderchars' ] = [ '─', '│', '─', '│', '╭', '╮', '┛', '╰' ]
+  endif
+
+  if a:scope ==# 'document'
+    let s:find_symbol_status.query_func = function( 's:SearchDocument' )
+  else
+    let s:find_symbol_status.query_func = function( 's:SearchWorkspace' )
+  endif
+
+  let s:find_symbol_status.id = popup_create( 'Type to query for stuff', opts )
+
+  " Kick off the request now
+  let s:find_symbol_status.waiting = 1
+  if a:scope ==# 'document'
+    call s:StartSpinner()
+    call s:RequestDocumentSymbols()
+  else
+    call s:SearchWorkspace( '' )
+  endif
+
+  let bufnr = bufadd( '_ycm_filter_' )
+  silent call bufload( bufnr )
+  silent topleft 1split _ycm_filter_
+  let s:find_symbol_status.prompt_bufnr = bufnr
+  let s:find_symbol_status.prompt_winid = win_getid()
+
+  setlocal buftype=prompt noswapfile modifiable nomodified noreadonly
+  setlocal nobuflisted bufhidden=delete textwidth=0
+  call prompt_setprompt( bufnr(), s:prompt )
+  augroup YCMPromptFindSymbol
+    autocmd!
+    autocmd TextChanged,TextChangedI <buffer> call s:OnQueryTextChanged()
+    autocmd WinLeave <buffer> call s:Cancel()
+    autocmd CmdLineEnter <buffer> call s:Cancel()
+  augroup END
+  startinsert
+endfunction
+
+function! s:OnQueryTextChanged() abort
+  if s:find_symbol_status.id < 0
+    return
+  endif
+
+  let bufnr = s:find_symbol_status.prompt_bufnr
+  let query = getbufline( bufnr, '$' )[ 0 ]
+  let s:find_symbol_status.query = query[ len( s:prompt ) : ]
+  let s:find_symbol_status.pending = 1
+  call s:RequeryFinderPopup()
+  setlocal nomodified
+endfunction
+
+
+function! s:Cancel() abort
+  if s:find_symbol_status.id < 0
+    return
+  endif
+
+  call popup_close( s:find_symbol_status.id, -1 )
+endfunction
+" }}}
+
+" Popup and keyboard events {{{
+
+function! s:HandleKeyPress( id, key ) abort
+  let redraw = 0
+  let handled = 0
+
+  " The input for the search/query is taken from the prompt buffer and the
+  " TextChangedI event
+  if a:key ==# "\<C-j>" ||
+        \ a:key ==# "\<Down>" ||
+        \ a:key ==# "\<C-n>" ||
+        \ a:key ==# "\<Tab>"
+    let s:find_symbol_status.selected += 1
+    " wrap
+    if s:find_symbol_status.selected >= len( s:find_symbol_status.results )
+      let s:find_symbol_status.selected = 0
+    endif
+    let redraw = 1
+    let handled = 1
+  elseif a:key ==# "\<C-k>" ||
+        \ a:key ==# "\<Up>" ||
+        \ a:key ==# "\<C-p>" ||
+        \ a:key ==# "\<S-Tab>"
+    let s:find_symbol_status.selected -= 1
+    " wrap
+    if s:find_symbol_status.selected < 0
+      let s:find_symbol_status.selected =
+            \ len( s:find_symbol_status.results ) - 1
+    endif
+    let redraw = 1
+    let handled = 1
+  elseif a:key ==# "\<PageDown>" || a:key ==# "\<kPageDown>"
+    let s:find_symbol_status.selected +=
+          \ popup_getpos( s:find_symbol_status.id ).core_height
+    " Don't wrap
+    if s:find_symbol_status.selected >= len( s:find_symbol_status.results )
+      let s:find_symbol_status.selected =
+            \ len( s:find_symbol_status.results ) - 1
+    endif
+    let redraw = 1
+    let handled = 1
+  elseif a:key ==# "\<PageUp>" || a:key ==# "\<kPageUp>"
+    let s:find_symbol_status.selected -=
+          \ popup_getpos( s:find_symbol_status.id ).core_height
+    " Don't wrap
+    if s:find_symbol_status.selected < 0
+      let s:find_symbol_status.selected = 0
+    endif
+    let redraw = 1
+    let handled = 1
+  elseif a:key ==# "\<C-c>"
+    call popup_close( a:id, -1 )
+    let handled = 1
+  elseif a:key ==# "\<CR>"
+    if s:find_symbol_status.selected >= 0
+      call popup_close( a:id, s:find_symbol_status.selected )
+      let handled = 1
+    endif
+  elseif a:key ==# "\<Home>" || a:key ==# "\<kHome>"
+    let s:find_symbol_status.selected = 0
+    let redraw = 1
+    let handled = 1
+  elseif a:key ==# "\<End>" || a:key ==# "\<kEnd>"
+    let s:find_symbol_status.selected = len( s:find_symbol_status.results ) - 1
+    let redraw = 1
+    let handled = 1
+  endif
+
+  if redraw
+    call s:RedrawFinderPopup()
+  endif
+
+  return handled
+endfunction
+
+
+" Handle the popup closing: jump to the selected item
+function! s:PopupClosed( id, selected ) abort
+  stopinsert
+  call win_gotoid( s:find_symbol_status.prompt_winid )
+  silent bwipe!
+
+  " Return to original window
+  call win_gotoid( s:find_symbol_status.winid )
+
+  if a:selected >= 0
+    let selected = s:find_symbol_status.results[ a:selected ]
+
+    py3 vimsupport.JumpToLocation(
+          \ filename = vimsupport.ToUnicode( vim.eval( 'selected.filepath' ) ),
+          \ line = int( vim.eval( 'selected.line_num' ) ),
+          \ column = int( vim.eval( 'selected.column_num' ) ),
+          \ modifiers = '',
+          \ command = 'same-buffer'
+          \ )
+
+    if len( s:find_symbol_status.results ) > 1
+      " Also, populate the quickfix list
+      py3 vimsupport.SetQuickFixList(
+            \ [ vimsupport.BuildQfListItem( x ) for x in
+            \ vim.eval( 's:find_symbol_status.results' ) ] )
+
+
+      " Emulate :echo, to avoid a redraw getting rid of the message.
+      let txt = 'Added ' . len( getqflist() ) . ' entries to quickfix list.'
+      call popup_notification(
+            \ txt,
+            \ {
+              \  'line':      1,
+              \  'col':       &columns - len( txt ),
+              \  'padding':   [ 0, 0, 0, 0 ],
+              \  'border':    [ 0, 0, 0, 0 ],
+              \  'highlight': 'PMenu'
+            \ } )
+
+      " But don't open it, as this could take up valuable actual screen space
+      " py3 vimsupport.OpenQuickFixList()
+    endif
+  endif
+
+
+  call s:StopSpinner()
+  let s:find_symbol_status.id = -1
+endfunction
+
+"}}}
+
+" Results handling and re-query {{{
+
+" Render a set of results returned from the filter/search function
+function! s:HandleSymbolSearchResults( results ) abort
+  let s:find_symbol_status.waiting = 0
+  let s:find_symbol_status.results = []
+  call s:StopSpinner()
+
+  if s:find_symbol_status.id < 0
+    " Popup was closed, ignore this event
+    return
+  endif
+
+  let s:find_symbol_status.results = a:results
+  call s:RedrawFinderPopup()
+  call s:RequeryFinderPopup()
+endfunction
+
+
+" Set the popup text
+function! s:RedrawFinderPopup() abort
+  " Clamp selected. If there are any results, the first one is selected by
+  " default
+  let s:find_symbol_status.selected = max( [
+        \   s:find_symbol_status.selected,
+        \   len( s:find_symbol_status.results ) > 0 ? 0 : -1
+        \ ] )
+  let s:find_symbol_status.selected = min( [
+        \   s:find_symbol_status.selected,
+        \   len( s:find_symbol_status.results ) - 1
+        \ ] )
+
+  if empty( s:find_symbol_status.results )
+    call popup_settext( s:find_symbol_status.id, 'No results' )
+    let s:find_symbol_status.selected = -1
+  else
+    let popup_width = popup_getpos( s:find_symbol_status.id ).core_width
+
+    let buffer = []
+
+    for result in s:find_symbol_status.results
+      " Calculate  the text to use. Try and include the full path and line
+      " number, (right aligned), but truncate if there isn't space for the
+      " description and the file path. Include at least 8 spaces between them
+      " (if there's room).
+      if result->has_key( 'extra_data' )
+        let kind = result[ 'extra_data' ][ 'kind' ]
+        let name = result[ 'extra_data' ][ 'name' ]
+        let desc = kind .. ': ' .. name
+        if s:highlight_group_for_symbol_kind->has_key( kind )
+          let prop = 'YCM-symbol-' . kind
+        else
+          let prop = 'YCM-symbol-Normal'
+        endif
+        let props = [
+            \ { 'col': 1,
+            \   'length': len( kind ) + 2,
+            \   'type': 'YCM-symbol-Normal'  },
+            \ { 'col': len( kind ) + 3,
+            \   'length': len( name ),
+            \   'type': prop },
+            \ ]
+      elseif result->has_key( 'description' )
+        let desc = result[ 'description' ]
+        let props = [
+            \ { 'col': 1, 'length': len( desc ), 'type': 'YCM-symbol-Normal' },
+            \ ]
+      else
+        let desc = 'Invalid entry: ' . string( result )
+        let props = []
+      endif
+
+      let line_num = result[ 'line_num' ]
+      let path = fnamemodify( result[ 'filepath' ], ':.' )
+               \ .. ':'
+               \ .. line_num
+
+      let spaces = popup_width - len( desc ) - len( path )
+      let spacing = 8
+      if spaces < spacing
+        let spaces = spacing
+        let path_len_to_use = popup_width - spacing - len( desc ) - 3
+        if path_len_to_use > 0
+          let path = '...' . strpart( path, len( path ) - path_len_to_use )
+        else
+          let path = '...:' .. line_num
+        endif
+      endif
+      let line = desc .. repeat( ' ', spaces ) .. path
+      call add( buffer, {
+            \ 'text': line,
+            \ 'props': props + [
+              \ { 'col': popup_width - len( path ) + 1,
+              \   'length': len( path ) - len( line_num ),
+              \   'type': 'YCM-symbol-file' },
+              \ { 'col': popup_width - len( line_num ) + 1,
+              \   'length': len( line_num ),
+              \   'type': 'YCM-symbol-line-num' }
+              \ ]
+            \ } )
+    endfor
+
+    call popup_settext( s:find_symbol_status.id, buffer )
+  endif
+
+  if s:find_symbol_status.selected > -1
+    " Move the cursor so that cursorline highlights the selected item. Also
+    " scroll the window if the selected item is not in view. To make scrolling
+    " feel natural we position the current line a the bottom of the window if
+    " the new current line is below the current viewport, and at the top if the
+    " new current line is above the viewport.
+    let new_line =  s:find_symbol_status.selected + 1
+    let pos = popup_getpos( s:find_symbol_status.id )
+
+    call win_execute( s:find_symbol_status.id,
+                    \ 'call cursor( [' . string( new_line ) . ', 1] )' )
+
+    if new_line < pos.firstline
+      " New line is above the viewport, scroll so that this line is at the top
+      " of the window.
+      call win_execute( s:find_symbol_status.id, "normal z\<CR>" )
+    elseif new_line >= ( pos.firstline + pos.core_height )
+      " New line is below the viewport, scroll so that this line is at the
+      " bottom of the window.
+      call win_execute( s:find_symbol_status.id, ':normal z-' )
+    endif
+    " Otherwise, new item is already displayed - don't scroll the window.
+
+    if !getwinvar( s:find_symbol_status.id, '&cursorline' )
+      call win_execute( s:find_symbol_status.id, 'set cursorline' )
+    endif
+  else
+    call win_execute( s:find_symbol_status.id, 'set nocursorline' )
+  endif
+
+endfunction
+
+function! s:SetTitle() abort
+  if s:find_symbol_status.spinner_timer > -1
+    let status = s:icon_spinner[ s:find_symbol_status.spinner ]
+  else
+    let status = s:icon_done
+  endif
+
+  call popup_setoptions( s:find_symbol_status.id, {
+        \ 'title': ' [' . status . '] Search for symbol: '
+        \            . s:find_symbol_status.query . ' '
+        \ } )
+endfunction
+
+
+
+" Re-query or re-filter by calling the filter function
+function! s:RequeryFinderPopup() abort
+  " Update the title even if we delay the query, as this makes the UI feel
+  " snappy
+  call s:SetTitle()
+
+  if s:find_symbol_status.waiting == 1
+    let s:find_symbol_status.pending = 1
+  elseif s:find_symbol_status.pending == 1
+    let s:find_symbol_status.pending = 0
+    let s:find_symbol_status.waiting = 1
+    call win_execute( s:find_symbol_status.winid,
+          \ 'call s:find_symbol_status.query_func('
+          \ . 's:find_symbol_status.query )' )
+  endif
+endfunction
+
+function! s:ParseGoToResponse( results ) abort
+  if type( a:results ) == v:t_none || empty( a:results )
+    let results = []
+  elseif type( a:results ) != v:t_list
+    let results = [ a:results ]
+  else
+    let results = a:results
+  endif
+
+  call map( results,
+        \ { i,v -> extend( v,
+              \ { 'key': v->get( 'extra_data',
+              \                  {} )->get( 'name',
+              \                             v[ 'description' ] ) } ) } )
+
+  return results
+endfunction
+
+" }}}
+
+" Spinner {{{
+
+function! s:StartSpinner() abort
+  call s:StopSpinner()
+
+  let s:find_symbol_status.spinner = 0
+  let s:find_symbol_status.spinner_timer = timer_start( s:spinner_delay,
+        \ function( 's:TickSpinner' ) )
+
+  call s:SetTitle()
+endfunction
+
+function! s:StopSpinner() abort
+  call timer_stop( s:find_symbol_status.spinner_timer )
+  let s:find_symbol_status.spinner_timer = -1
+
+  call s:SetTitle()
+endfunction
+
+function! s:TickSpinner( timer_id ) abort
+  let s:find_symbol_status.spinner = ( s:find_symbol_status.spinner + 1 ) %
+        \ len( s:icon_spinner )
+
+  let s:find_symbol_status.spinner_timer = timer_start( s:spinner_delay,
+        \ function( 's:TickSpinner' ) )
+
+  call s:SetTitle()
+endfunction
+
+" }}}
+
+" Workspace search {{{
+
+function! s:SearchWorkspace( query ) abort
+  call s:StartSpinner()
+
+  let s:find_symbol_status.raw_results = v:none
+  call youcompleteme#GetRawCommandResponseAsync(
+        \ function( 's:HandleWorkspaceSymbols' ),
+        \ 'GoToSymbol',
+        \ a:query )
+endfunction
+
+
+function! s:HandleWorkspaceSymbols( results ) abort
+  let results = s:ParseGoToResponse( a:results )
+
+  if g:ycm_refilter_workspace_symbols && !empty( results )
+    " This is kinda wonky, but seems to work well enough.
+    "
+    " We get the server to give us a result set, then use our own
+    " filter_and_sort_candidates on the result set filtered by the server
+    "
+    " The reason for this is:
+    "  - server filterins will differ by server and this leads to horrible wonky
+    "    user experience
+    "  - ycmd filter is consistent, even if not perfect
+    "  - servers are supposed to return _all_ symbols if we request a query of ""
+    "    but no actual servers obey this part of the spec.
+    "
+    " So as a compromise we let the server filter the results, then we _refilter_
+    " and sort them using ycmd's method. This provides consistency with the
+    " filtering and sorting on the completion popup menu, with the disadvantage of
+    " additional latency.
+    "
+    " We're not currently sure this is going to be perfecct, so we have a hidden
+    " option to disable this re-filter/sort.
+    "
+    let results = py3eval(
+          \ 'ycm_state.FilterAndSortItems( '
+          \ . ' vim.eval( "results" ),'
+          \ . ' "description",'
+          \ . ' vim.eval( "s:find_symbol_status.query" ) )' )
+  endif
+
+  eval s:HandleSymbolSearchResults( results )
+endfunction
+
+" }}}
+
+" Document Search {{{
+
+function! s:SearchDocument( query ) abort
+  if type( s:find_symbol_status.raw_results ) == v:t_none
+    call s:StopSpinner()
+    call popup_settext( s:find_symbol_status.id,
+          \ 'No symbols found in document' )
+    return
+  endif
+
+  call s:StartSpinner()
+
+  " Call filter_and_sort_candidates on the results (synchronously)
+  let response = py3eval(
+        \ 'ycm_state.FilterAndSortItems( '
+        \ . ' vim.eval( "s:find_symbol_status.raw_results" ),'
+        \ . ' "description",'
+        \ . ' vim.eval( "a:query" ) )' )
+
+  eval s:HandleSymbolSearchResults( response )
+endfunction
+
+
+function! s:RequestDocumentSymbols()
+  call youcompleteme#GetRawCommandResponseAsync(
+        \ function( 's:HandleDocumentSymbols' ),
+        \ 'GoToDocumentOutline' )
+endfunction
+
+
+function! s:HandleDocumentSymbols( results ) abort
+  let s:find_symbol_status.raw_results = s:ParseGoToResponse( a:results )
+  call s:SearchDocument( '' )
+endfunction
+
+" }}}
+
+" Utility for testing {{{
+
+function! youcompleteme#finder#GetState() abort
+  return s:find_symbol_status
+endfunction
+
+" }}}
+
+" This is basic vim plugin boilerplate
+let &cpoptions = s:save_cpo
+unlet s:save_cpo
+
+" vim: foldmethod=marker

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -283,6 +283,9 @@ let g:ycm_java_jdtls_workspace_root_path =
 let g:ycm_python_binary_path =
       \ get( g:, 'ycm_python_binary_path', '' )
 
+let g:ycm_refilter_workspace_symbols =
+      \ get( g:, 'ycm_refilter_workspace_symbols', 1 )
+
 if has( 'vim_starting' ) " Loading at startup.
   " We defer loading until after VimEnter to allow the gui to fork (see
   " `:h gui-fork`) and avoid a deadlock situation, as explained here:

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -17,7 +17,6 @@
 
 from ycm.client.base_request import BaseRequest, BuildRequestData
 from ycm import vimsupport
-from ycmd.utils import ToUnicode
 
 DEFAULT_BUFFER_COMMAND = 'same-buffer'
 
@@ -132,7 +131,7 @@ class CommandRequest( BaseRequest ):
   def _HandleGotoResponse( self, buffer_command, modifiers ):
     if isinstance( self._response, list ):
       vimsupport.SetQuickFixList(
-        [ _BuildQfListItem( x ) for x in self._response ] )
+        [ vimsupport.BuildQfListItem( x ) for x in self._response ] )
       vimsupport.OpenQuickFixList( focus = True, autoclose = True )
     else:
       vimsupport.JumpToLocation( self._response[ 'filepath' ],
@@ -222,24 +221,3 @@ def GetCommandResponse( arguments, extra_data = None ):
                                      silent = True )
   # Block here to get the response
   return request.StringResponse()
-
-
-def _BuildQfListItem( goto_data_item ):
-  qf_item = {}
-  if 'filepath' in goto_data_item:
-    qf_item[ 'filename' ] = ToUnicode( goto_data_item[ 'filepath' ] )
-  if 'description' in goto_data_item:
-    qf_item[ 'text' ] = ToUnicode( goto_data_item[ 'description' ] )
-  if 'line_num' in goto_data_item:
-    qf_item[ 'lnum' ] = goto_data_item[ 'line_num' ]
-  if 'column_num' in goto_data_item:
-    # ycmd returns columns 1-based, and QuickFix lists require "byte offsets".
-    # See :help getqflist and equivalent comment in
-    # vimsupport.ConvertDiagnosticsToQfList.
-    #
-    # When the Vim help says "byte index", it really means "1-based column
-    # number" (which is somewhat confusing). :help getqflist states "first
-    # column is 1".
-    qf_item[ 'col' ] = goto_data_item[ 'column_num' ]
-
-  return qf_item

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1150,7 +1150,7 @@ def OpenFilename( filename, options = {} ):
   - watch: automatically watch for changes (default: False). This is useful
   for logs;
   - position: set the position where the file is opened (default: start).
-  Choices are start and end.
+  Choices are 'start' and 'end'.
   - mods: The vim <mods> for the command, such as :vertical"""
 
   # Set the options.
@@ -1317,3 +1317,24 @@ def DisplayWidth():
 
 def DisplayWidthOfString( s ):
   return GetIntValue( f"strdisplaywidth( '{ EscapeForVim( s ) }' )" )
+
+
+def BuildQfListItem( goto_data_item ):
+  qf_item = {}
+  if 'filepath' in goto_data_item:
+    qf_item[ 'filename' ] = ToUnicode( goto_data_item[ 'filepath' ] )
+  if 'description' in goto_data_item:
+    qf_item[ 'text' ] = ToUnicode( goto_data_item[ 'description' ] )
+  if 'line_num' in goto_data_item:
+    qf_item[ 'lnum' ] = goto_data_item[ 'line_num' ]
+  if 'column_num' in goto_data_item:
+    # ycmd returns columns 1-based, and QuickFix lists require "byte offsets".
+    # See :help getqflist and equivalent comment in
+    # vimsupport.ConvertDiagnosticsToQfList.
+    #
+    # When the Vim help says "byte index", it really means "1-based column
+    # number" (which is somewhat confusing). :help getqflist states "first
+    # column is 1".
+    qf_item[ 'col' ] = goto_data_item[ 'column_num' ]
+
+  return qf_item

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -828,6 +828,19 @@ class YouCompleteMe:
       vimsupport.OpenLocationList( focus = True )
 
 
+  def FilterAndSortItems( self,
+                          items,
+                          sort_property,
+                          query,
+                          max_items = 0 ):
+    return BaseRequest().PostDataToHandler( {
+      'candidates': items,
+      'sort_property': sort_property,
+      'max_num_candidates': max_items,
+      'query': vimsupport.ToUnicode( query )
+    }, 'filter_and_sort_candidates' )
+
+
   def _AddSyntaxDataIfNeeded( self, extra_data ):
     if not self._user_options[ 'seed_identifiers_with_syntax' ]:
       return

--- a/test/.vimspector.json
+++ b/test/.vimspector.json
@@ -10,7 +10,7 @@
           "--clean",
           "--not-a-term",
           "-S", "lib/run_test.vim",
-          "${file}",
+          "${TestScriptName}",
           "${TestFunction}"
         ]
       }

--- a/test/docker/ci/image/Dockerfile
+++ b/test/docker/ci/image/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL C.UTF-8
 
-ARG VIM_VERSION=v8.2.1456
+ARG VIM_VERSION=v8.2.2735
 ARG YCM_VIM_PYTHON=python3
 
 RUN apt-get update && \

--- a/test/finder.test.vim
+++ b/test/finder.test.vim
@@ -1,0 +1,406 @@
+function! SetUp()
+  let g:ycm_use_clangd = 1
+  call youcompleteme#test#setup#SetUp()
+  nmap <leader><leader>w <Plug>(YCMFindSymbolInWorkspace)
+  nmap <leader><leader>d <Plug>(YCMFindSymbolInDocument)
+endfunction
+
+function! TearDown()
+endfunction
+
+function! Test_WorkspaceSymbol_Basic()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/test/testdata/cpp/complete_with_sig_help.cc', {} )
+
+  let original_win = winnr()
+  let b = bufnr()
+  let l = winlayout()
+
+  let popup_id = -1
+
+  function! PutQuery( ... )
+    " Wait for the current buffer to be a prompt buffer
+    call WaitForAssert( { -> assert_equal( 'prompt', &buftype ) } )
+    call WaitForAssert( { -> assert_equal( 'i', mode() ) } )
+
+    call WaitForAssert( { -> assert_true(
+          \ youcompleteme#finder#GetState().id != -1 ) } )
+
+    " TODO: Wait for the popup to be displayed, and check the contents
+    call FeedAndCheckAgain( 'thisisathing', funcref( 'SelectItem' ) )
+  endfunction
+
+  function SelectItem( ... )
+    let id = youcompleteme#finder#GetState().id
+    let o = popup_getoptions( id )
+
+    call WaitForAssert( { ->
+          \ assert_equal( ' [X] Search for symbol: thisisathing ',
+          \ o.title  ) },
+          \ 10000 )
+
+    call WaitForAssert( { -> assert_equal( 1, line( '$', id ) ) } )
+
+    call feedkeys( "\<CR>" )
+  endfunction
+
+  " <Leader> is \ - this calls <Plug>(YCMFindSymbolInWorkspace)
+  call FeedAndCheckMain( '\\w', funcref( 'PutQuery' ) )
+
+  call WaitForAssert( { -> assert_equal( l, winlayout() ) } )
+  call WaitForAssert( { -> assert_equal( original_win, winnr() ) } )
+  call assert_equal( b, bufnr() )
+  call assert_equal( [ 0, 5, 7, 0 ], getpos( '.' ) )
+
+  delfunct PutQuery
+  delfunct SelectItem
+  %bwipe!
+endfunction
+
+function! Test_DocumentSymbols_Basic()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/test/testdata/cpp/complete_with_sig_help.cc', {} )
+
+  let original_win = winnr()
+  let b = bufnr()
+  let l = winlayout()
+
+  let popup_id = -1
+
+  function! PutQuery( ... )
+    " Wait for the current buffer to be a prompt buffer
+    call WaitForAssert( { -> assert_equal( 'prompt', &buftype ) } )
+    call WaitForAssert( { -> assert_equal( 'i', mode() ) } )
+
+    call WaitForAssert( { -> assert_true(
+          \ youcompleteme#finder#GetState().id != -1 ) } )
+
+    " TODO: Wait for the popup to be displayed, and check the contents
+    call FeedAndCheckAgain( 'thisisathing', funcref( 'SelectItem' ) )
+  endfunction
+
+  function SelectItem( ... )
+    let id = youcompleteme#finder#GetState().id
+    let o = popup_getoptions( id )
+
+    call WaitForAssert( { ->
+          \ assert_equal( ' [X] Search for symbol: thisisathing ',
+          \ o.title  ) },
+          \ 10000 )
+
+    call WaitForAssert( { -> assert_equal( 1, line( '$', id ) ) } )
+
+    call feedkeys( "\<CR>" )
+  endfunction
+
+  " <Leader> is \ - this calls <Plug>(YCMFindSymbolInDocument)
+  call FeedAndCheckMain( '\\d', funcref( 'PutQuery' ) )
+
+  call WaitForAssert( { -> assert_equal( l, winlayout() ) } )
+  call WaitForAssert( { -> assert_equal( original_win, winnr() ) } )
+  call assert_equal( b, bufnr() )
+  " NOTE: cland returns the position of the decl here not the identifier. This
+  " is why it's position 3 not 7 as in the Test_WorkspaceSymbol_Basic
+  call assert_equal( [ 0, 5, 3, 0 ], getpos( '.' ) )
+
+  delfunct PutQuery
+  delfunct SelectItem
+  %bwipe!
+endfunction
+
+function! Test_Cancel_DocumentSymbol()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/test/testdata/cpp/complete_with_sig_help.cc', {} )
+
+  let original_win = winnr()
+  let b = bufnr()
+  let l = winlayout()
+
+  " Jump to a different position so that we can ensure we return to the same
+  " place
+  normal! G
+  let p = getpos( '.' )
+
+  let popup_id = -1
+
+  function! PutQuery( ... )
+    " Wait for the current buffer to be a prompt buffer
+    call WaitForAssert( { -> assert_equal( 'prompt', &buftype ) } )
+    call WaitForAssert( { -> assert_equal( 'i', mode() ) } )
+
+    call WaitForAssert( { -> assert_true(
+          \ youcompleteme#finder#GetState().id != -1 ) } )
+
+    call FeedAndCheckAgain( 'thisisathing', funcref( 'SelectItem' ) )
+  endfunction
+
+  function SelectItem( ... )
+    let id = youcompleteme#finder#GetState().id
+    let o = popup_getoptions( id )
+
+    call WaitForAssert( { ->
+          \ assert_equal( ' [X] Search for symbol: thisisathing ',
+          \ o.title  ) },
+          \ 10000 )
+
+    call WaitForAssert( { -> assert_equal( 1, line( '$', id ) ) } )
+
+    " Cancel - this should stopinsert
+    call feedkeys( "\<C-c>" )
+  endfunction
+
+  " <Leader> is \ - this calls <Plug>(YCMFindSymbolInDocument)
+  call FeedAndCheckMain( '\\d', funcref( 'PutQuery' ) )
+
+  call WaitForAssert( { -> assert_equal( l, winlayout() ) } )
+  call WaitForAssert( { -> assert_equal( original_win, winnr() ) } )
+  call assert_equal( b, bufnr() )
+
+  " Retuned to just where we started
+  call assert_equal( p, getpos( '.' ) )
+
+  delfunct PutQuery
+  delfunct SelectItem
+  %bwipe!
+endfunction
+
+function! Test_EmptySearch()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/test/testdata/cpp/complete_with_sig_help.cc', {} )
+
+  let original_win = winnr()
+  let b = bufnr()
+  let l = winlayout()
+
+  let popup_id = -1
+
+  function! PutQuery( ... )
+    " Wait for the current buffer to be a prompt buffer
+    call WaitForAssert( { -> assert_equal( 'prompt', &buftype ) } )
+    call WaitForAssert( { -> assert_equal( 'i', mode() ) } )
+
+    call WaitForAssert( { -> assert_true(
+          \ youcompleteme#finder#GetState().id != -1 ) } )
+
+    " TODO: Wait for the popup to be displayed, and check the contents
+    call FeedAndCheckAgain( 'nothingshouldmatchthis',
+                          \ funcref( 'SelectNothing' ) )
+  endfunction
+
+  function SelectNothing( ... )
+    let id = youcompleteme#finder#GetState().id
+    let o = popup_getoptions( id )
+
+    call WaitForAssert( { ->
+          \ assert_equal( ' [X] Search for symbol: nothingshouldmatchthis ',
+          \ o.title  ) },
+          \ 10000 )
+
+    call WaitForAssert( { -> assert_equal( 1, line( '$', id ) ) } )
+
+    call assert_equal( 'No results', getbufline( winbufnr( id ), '$' )[ 0 ] )
+    call FeedAndCheckAgain( "\<CR>", funcref( 'ChangeSearch' ) )
+  endfunction
+
+  function ChangeSearch( ... )
+    let id = youcompleteme#finder#GetState().id
+    let o = popup_getoptions( id )
+
+    " Hitting enter with nothing to select clears the prompt, because prompt
+    " buffer
+    call WaitForAssert( { ->
+          \ assert_equal( ' [X] Search for symbol:  ',
+          \ o.title  ) },
+          \ 10000 )
+    call assert_equal( 'No results', getbufline( winbufnr( id ), '$' )[ 0 ] )
+
+    call assert_equal( -1, youcompleteme#finder#GetState().selected )
+
+    call FeedAndCheckAgain( 'tiat', funcref( 'TestUpDownSelect' ) )
+  endfunction
+
+  let popup_id = -1
+  function TestUpDownSelect( ... ) closure
+    let popup_id = youcompleteme#finder#GetState().id
+    let o = popup_getoptions( popup_id )
+
+    call WaitForAssert( { ->
+          \ assert_equal( ' [X] Search for symbol: tiat ',
+          \ o.title  ) },
+          \ 10000 )
+    call WaitForAssert( { -> assert_equal( 2, line( '$', popup_id ) ) } )
+
+    " FIXME: Doing all these tests with only 2 entries means that it's not
+    " really checking the behaviour completely accurately, we should at least
+    " use 3, but that would require crafting a new test file, which is nonzero
+    " effort. Well, it's probably as much effort as writing this comment...
+
+    " Check down movement
+    call assert_equal( 0, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'this_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<C-j>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<Down>", 'xt' )
+    call assert_equal( 0, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'this_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<Tab>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<C-n>", 'xt' )
+    call assert_equal( 0, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'this_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    " Check up movement and wrapping
+    call feedkeys( "\<C-k>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<Up>", 'xt' )
+    call assert_equal( 0, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'this_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<S-Tab>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<C-p>", 'xt' )
+    call assert_equal( 0, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'this_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<Tab>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<Home>", 'xt' )
+    call assert_equal( 0, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'this_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<End>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<End>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<PageUp>", 'xt' )
+    call assert_equal( 0, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'this_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<PageDown>", 'xt' )
+    call assert_equal( 1, youcompleteme#finder#GetState().selected )
+    call assert_equal( 'that_is_a_thing',
+          \ youcompleteme#finder#GetState().results[
+          \   youcompleteme#finder#GetState().selected ].extra_data.name )
+
+    call feedkeys( "\<CR>" )
+  endfunction
+
+  " <Leader> is \ - this calls <Plug>(YCMFindSymbolInWorkspace)
+  call FeedAndCheckMain( '\\w', funcref( 'PutQuery' ) )
+
+  call WaitForAssert( { -> assert_equal( {}, popup_getpos( popup_id ) ) } )
+  call WaitForAssert( { -> assert_equal( l, winlayout() ) } )
+  call WaitForAssert( { -> assert_equal( original_win, winnr() ) } )
+  call assert_equal( b, bufnr() )
+  call assert_equal( [ 0, 5, 28, 0 ], getpos( '.' ) )
+
+  " We pop up a notification with some text in it
+  if exists( '*popup_list' )
+    call assert_equal( 1, len( popup_list() ) )
+  endif
+
+  " Old vim doesn't have popup_list, so hit-test the top-right corner which is
+  " where we pup the popu
+  let notification_id = popup_locate( 1, &columns - 1 )
+  call assert_equal( [ 'Added 2 entries to quickfix list.' ],
+                   \ getbufline( winbufnr( notification_id ), 1, '$' ) )
+  " Wait for the notification to clear
+  call WaitForAssert(
+        \ { -> assert_equal( {}, popup_getpos( notification_id ) ) },
+        \ 10000 )
+
+  delfunct PutQuery
+  delfunct SelectNothing
+  delfunct ChangeSearch
+  delfunct TestUpDownSelect
+  %bwipe!
+endfunction
+
+function! Test_LeaveWindow_CancelSearch()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/test/testdata/cpp/complete_with_sig_help.cc', {} )
+
+  let original_win = winnr()
+  let b = bufnr()
+  let l = winlayout()
+
+  " Jump to a different position so that we can ensure we return to the same
+  " place
+  normal! G
+  let p = getpos( '.' )
+
+  let popup_id = -1
+
+  function! PutQuery( ... )
+    " Wait for the current buffer to be a prompt buffer
+    call WaitForAssert( { -> assert_equal( 'prompt', &buftype ) } )
+    call WaitForAssert( { -> assert_equal( 'i', mode() ) } )
+
+    call WaitForAssert( { -> assert_true(
+          \ youcompleteme#finder#GetState().id != -1 ) } )
+
+    call feedkeys( "\<C-w>w" )
+  endfunction
+
+  " <Leader> is \ - this calls <Plug>(YCMFindSymbolInWorkspace)
+  call FeedAndCheckMain( '\\w', funcref( 'PutQuery' ) )
+
+  call WaitForAssert( { -> assert_equal( l, winlayout() ) } )
+  call WaitForAssert( { -> assert_equal( original_win, winnr() ) } )
+  call assert_equal( b, bufnr() )
+
+  " Retuned to just where we started
+  call assert_equal( p, getpos( '.' ) )
+
+  " No notifiaction
+  if exists( '*popup_list' )
+    call assert_equal( 0, len( popup_list() ) )
+  endif
+
+  delfunct PutQuery
+  %bwipe!
+endfunction

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -1,27 +1,9 @@
 function! s:WaitForCommandRequestComplete()
-  call WaitForAssert( { ->
-        \ assert_true( py3eval(
-        \     'ycm_state.GetCommandRequest() is not None and '
-        \   . 'ycm_state.GetCommandRequest().Done()' ) )
-        \ } )
-
-  call WaitForAssert( { ->
-        \ assert_equal( -1,
-        \               youcompleteme#Test_GetPollers().command.id )
-        \ } )
+  return youcompleteme#test#commands#WaitForCommandRequestComplete()
 endfunction
 
 function! s:CheckNoCommandRequest()
-  call WaitForAssert( { ->
-        \ assert_true( py3eval(
-        \     'ycm_state.GetCommandRequest() is None or '
-        \   . 'ycm_state.GetCommandRequest().Done()' ) )
-        \ } )
-
-  call WaitForAssert( { ->
-        \ assert_equal( -1,
-        \               youcompleteme#Test_GetPollers().command.id )
-        \ } )
+  return youcompleteme#test#commands#CheckNoCommandRequest()
 endfunction
 
 function! s:CheckPopupVisible( row, col, text, syntax )

--- a/test/lib/autoload/youcompleteme/test/commands.vim
+++ b/test/lib/autoload/youcompleteme/test/commands.vim
@@ -1,0 +1,26 @@
+function! youcompleteme#test#commands#WaitForCommandRequestComplete() abort
+  call WaitForAssert( { ->
+        \ assert_true( py3eval(
+        \     'ycm_state.GetCommandRequest() is not None and '
+        \   . 'ycm_state.GetCommandRequest().Done()' ) )
+        \ } )
+
+  call WaitForAssert( { ->
+        \ assert_equal( -1,
+        \               youcompleteme#Test_GetPollers().command.id )
+        \ } )
+endfunction
+
+function! youcompleteme#test#commands#CheckNoCommandRequest() abort
+  call WaitForAssert( { ->
+        \ assert_true( py3eval(
+        \     'ycm_state.GetCommandRequest() is None or '
+        \   . 'ycm_state.GetCommandRequest().Done()' ) )
+        \ } )
+
+  call WaitForAssert( { ->
+        \ assert_equal( -1,
+        \               youcompleteme#Test_GetPollers().command.id )
+        \ } )
+endfunction
+

--- a/test/lib/run_test.vim
+++ b/test/lib/run_test.vim
@@ -383,6 +383,7 @@ EOF
 if exists( '$COVERAGE' )
   profile start .vim_profile
   exe 'profile! file */youcompleteme.vim'
+  exe 'profile! file */youcompleteme/**.vim'
 endif
 
 " Execute the tests in alphabetical order.


### PR DESCRIPTION
Demo: 

[![asciicast](https://asciinema.org/a/4JmYLAaz5hOHbZDD0hbsQpY8C.svg)](https://asciinema.org/a/4JmYLAaz5hOHbZDD0hbsQpY8C)

Basic idea is to provide "GoToSymbol" and "GoToDocumentOutline" using a "narrow-down-while-typing" approach similar to the insert completion popup.

To enable:

* `nmap <something> <Plug>(YCMFindSymbolInWorkspace)`
* `nmap <something> <Plug>(YCMFindSymbolInDocument)`

e.g.

* `nmap <leader>yfw <Plug>(YCMFindSymbolInWorkspace)`
* `nmap <leader>yfd <Plug>(YCMFindSymbolInDocument)`

Currently:

- "Workspace" search (GoToSymbol) relies on the _server_ (i.e. the LSP server) doing the filtering of the query. This is because none of the LSP servers I tested would return anything with query = ''. Therefore we can't easily use YCM's "filter and sort candidates" which would be preferable for consistency of "fuzzy" matching
- "Document" search (GoToDocumentOutline) uses YCM's filter and sort candidates because there is no server-side (i.e. LSP server) filtering for this request - it's all or nothing. 

After selecting an item, we jump to that item and if there are more than 1, we populate and open the quick fix window with any matches.

We use a prompt buffer for the input, and use the TextChanged events to update the current query, which is drawn in a massive popup taking up the entire screen. 

While the popup is open, we catch and handle some keys:

* `C-j`, `Down`, `C-n` - select the next item
* `C-k`, `Up`, `C-p` - select the previous item
* `Enter` - jump to the selected item
* `C-c` cancel/dismiss the popup

There are probably ways to improve this, it's just a starter for 10.

Of course, no neovim support.

Other ideas for improvement

* [x] What do we think now about the "Function" / etc. prefixes that the descriptions get from ycmd ?
* [x] For workspace we could use the server request _until we get any matches_, then switch to our filter/sort. this could mean we use our filter/sort on the meximal set of matches. If the query length is reduced, switch back to asking the server? Feels hacky, but may be worth a try
* [x] symntax highlighting in the popup
* [x] handle things like `C-d`/`C-u`/page up/down  to keyboard handler
* [x] Support mouse click to select, mouse wheel to change selection

more?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3859)
<!-- Reviewable:end -->
