### PR TITLE
Generalize path to Homebrew-installed java on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ $ brew install cmake python go nodejs
 
 ```
 $ brew install java
-$ sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+$ sudo ln -sfn $(brew --prefix java)/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
 ```
 
 - Pre-installed macOS *system* Vim does not support Python 3. So you need to


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Installation instructions for macOS recommend to install and link Java via Homebrew with the following commands:

```
$ brew install java
$ sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
```

However, on my new computer, Homebrew installs `java` into `/opt/homebrew/opt/openjdk` instead of `/usr/local/opt/openjdk`.
I don't know the reason for the path change. Probably it is due to the OS changes, as I have Homebrew 3.3.9 on macOS Catalina and Monterey with different paths.

Anyway, the PR changes `/usr/local/opt/openjdk` part to `$(brew --prefix java)` that should give the correct path to the `java` package.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4000)
<!-- Reviewable:end -->
