### PR TITLE
Auto open possible folding when jumping to a location

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1701,6 +1701,7 @@ class VimsupportTest( TestCase ):
       assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1722,6 +1723,7 @@ class VimsupportTest( TestCase ):
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
         call( f'keepjumps belowright edit { target_name }' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1740,6 +1742,7 @@ class VimsupportTest( TestCase ):
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
         call( f'keepjumps botright split { target_name }' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1758,6 +1761,7 @@ class VimsupportTest( TestCase ):
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
         call( f'keepjumps leftabove edit { target_name }' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1835,6 +1839,7 @@ class VimsupportTest( TestCase ):
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
         call( f'keepjumps aboveleft split { target_name }' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1863,6 +1868,7 @@ class VimsupportTest( TestCase ):
       assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1892,6 +1898,7 @@ class VimsupportTest( TestCase ):
       assert_that( vim.current.window.cursor, equal_to( ( 4, 0 ) ) )
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1913,6 +1920,7 @@ class VimsupportTest( TestCase ):
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
         call( f'keepjumps tab split { target_name }' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1940,6 +1948,7 @@ class VimsupportTest( TestCase ):
         assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
         vim_command.assert_has_exact_calls( [
           call( 'normal! m\'' ),
+          call( 'normal! zv' ),
           call( 'normal! zz' )
         ] )
 
@@ -1961,6 +1970,7 @@ class VimsupportTest( TestCase ):
       vim_command.assert_has_exact_calls( [
         call( 'normal! m\'' ),
         call( f'keepjumps aboveleft vertical tabedit { target_name }' ),
+        call( 'normal! zv' ),
         call( 'normal! zz' )
       ] )
 
@@ -1988,6 +1998,7 @@ class VimsupportTest( TestCase ):
         assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
         vim_command.assert_has_exact_calls( [
           call( 'normal! m\'' ),
+          call( 'normal! zv' ),
           call( 'normal! zz' )
         ] )
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -527,6 +527,8 @@ def TryJumpLocationInTab( tab, filename, line, column ):
       vim.current.window = win
       vim.current.window.cursor = ( line, column - 1 )
 
+      # Open possible folding at location
+      vim.command( 'normal! zv' )
       # Center the screen on the jumped-to location
       vim.command( 'normal! zz' )
       return True
@@ -604,6 +606,8 @@ def JumpToLocation( filename, line, column, modifiers, command ):
 
   vim.current.window.cursor = ( line, column - 1 )
 
+  # Open possible folding at location
+  vim.command( 'normal! zv' )
   # Center the screen on the jumped-to location
   vim.command( 'normal! zz' )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
  no new test, but updated vimsupport_test.py to match updated vimsupport.py
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
I work with large code files with folding enabled (I suppose this is quite common settings for vim users), when using YCM GoTo to jump around the code, I need to press zv every time when jumping in middle of a closed folding. Similar behavior in Vim Termdebug has been reported and patched.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3990)
<!-- Reviewable:end -->
