### PR TITLE
Use the standard library for memoizing return values

### DIFF
--- a/python/ycm/signature_help.py
+++ b/python/ycm/signature_help.py
@@ -64,7 +64,7 @@ def _MakeSignatureHelpBuffer( signature_info ):
   return lines
 
 
-@memoize
+@memoize()
 def ShouldUseSignatureHelp():
   return ( vimsupport.VimHasFunctions( 'screenpos', 'pum_getpos' ) and
            vimsupport.VimSupportsPopupWindows() )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -22,7 +22,7 @@ MockVimModule()
 
 from ycm import vimsupport
 from hamcrest import ( assert_that, calling, contains_exactly, empty, equal_to,
-                       has_entry, is_not, raises )
+                       has_entry, raises )
 from unittest.mock import MagicMock, call, patch
 from ycmd.utils import ToBytes
 import os
@@ -2018,36 +2018,3 @@ def VimVersionAtLeast_test():
   assert_that( not vimsupport.VimVersionAtLeast( '7.4.1579' ) )
   assert_that( not vimsupport.VimVersionAtLeast( '7.4.1898' ) )
   assert_that( not vimsupport.VimVersionAtLeast( '8.1.278' ) )
-
-
-@patch( 'ycm.vimsupport.GetIntValue', return_value = 1 )
-def VimSupportsPopupWindows_Memo_test( *args ):
-  vimsupport.MEMO = {}
-
-  try:
-    assert_that( vimsupport.VimSupportsPopupWindows() )
-    assert_that( vimsupport.MEMO, is_not( empty() ) )
-
-    # If the momizer did not step in, we would throw an error in the following
-    # call to VimVersionAtLeast
-    with patch( 'ycm.vimsupport.VimHasFunctions', side_effect = RuntimeError ):
-      assert_that( vimsupport.VimSupportsPopupWindows() )
-  finally:
-    vimsupport.MEMO = {}
-
-
-@patch( 'ycm.vimsupport.GetIntValue', return_value = 1 )
-def VimHasFunction_Memo_test( GetIntValue ):
-  vimsupport.MEMO = {}
-
-  try:
-    assert_that( vimsupport.VimHasFunction( 'test' ) )
-    assert_that( vimsupport.MEMO, is_not( empty() ) )
-
-    GetIntValue.return_value = 0
-
-    # If the memoizer didn't kick in, the following call would return False
-    assert_that( vimsupport.VimHasFunction( 'test' ) )
-
-  finally:
-    vimsupport.MEMO = {}

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -20,6 +20,7 @@ import os
 import json
 import re
 from collections import defaultdict, namedtuple
+from functools import lru_cache as memoize
 from ycmd.utils import ( ByteOffsetToCodepointOffset,
                          GetCurrentDirectory,
                          JoinLinesAsUnicode,
@@ -70,29 +71,6 @@ NO_COMPLETIONS = {
   'completion_start_column': -1,
   'completions': []
 }
-
-# checking for existence of funcitons is a little slow and can't change at
-# tuntime, so we cache the results
-MEMO = {}
-
-
-def memoize( func ):
-  global MEMO
-
-  import functools
-
-  @functools.wraps( func )
-  def wrapper( *args, **kwargs ):
-    dct = MEMO.setdefault( func, {} )
-    key = ( args, frozenset( kwargs.items() ) )
-    try:
-      return dct[ key ]
-    except KeyError:
-      result = func( *args, **kwargs )
-      dct[ key ] = result
-      return result
-
-  return wrapper
 
 
 def CurrentLineAndColumn():
@@ -1275,7 +1253,7 @@ def AutoCloseOnCurrentBuffer( name ):
   vim.command( 'augroup END' )
 
 
-@memoize
+@memoize()
 def VimSupportsPopupWindows():
   return VimHasFunctions( 'popup_create',
                           'popup_move',
@@ -1287,7 +1265,7 @@ def VimSupportsPopupWindows():
                           'prop_type_add' )
 
 
-@memoize
+@memoize()
 def VimHasFunction( func ):
   return bool( GetIntValue( f"exists( '*{ EscapeForVim( func ) }' )" ) )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Python, since 3.2, provides [`@lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache), which is more flexible than our `@memoize`. We don't really need the extra features.

https://github.com/python/cpython/blob/main/Lib/functools.py#L479-L644

Considering the complexity, I'm not sure we want `@lru_cache` instead of our own version. For a trivial function, the retrieval from the cache was done in ~100us.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3923)
<!-- Reviewable:end -->
