### PR TITLE
[READY] Do not error when trying to complete without typing any characters

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -223,6 +223,7 @@ function! youcompleteme#EnableCursorMovedAutocommands()
     autocmd!
     autocmd CursorMoved * call s:OnCursorMovedNormalMode()
     autocmd CursorMovedI * let s:current_cursor_position = getpos( '.' )
+    autocmd InsertEnter * let s:current_cursor_position = getpos( '.' )
     autocmd TextChanged * call s:OnTextChangedNormalMode()
     autocmd TextChangedI * call s:OnTextChangedInsertMode( v:false )
     autocmd TextChangedP * call s:OnTextChangedInsertMode( v:true )

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -336,7 +336,7 @@ function! Test_Completion_FixIt()
   call youcompleteme#test#setup#OpenFile(
         \ 'test/testdata/cpp/auto_include.cc', {} )
 
-  function Check1( id )
+  function! Check1( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'do_a' )
     call CheckCompletionItemsContainsExactly( [ 'do_a_thing(Thing thing)',
@@ -344,7 +344,7 @@ function! Test_Completion_FixIt()
     call FeedAndCheckAgain( "\<Tab>" , funcref( 'Check2' ) )
   endfunction
 
-  function Check2( id )
+  function! Check2( id )
     call WaitForCompletion()
     call CheckCurrentLine( 'do_a_thing' )
     call CheckCompletionItemsContainsExactly( [ 'do_a_thing(Thing thing)',
@@ -353,7 +353,7 @@ function! Test_Completion_FixIt()
   endfunction
 
 
-  function Check3( id )
+  function! Check3( id )
     call WaitForAssert( {-> assert_false( pumvisible(), 'pumvisible()' ) } )
     call CheckCurrentLine( 'do_a_thing(' )
     call assert_equal( '#include "auto_include.h"', getline( 1 ) )
@@ -422,4 +422,20 @@ function! Test_Select_Next_Previous_InsertModeMapping()
 
   call test_override( 'ALL', 0 )
   iunmap <C-n>
+endfunction
+
+function! Test_Completion_WorksWithoutMovingCursor()
+  call youcompleteme#test#setup#OpenFile(
+        \ 'test/testdata/cpp/auto_include_workaround.cc', {} )
+
+  function! Check( id )
+    call WaitForCompletion() " We don't care about completion
+                             " items, just that we didn't error
+                             " while opening the completion pum
+                             " without typing anything first.
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+  call setpos( '.', [ 0, 3, 1 ] )
+  call FeedAndCheckMain( "i\<C-Space>", funcref( 'Check' ) )
 endfunction


### PR DESCRIPTION
Pull request #3953 introduced cursor tracking via
s:current_cursor_position, which used to be set on `TextChangedI` and
`CursorMovedI`.

If neither of those events happen and YCM attempts completion, a user
would see a vim stack trace.

This is possible if forcing semantic completion immediately after
entering insert mode. To fix this, we also set
`s:current_cursor_position` on `InsertEnter`.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3982)
<!-- Reviewable:end -->
