### PR TITLE
[READY] Avoid KeyError when a different plugin's property type gets deleted

### DIFF
--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -597,6 +597,11 @@ class VimProp:
       return self.end_column - self.start_column
 
 
+  def get( self, key, default = None ):
+    if key == 'type':
+      return self.prop_type
+
+
 class VimSign:
 
   def __init__( self, line, name, bufnr ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -221,7 +221,7 @@ def GetTextProperties( buffer_number ):
           line_number + 1,
           int( p[ 'col' ] ),
           int( p[ 'length' ] ) )
-        for p in vim_props if p[ 'type' ].startswith( 'Ycm' )
+        for p in vim_props if p.get( 'type', '' ).startswith( 'Ycm' )
       )
     return properties
   else:

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -184,3 +184,13 @@ function! Test_BufferWithoutAssociatedFile_HighlightingWorks()
     \    'start': 1 } ]
   call assert_equal( expected_properties, prop_list( 1 ) )
 endfunction
+
+function! Test_ThirdPartyDeletesItsTextProperty()
+  enew
+  call prop_type_add( 'ThirdPartyProperty', { 'highlight': 'Error' } )
+  call prop_add( 1, 1, { 'type': 'ThirdPartyProperty', 'bufnr': bufnr('%'), 'id': 42 } )
+  call prop_type_delete( 'ThirdPartyProperty' )
+
+  py3 from ycm.vimsupport import GetTextProperties, GetIntValue
+  call assert_equal( [], py3eval( 'GetTextProperties( GetIntValue( """bufnr( "%" )""" ) )' ) )
+endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

`vimsupport.GetTextProperties()` goes over all the properties in a
buffer. Then it filters for those whose type starts with `Ycm`.

However, if a plugin ever deletes its property type but leaves around a
property of that type, `prop_list()` will not contain the property type
for that property. This is where we previously encounter a rather nasty
`KeyError`.

I really wish vim had a nicer API for listing properties.

This bug was reported by @roachsinai on gitter.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3966)
<!-- Reviewable:end -->
