### PR TITLE
Context Free Symbol search: query all open filetypes and merge results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1814,6 +1814,9 @@ input, and puts you in insert mode. This means that you can hit `<Esc>` to go
 into normal mode and use any other input commands that are supported in prompt
 buffers. As you type characters, the search is updated.
 
+Intially, results are queried from all open filetypes. You can hit `<C-f>` to
+switch to just the current filetype while the popup is open.
+
 While the popup is open, the following keys are intercepted:
 
 * `<C-j>`, `<Down>`, `<C-n>`, `<Tab>` - select the next item
@@ -1824,6 +1827,7 @@ While the popup is open, the following keys are intercepted:
 * `<End>`, `<kEnd>` - jump to last item
 * `<CR>` - jump to the selected item
 * `<C-c>` cancel/dismiss the popup
+* `<C-f>` - toggle results from all file types or just the current filetype
 
 The search is also cancelled if you leave the prompt buffer window at any time,
 so you can use window commands `<C-w>...` for example.

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1361,6 +1361,7 @@ function! s:PollCommands( timer_id ) abort
 
     " This request is done
     call remove( s:pollers.command.requests, request_id )
+    py3 ycm_state.FlushCommandRequest( vim.eval( "request_id" ) )
     call request[ 'callback' ]( result )
   endfor
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -483,15 +483,6 @@ function! s:DisableOnLargeFile( buffer )
   return b:ycm_largefile
 endfunction
 
-function! s:HasAnyKey( dict, keys )
-  for key in a:keys
-    if has_key( a:dict, key )
-      return 1
-    endif
-  endfor
-  return 0
-endfunction
-
 function! s:PropertyTypeNotDefined( type )
   return exists( '*prop_type_add' ) &&
     \ index( prop_type_list(), a:type ) == -1
@@ -509,21 +500,13 @@ function! s:AllowedToCompleteInBuffer( buffer )
     let filetype = 'ycm_nofiletype'
   endif
 
-  let whitelist_allows = type( g:ycm_filetype_whitelist ) != v:t_dict ||
-        \ has_key( g:ycm_filetype_whitelist, '*' ) ||
-        \ s:HasAnyKey( g:ycm_filetype_whitelist, split( filetype, '\.' ) )
-  let blacklist_allows = type( g:ycm_filetype_blacklist ) != v:t_dict ||
-        \ !s:HasAnyKey( g:ycm_filetype_blacklist, split( filetype, '\.' ) )
-
-  let allowed = whitelist_allows && blacklist_allows
+  let allowed = youcompleteme#filetypes#AllowedForFiletype( filetype )
 
   if !allowed || s:DisableOnLargeFile( a:buffer )
     return 0
   endif
 
-  if allowed
-    let s:previous_allowed_buffer_number = bufnr( a:buffer )
-  endif
+  let s:previous_allowed_buffer_number = bufnr( a:buffer )
   return allowed
 endfunction
 

--- a/autoload/youcompleteme/filetypes.vim
+++ b/autoload/youcompleteme/filetypes.vim
@@ -1,0 +1,36 @@
+" Copyright (C) 2011-2018 YouCompleteMe contributors
+"
+" This file is part of YouCompleteMe.
+"
+" YouCompleteMe is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" YouCompleteMe is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+
+function! s:HasAnyKey( dict, keys ) abort
+  for key in a:keys
+    if has_key( a:dict, key )
+      return 1
+    endif
+  endfor
+  return 0
+endfunction
+
+function! youcompleteme#filetypes#AllowedForFiletype( filetype ) abort
+  let whitelist_allows = type( g:ycm_filetype_whitelist ) != v:t_dict ||
+        \ has_key( g:ycm_filetype_whitelist, '*' ) ||
+        \ s:HasAnyKey( g:ycm_filetype_whitelist, split( a:filetype, '\.' ) )
+  let blacklist_allows = type( g:ycm_filetype_blacklist ) != v:t_dict ||
+        \ !s:HasAnyKey( g:ycm_filetype_blacklist, split( a:filetype, '\.' ) )
+
+  return whitelist_allows && blacklist_allows
+endfunction

--- a/autoload/youcompleteme/finder.vim
+++ b/autoload/youcompleteme/finder.vim
@@ -240,7 +240,6 @@ function! youcompleteme#finder#FindSymbol( scope ) abort
   augroup YCMPromptFindSymbol
     autocmd!
     autocmd TextChanged,TextChangedI <buffer> call s:OnQueryTextChanged()
-    autocmd TextChanged,TextChanged <buffer> call s:OnQueryTextChanged()
     autocmd WinLeave <buffer> call s:Cancel()
     autocmd CmdLineEnter <buffer> call s:Cancel()
   augroup END

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -37,10 +37,15 @@ class CommandRequest( BaseRequest ):
     self._request_data = None
     self._response_future = None
     self._silent = silent
+    self._bufnr = extra_data.pop( 'bufnr', None ) if extra_data else None
 
 
   def Start( self ):
-    self._request_data = BuildRequestData()
+    if self._bufnr is not None:
+      self._request_data = BuildRequestData( self._bufnr )
+    else:
+      self._request_data = BuildRequestData()
+
     if self._extra_data:
       self._request_data.update( self._extra_data )
     self._request_data.update( {

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -148,6 +148,7 @@ class CommandTest( TestCase ):
         '',
         'same-buffer',
         {
+          'completer_target': 'python',
           'options': {
             'tab_size': 2,
             'insert_spaces': True
@@ -156,7 +157,7 @@ class CommandTest( TestCase ):
       )
 
       with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-        ycm.SendCommandRequest( [ 'ft=ycm:ident', 'GoTo' ], '', False, 1, 1 )
+        ycm.SendCommandRequest( [ 'ft=python', 'GoTo' ], '', False, 1, 1 )
         send_request.assert_called_once_with( *expected_args )
 
       with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -784,6 +784,16 @@ def EscapeForVim( text ):
   return ToUnicode( text.replace( "'", "''" ) )
 
 
+def AllOpenedFiletypes():
+  """Returns a dict mapping filetype to list of buffer numbers for all open
+  buffers"""
+  filetypes = defaultdict( list )
+  for buffer in vim.buffers:
+    for filetype in FiletypesForBuffer( buffer ):
+      filetypes[ filetype ].append( buffer.number )
+  return filetypes
+
+
 def CurrentFiletypes():
   filetypes = vim.eval( "&filetype" )
   if not filetypes:

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -375,21 +375,24 @@ class YouCompleteMe:
                                    has_range,
                                    start_line,
                                    end_line ):
-    final_arguments = []
-    for argument in arguments:
-      # The ft= option which specifies the completer when running a command is
-      # ignored because it has not been working for a long time. The option is
-      # still parsed to not break users that rely on it.
-      if argument.startswith( 'ft=' ):
-        continue
-      final_arguments.append( argument )
-
     extra_data = {
       'options': {
         'tab_size': vimsupport.GetIntValue( 'shiftwidth()' ),
         'insert_spaces': vimsupport.GetBoolValue( '&expandtab' )
       }
     }
+
+    final_arguments = []
+    for argument in arguments:
+      if argument.startswith( 'ft=' ):
+        extra_data[ 'completer_target' ] = argument[ 3: ]
+        continue
+      elif argument.startswith( '--bufnr=' ):
+        extra_data[ 'bufnr' ] = int( argument[ len( '--bufnr=' ): ] )
+        continue
+
+      final_arguments.append( argument )
+
     if has_range:
       extra_data.update( vimsupport.BuildRange( start_line, end_line ) )
     self._AddExtraConfDataIfNeeded( extra_data )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -448,6 +448,10 @@ class YouCompleteMe:
     return self._command_requests.get( request_id )
 
 
+  def FlushCommandRequest( self, request_id ):
+    self._command_requests.pop( request_id, None )
+
+
   def GetDefinedSubcommands( self ):
     request = BaseRequest()
     subcommands = request.PostDataToHandler( BuildRequestData(),

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -119,7 +119,8 @@ class YouCompleteMe:
     self._latest_completion_request = None
     self._latest_signature_help_request = None
     self._signature_help_available_requests = SigHelpAvailableByFileType()
-    self._latest_command_reqeust = None
+    self._command_requests = {}
+    self._next_command_request_id = 0
 
     self._signature_help_state = signature_help.SignatureHelpState()
     self._user_options = base.GetUserOptions( self._default_options )
@@ -434,12 +435,17 @@ class YouCompleteMe:
       False,
       0,
       0 )
-    self._latest_command_reqeust = SendCommandRequestAsync( final_arguments,
-                                                            extra_data )
+
+    request_id = self._next_command_request_id
+    self._next_command_request_id += 1
+    self._command_requests[ request_id ] = SendCommandRequestAsync(
+      final_arguments,
+      extra_data )
+    return request_id
 
 
-  def GetCommandRequest( self ):
-    return self._latest_command_reqeust
+  def GetCommandRequest( self, request_id ):
+    return self._command_requests.get( request_id )
 
 
   def GetDefinedSubcommands( self ):

--- a/test/finder.test.vim
+++ b/test/finder.test.vim
@@ -677,9 +677,15 @@ function! Test_WorkspaceSymbol_NormalModeChange()
     call WaitForAssert( { -> assert_true(
           \ youcompleteme#finder#GetState().id != -1 ) } )
 
+    let popup_id = youcompleteme#finder#GetState().id
+    call WaitForAssert( { ->
+          \ assert_equal( ' [X] Search for symbol: thiswillnotmatchanything ',
+          \ popup_getoptions( popup_id ).title  ) },
+          \ 10000 )
+
     let id = youcompleteme#finder#GetState().id
     call assert_equal( 'No results', getbufline( winbufnr( id ), '$' )[ 0 ] )
-    call FeedAndCheckAgain( 'thisisathing', funcref( 'ChangeQuery' ) )
+    call FeedAndCheckAgain( "\<C-u>thisisathing", funcref( 'ChangeQuery' ) )
   endfunction
 
   function ChangeQuery( ... )
@@ -722,7 +728,7 @@ function! Test_WorkspaceSymbol_NormalModeChange()
   endfunction
 
   " <Leader> is \ - this calls <Plug>(YCMFindSymbolInWorkspace)
-  call FeedAndCheckMain( '\\w', funcref( 'PutQuery' ) )
+  call FeedAndCheckMain( '\\wthiswillnotmatchanything', funcref( 'PutQuery' ) )
 
   call WaitForAssert( { -> assert_equal( l, winlayout() ) } )
   call WaitForAssert( { -> assert_equal( original_win, winnr() ) } )

--- a/test/lib/autoload/youcompleteme/test/commands.vim
+++ b/test/lib/autoload/youcompleteme/test/commands.vim
@@ -1,8 +1,10 @@
 function! youcompleteme#test#commands#WaitForCommandRequestComplete() abort
   call WaitForAssert( { ->
         \ assert_true( py3eval(
-        \     'ycm_state.GetCommandRequest() is not None and '
-        \   . 'ycm_state.GetCommandRequest().Done()' ) )
+        \     'ycm_state.GetCommandRequest( '
+        \   . '  ycm_state._next_command_request_id - 1 ) is not None and '
+        \   . 'ycm_state.GetCommandRequest(  '
+        \   . '  ycm_state._next_command_request_id - 1 ).Done()' ) )
         \ } )
 
   call WaitForAssert( { ->
@@ -14,8 +16,10 @@ endfunction
 function! youcompleteme#test#commands#CheckNoCommandRequest() abort
   call WaitForAssert( { ->
         \ assert_true( py3eval(
-        \     'ycm_state.GetCommandRequest() is None or '
-        \   . 'ycm_state.GetCommandRequest().Done()' ) )
+        \     'ycm_state.GetCommandRequest( '
+        \   . '  ycm_state._next_command_request_id - 1 ) is None or '
+        \   . 'ycm_state.GetCommandRequest( '
+        \   . '  ycm_state._next_command_request_id - 1 ).Done()' ) )
         \ } )
 
   call WaitForAssert( { ->


### PR DESCRIPTION
Sorry this is a pretty big PR. May help to review by commits, as the earlier commits make the underlying changes, and the later commits implement the functional changes.

I frequently found myself wanting to query any part of my current "workspace" irrespective of current context.

In particular, my mental model was of using a "C++ project" but if my cursor was in a config file or script, then the symbol search just wouldn't work.  As I said on GItter:

> This is the kind of thing where we want it to feel intuitive. In my case about 8/10 times I was working in a c++ project but had say a config file or script open in the current buffer. My “mental model” was that I was working in c++ but I actually was working in, say, TCL at that moment.


So instead we query for each open filetype for which YCM is not blacklisted.

In order for this to feel snappy, we have to be able to request the symbols from multiple filetypes at the same time. This required some changes:

* allow multiple simultaneous command requests. This is not breaking change, as the result was always delivered from a callback. This works by associating an ID with each request and having the poller just check each pending request and call the appropriate one(s). this is way better than a timer-per-request in my testing. 
* make the "pending request" part of symbol popup handling recording any filetypes which are "busy" when the query last changed, then sending a new request when responses come in).
* store raw results in a per-filetype map.

Of course, this only applies to the workspace search, not the document search, which naturally context sensitive.

I also added the filetype to the popup window/buffer. This is a little tricky to code due to trying to get the widths right, but looks like this:

<img width="595" alt="Screenshot-2021-04-30-at-18 12 21" src="https://user-images.githubusercontent.com/10584846/117061025-97f2ee00-ad19-11eb-8710-42a5f16526b3.png">

Incidentally I have a ycmd change that will make the typescript symbols highlight correctly.

May help to review by commits, as the earlier commits make the underlying changes, and the later commits tell a bit of a story about how this was developed (first dumbly with all requests waiting for each other, then with the more complex pending requests mechanism).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3886)
<!-- Reviewable:end -->
