### PR TITLE
[READY] Move ycm_state.UpdateMatches() to s:OnBufferEnter()

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -185,13 +185,12 @@ function! youcompleteme#Enable()
     " buffer is already parsed.
     autocmd BufWritePost,FileWritePost * call s:OnFileSave()
     autocmd FileType * call s:OnFileTypeSet()
-    autocmd BufEnter,CmdwinEnter * call s:OnBufferEnter()
+    autocmd BufEnter,CmdwinEnter,WinEnter * call s:OnBufferEnter()
     autocmd BufUnload * call s:OnBufferUnload()
     autocmd InsertLeave * call s:OnInsertLeave()
     autocmd VimLeave * call s:OnVimLeave()
     autocmd CompleteDone * call s:OnCompleteDone()
     autocmd CompleteChanged * call s:OnCompleteChanged()
-    autocmd BufEnter,WinEnter * call s:UpdateMatches()
   augroup END
 
   " The FileType event is not triggered for the first loaded file. We wait until
@@ -698,6 +697,7 @@ function! s:OnBufferEnter()
   call s:SetUpCompleteopt()
   call s:EnableCompletingInCurrentBuffer()
 
+  py3 ycm_state.UpdateMatches()
   py3 ycm_state.OnBufferVisit()
   " Last parse may be outdated because of changes from other buffers. Force a
   " new parse.
@@ -714,11 +714,6 @@ function! s:OnBufferUnload()
   endif
 
   py3 ycm_state.OnBufferUnload( vimsupport.GetIntValue( 'buffer_number' ) )
-endfunction
-
-
-function! s:UpdateMatches()
-  py3 ycm_state.UpdateMatches()
 endfunction
 
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This change does away with s:UpdateMatches(), for the sake of
performance in large files.

Previously, we would still try to update diagnostics in large files,
which would result in YCM calling a vim API for every line in that large
file.

The obvious solution - just call `s:AllowedToCompleteInCurrentBuffer()`
in `s:UpdateMatches()` - doesn't work, because it make
`s:OnBufferEnter()` return early as well, because
`s:VisitedBufferRequiresReparse() == false`. That makes
`s:OnBufferEnter()` skip the rest of the setup of completion.

Yes, this means that vimscript API for getting the text properties is
very inefficient.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3969)
<!-- Reviewable:end -->
