### PR TITLE
[RFC] Do not call complete() if the cursor changed position since the completion request

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -222,6 +222,7 @@ function! youcompleteme#EnableCursorMovedAutocommands()
   augroup ycmcompletemecursormove
     autocmd!
     autocmd CursorMoved * call s:OnCursorMovedNormalMode()
+    autocmd CursorMovedI * let s:current_cursor_position = getpos( '.' )
     autocmd TextChanged * call s:OnTextChangedNormalMode()
     autocmd TextChangedI * call s:OnTextChangedInsertMode( v:false )
     autocmd TextChangedP * call s:OnTextChangedInsertMode( v:true )
@@ -844,6 +845,7 @@ function! s:OnTextChangedInsertMode( popup_is_visible )
     return
   endif
 
+  let s:current_cursor_position = getpos( '.' )
   if s:completion_stopped
     let s:completion_stopped = 0
     let s:completion = s:default_completion
@@ -1038,7 +1040,9 @@ function! s:PollCompletion( ... )
   endif
 
   let s:completion = py3eval( 'ycm_state.GetCompletionResponse()' )
-  call s:Complete()
+  if s:current_cursor_position == getpos( '.' )
+    call s:Complete()
+  endif
 endfunction
 
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This can happen if there's another async plugin that can change cursor
position, like matchup. In that case, it's a race condition between YCM
completing correctly and the plugin movin the cursor some place else.

The workaround here is to make sure the cursor position at request is
the same as cursor position at `complete()` time. As a result:

1. Erratic cursor movement won't mess up the buffer content and get in
   the way of typing.
2. Occasionally, YCM won't call `complete()` in a situation where a user
   might expect it to, but that's a direct consequence of `1`.
3. YCM will have spuroius "identifier complete" actions which means that
   "half" of a word might end up in identifier completer's database and
   subsequently suggested as a candidate. This is only temporary and the
   whole thing is eventually-consistent.

RFC because I'd like to see more human trials before merging. No tests, because I have no idea how to test this.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3953)
<!-- Reviewable:end -->
