### PR TITLE
[DOC] Updated Windows installation sect in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ that are conservatively turned off by default that you may want to turn on.
 #### Quick start, installing all completers
 
 - Install YCM plugin via [Vundle][]
-- Install [Visual Studio Build Tools 2017][visual-studio-download]
+- Install [Visual Studio Build Tools 2019][visual-studio-download]
 - Install cmake, vim and python
 - Install go, node and npm
 - Compile YCM
@@ -528,8 +528,8 @@ Download and install the following software:
   matching the version number exactly.
 - [CMake][cmake-download]. Add CMake executable to the PATH environment
   variable.
-- [Visual Studio Build Tools 2017][visual-studio-download]. During setup,
-  select _Visual C++ build tools_ in _Workloads_.
+- [Build Tools for Visual Studio 2019][visual-studio-download]. During setup,
+  select _C++ build tools_ in _Workloads_.
 
 Compiling YCM **with** semantic support for C-family languages through
 **clangd**:
@@ -3467,7 +3467,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [tsconfig.json]: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 [vim-win-download]: https://github.com/vim/vim-win32-installer/releases
 [python-win-download]: https://www.python.org/downloads/windows/
-[visual-studio-download]: https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15
+[visual-studio-download]: https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16
 [mono-install-macos]: https://www.mono-project.com/docs/getting-started/install/mac/
 [mono-install-linux]: https://www.mono-project.com/download/stable/#download-lin
 [go-install]: https://golang.org/doc/install

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -653,7 +653,7 @@ Windows ~
 Quick start, installing all completers ~
 
 - Install YCM plugin via Vundle [25]
-- Install Visual Studio Build Tools 2017 [34]
+- Install Visual Studio Build Tools 2019 [34]
 - Install cmake, vim and python
 - Install go, node and npm
 - Compile YCM
@@ -712,7 +712,7 @@ Download and install the following software:
 
 - CMake [38]. Add CMake executable to the PATH environment variable.
 
-- Visual Studio Build Tools 2017 [34]. During setup, select _Visual C++ build
+- Build Tools for Visual Studio 2019 [34]. During setup, select _C++ build
   tools_ in _Workloads_.
 
 Compiling YCM **with** semantic support for C-family languages through
@@ -3641,7 +3641,7 @@ References ~
 [31] https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 [32] https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source
 [33] https://www.mono-project.com/download/stable/#download-lin
-[34] https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15
+[34] https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16
 [35] https://vimhelp.appspot.com/starting.txt.html#vimrc
 [36] https://github.com/vim/vim-win32-installer/releases
 [37] https://www.python.org/downloads/windows/


### PR DESCRIPTION
Changed Visual studio Build Tools version from 2017 to 2019, since
this (2017) gave me an (well known) error. Now I know of --msvc,
but this way is more natural and intuitive for unexperienced
YouCompleteMe users like me. But I am not the only one as the issue
https://github.com/ycm-core/YouCompleteMe/issues/3472 shows.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]
You can see comments in code of this commit (below (If I understand github correctly)).
The main rationale is that if you follow the simple instructions in README.md, you will get an error as I already mentioned in commit message. Therefore I think it is more straightforward if you download Visual studio Build Tools version 2019 instead of 2017. This is why I want to change the README.md file as in this PR.

There are also some minor edits like Visual Studio Build Tools -> Build Tools for Visual Studio for this
is the officially written title of downloaded file.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3860)
<!-- Reviewable:end -->
