### PR TITLE
[READY] Do not assume current buffer in vimsupport.LineAndColumnNumbersClamped()

### DIFF
--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -135,6 +135,7 @@ class DiagnosticInterface:
       # Insert squiggles in reverse order so that errors overlap warnings.
       for diag in reversed( diags ):
         for line, column, name, extras in _ConvertDiagnosticToTextProperties(
+            self._bufnr,
             diag ):
           global YCM_VIM_PROPERTY_ID
 
@@ -213,7 +214,7 @@ def _NormalizeDiagnostic( diag ):
   return diag
 
 
-def _ConvertDiagnosticToTextProperties( diagnostic ):
+def _ConvertDiagnosticToTextProperties( bufnr, diagnostic ):
   properties = []
 
   name = ( 'YcmErrorProperty' if _DiagnosticIsError( diagnostic ) else
@@ -225,16 +226,19 @@ def _ConvertDiagnosticToTextProperties( diagnostic ):
   if location_extent[ 'start' ][ 'line_num' ] <= 0:
     location = diagnostic[ 'location' ]
     line, column = vimsupport.LineAndColumnNumbersClamped(
+      bufnr,
       location[ 'line_num' ],
       location[ 'column_num' ]
     )
     properties.append( ( line, column, name, {} ) )
   else:
     start_line, start_column = vimsupport.LineAndColumnNumbersClamped(
+      bufnr,
       location_extent[ 'start' ][ 'line_num' ],
       location_extent[ 'start' ][ 'column_num' ]
     )
     end_line, end_column = vimsupport.LineAndColumnNumbersClamped(
+      bufnr,
       location_extent[ 'end' ][ 'line_num' ],
       location_extent[ 'end' ][ 'column_num' ]
     )
@@ -247,10 +251,12 @@ def _ConvertDiagnosticToTextProperties( diagnostic ):
 
   for diagnostic_range in diagnostic[ 'ranges' ]:
     start_line, start_column = vimsupport.LineAndColumnNumbersClamped(
+      bufnr,
       diagnostic_range[ 'start' ][ 'line_num' ],
       diagnostic_range[ 'start' ][ 'column_num' ]
     )
     end_line, end_column = vimsupport.LineAndColumnNumbersClamped(
+      bufnr,
       diagnostic_range[ 'end' ][ 'line_num' ],
       diagnostic_range[ 'end' ][ 'column_num' ]
     )

--- a/python/ycm/tests/diagnostic_interface_test.py
+++ b/python/ycm/tests/diagnostic_interface_test.py
@@ -15,9 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 from ycm import diagnostic_interface
-from ycm.tests.test_utils import VimBuffer, MockVimModule
+from ycm.tests.test_utils import VimBuffer, MockVimModule, MockVimBuffers
 from hamcrest import assert_that, contains_exactly, has_entries, has_item
-from unittest.mock import patch
 from unittest import TestCase
 MockVimModule()
 
@@ -92,10 +91,13 @@ class DiagnosticInterfaceTest( TestCase ):
       ],
     ]:
       with self.subTest( diag = diag, contents = contents, result = result ):
-        current_buffer = VimBuffer( 'some_file', contents = contents )
+        current_buffer = VimBuffer( 'foo', number = 1, contents = [ '' ] )
+        target_buffer = VimBuffer( 'bar', number = 2, contents = contents )
 
-        with patch( 'vim.current.buffer', current_buffer ):
+        with MockVimBuffers( [ current_buffer, target_buffer ],
+                             [ current_buffer, target_buffer ] ):
           actual = diagnostic_interface._ConvertDiagnosticToTextProperties(
-                                          diag )
+              target_buffer.number,
+              diag )
           print( actual )
           assert_that( actual, result )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -284,10 +284,11 @@ def RemoveTextProperty( buffer_number: int, prop: DiagnosticProperty ):
 
 # Clamps the line and column numbers so that they are not past the contents of
 # the buffer. Numbers are 1-based byte offsets.
-def LineAndColumnNumbersClamped( line_num, column_num ):
-  line_num = max( min( line_num, len( vim.current.buffer ) ), 1 )
-  # Vim buffers are a list of Unicode objects on Python 3.
-  max_column = len( ToBytes( vim.current.buffer[ line_num - 1 ] ) ) + 1
+def LineAndColumnNumbersClamped( bufnr, line_num, column_num ):
+  vim_buffer = vim.buffers[ bufnr ]
+  line_num = max( min( line_num, len( vim_buffer ) ), 1 )
+  # Vim buffers are lists Unicode objects on Python 3.
+  max_column = len( ToBytes( vim_buffer[ line_num - 1 ] ) ) + 1
 
   return line_num, max( min( column_num, max_column ), 1 )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Before the big diagnostics refactor, we only served diagnostics for the
current buffer. That allowed `vimsupport.LineAndColumnNumbersClamped()`
to assume `vim.current.buffer` was always correct.

That is no longer the case - we were clamping offsets to, potentially,
the contents of a wrong buffer. More specifically, if

1. Current buffer is not the same buffer we are updating diagnostics
   for.
2. Current buffer does not have line number of the target buffer
   diagnostics.

Then we end up wrongfully "moving" the line of the diagnostic. On top of
that, if the target buffer's "moved" line is shorter than the start column of
the diagnostic, then we're still out of bounds.

Fixes #3964 

Thanks to @ddmin for providing a simple way to repro.

I'll try to make a proper vim level test later.

A test for this would be very much expected, but I'm just not sure 

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3965)
<!-- Reviewable:end -->
