### PR TITLE
Lock closed issues older than 60 days

### DIFF
--- a/.github/workflows/lock_old_issues.yaml
+++ b/.github/workflows/lock_old_issues.yaml
@@ -1,0 +1,27 @@
+name: "Lock Old Issues"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '60'
+          # issue-exclude-created-before: ''
+          # issue-exclude-labels: ''
+          # issue-lock-labels: ''
+          # issue-lock-comment: ''
+          # issue-lock-reason: 'resolved'
+          # pr-lock-inactive-days: '365'
+          # pr-exclude-created-before: ''
+          # pr-exclude-labels: ''
+          # pr-lock-labels: ''
+          # pr-lock-comment: ''
+          # pr-lock-reason: 'resolved'
+          process-only: 'issues'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,12 @@ issue you found is **closed as resolved** (e.g. with a PR or the original user's
 problem was resolved), raise a **new issue**, because you've found a new
 problem. Reference the original issue if you think that's useful information.
 
-If you do find a similar open issue, **don't just post 'me too' or similar**
+Please note: Closed issues which have been inactive for 60 days will be locked,
+this helps to keep discussions focussed. If you believe you are still
+experiencing an issue which has been closed, please raise a new issue,
+completing the issue template.
+
+If you do find a similar _open_ issue, **don't just post 'me too' or similar**
 responses. This almost never helps resolve the issue, and just causes noise for
 the maintainers. Only post if it will aid the maintainers in solving the issue;
 if there are existing diagnostics requested in the thread, perform


### PR DESCRIPTION
This locks issues which are:
- issues, not PRs
- closed
- not updated in last 60 days.


Runs once a day at around midnight (in some timezone, shrug). Can be run manually.


Code for the action:
https://github.com/dessant/lock-threads/blob/master/src/index.js

Settings for the action:
https://github.com/dessant/lock-threads#inputs

Things we might want to do:

* [ ] also lock closed PRs ?
* [ ] add a custom message like "Locking issue as it is closed and has not been updated for 60 days"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3884)
<!-- Reviewable:end -->
