### PR TITLE
Implement manual toggling of signature help popup visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,19 @@ leave insert mode. There is no key binding to clear the popup.
 For more details on this feature and a few demos, check out the
 [PR that proposed it][signature-help-pr].
 
+#### Dismiss signature help
+
+The signature help popup sometimes gets in the way. You can toggle its
+visibility with a mapping. YCM provides the "Plug" mapping
+`<Plug>(YCMToggleSignatureHelp)` for this.
+
+For example, to hide/show the signature help popup by pressing Ctrl+l in insert
+mode: `imap <silent> <C-l> <Plug>(YCMToggleSignatureHelp)`.
+
+_NOTE_: No default mapping is provided because insert mappings are very
+difficult to create without breaking or overriding some existing functionality.
+Ctrl-l is not a suggestion, just an example.
+
 ### General Semantic Completion
 
 You can use Ctrl+Space to trigger the completion suggestions anywhere, even

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1483,6 +1483,16 @@ function! youcompleteme#Test_GetPollers()
   return s:pollers
 endfunction
 
+function! s:ToggleSignatureHelp()
+  call py3eval( 'ycm_state.ToggleSignatureHelp()' )
+  " Because we do this in a insert-mode mapping, we return empty string to
+  " insert/type nothing
+  return ''
+endfunction
+
+silent! inoremap <silent> <plug>(YCMToggleSignatureHelp)
+      \ <C-r>=<SID>ToggleSignatureHelp()<CR>
+
 " This is basic vim plugin boilerplate
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -39,6 +39,7 @@ Contents ~
   2. Client-Server Architecture      |youcompleteme-client-server-architecture|
   3. Completion String Ranking        |youcompleteme-completion-string-ranking|
   4. Signature Help                              |youcompleteme-signature-help|
+   1. Dismiss signature help             |youcompleteme-dismiss-signature-help|
   5. General Semantic Completion    |youcompleteme-general-semantic-completion|
   6. C-family Semantic Completion  |youcompleteme-c-family-semantic-completion|
    1. Installation
@@ -461,7 +462,7 @@ Quick start, installing all completers ~
 
 - Install YCM plugin via Vundle [25]
 - Install CMake, MacVim and Python 3; Note that the pre-installed _macOS
-  system_ vim is not supported (due to it having broken Python intetgration).
+  system_ vim is not supported (due to it having broken Python integration).
 >
   $ brew install cmake python go nodejs
 <
@@ -472,7 +473,7 @@ Quick start, installing all completers ~
   Homebrew:
 >
   $ brew install java
-  $ sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+  $ sudo ln -sfn $(brew --prefix java)/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
 <
 - Pre-installed macOS _system_ Vim does not support Python 3. So you need to
   install either a Vim that supports Python 3 OR MacVim [27] with Homebrew
@@ -493,10 +494,10 @@ Quick start, installing all completers ~
   cd ~/.vim/bundle/YouCompleteMe
   python3 install.py --all
 <
-- If you have troubles with finding system frameworks or C++ stanard library,
-  try using the homebrew llvm:
+- If you have troubles with finding system frameworks or C++ standard
+  library, try using the homebrew llvm:
 >
-  brea install llvm
+  brew install llvm
   cd ~/.vim/bundle/YouCompleteMe
   python3 install.py --system-libclang --all
 <
@@ -1126,6 +1127,21 @@ For more details on this feature and a few demos, check out the PR that
 proposed it [44].
 
 -------------------------------------------------------------------------------
+                                         *youcompleteme-dismiss-signature-help*
+Dismiss signature help ~
+
+The signature help popup sometimes gets in the way. You can toggle its
+visibility with a mapping. YCM provides the "Plug" mapping
+'<Plug>(YCMToggleSignatureHelp)' for this.
+
+For example, to hide/show the signature help popup by pressing Ctrl+l in insert
+mode: 'imap <silent> <C-l> <Plug>(YCMToggleSignatureHelp)'.
+
+_NOTE_: No default mapping is provided because insert mappings are very
+difficult to create without breaking or overriding some existing functionality.
+Ctrl-l is not a suggestion, just an example.
+
+-------------------------------------------------------------------------------
                                     *youcompleteme-general-semantic-completion*
 General Semantic Completion ~
 
@@ -1189,7 +1205,7 @@ Supported architectures are:
 **_clangd_**:
 
 Typically, clangd is installed by the YCM installer (either with '--all' or
-with '--clangd-completer'). This downlaods a pre-built 'clangd' binary for your
+with '--clangd-completer'). This downloads a pre-built 'clangd' binary for your
 architecture. If your OS or architecture is not supported or too old, you can
 install a compatible 'clangd' and use |g:ycm_clangd_binary_path| to point to
 it.
@@ -1198,7 +1214,7 @@ it.
 
 'libclang' can be enabled also with '--all' or '--clang-completer'. As with
 'clangd', YCM will try and download a version of 'libclang' that is suitable
-for your environemnt, but again if your environemnt can't be supported, you can
+for your environment, but again if your environment can't be supported, you can
 build or acquire 'libclang' for yourself and specify it when building, as:
 >
   $ EXTRA_CMAKE_ARGS='-DPATH_TO_LLVM_ROOT=/path/to/your/llvm' ./install.py --clang-compelter --system-libclang

--- a/python/ycm/signature_help.py
+++ b/python/ycm/signature_help.py
@@ -25,6 +25,7 @@ from ycm.vimsupport import memoize, GetIntValue
 class SignatureHelpState:
   ACTIVE = 'ACTIVE'
   INACTIVE = 'INACTIVE'
+  ACTIVE_SUPPRESSED = 'ACTIVE_SUPPRESSED'
 
   def __init__( self,
                 popup_win_id = None,
@@ -32,6 +33,21 @@ class SignatureHelpState:
     self.popup_win_id = popup_win_id
     self.state = state
     self.anchor = None
+
+
+  def ToggleVisibility( self ):
+    if self.state == 'ACTIVE':
+      self.state = 'ACTIVE_SUPPRESSED'
+      vim.eval( f'popup_hide( { self.popup_win_id } )' )
+    elif self.state == 'ACTIVE_SUPPRESSED':
+      self.state = 'ACTIVE'
+      vim.eval( f'popup_show( { self.popup_win_id } )' )
+
+
+  def IsActive( self ):
+    if self.state in ( 'ACTIVE', 'ACTIVE_SUPPRESSED' ):
+      return 'ACTIVE'
+    return 'INACTIVE'
 
 
 def _MakeSignatureHelpBuffer( signature_info ):
@@ -82,10 +98,10 @@ def UpdateSignatureHelp( state, signature_info ): # noqa
       vim.eval( f"popup_close( { state.popup_win_id } )" )
     return SignatureHelpState( None, SignatureHelpState.INACTIVE )
 
-  if state.state != SignatureHelpState.ACTIVE:
+  if state.state == SignatureHelpState.INACTIVE:
     state.anchor = vimsupport.CurrentLineAndColumn()
 
-  state.state = SignatureHelpState.ACTIVE
+    state.state = SignatureHelpState.ACTIVE
 
   # Generate the buffer as a list of lines
   buf_lines = _MakeSignatureHelpBuffer( signature_info )
@@ -154,9 +170,10 @@ def UpdateSignatureHelp( state, signature_info ): # noqa
     # NOTE: We *dont'* use "cursorline" here - that actually uses PMenuSel,
     # which is just too invasive for us (it's more selected item than actual
     # cursorline. So instead, we manually set 'cursorline' in the popup window
-    # and enable sytax based on the current file syntax)
+    # and enable syntax based on the current file syntax)
     "flip": 1,
     "padding": [ 0, 1, 0, 1 ], # Pad 1 char in X axis to match completion menu
+    "hidden": int( state.state == SignatureHelpState.ACTIVE_SUPPRESSED )
   }
 
   if not state.popup_win_id:
@@ -169,7 +186,8 @@ def UpdateSignatureHelp( state, signature_info ): # noqa
 
   # Should do nothing if already visible
   vim.eval( f'popup_move( { state.popup_win_id }, { json.dumps( options ) } )' )
-  vim.eval( f'popup_show( { state.popup_win_id } )' )
+  if state.state == SignatureHelpState.ACTIVE:
+    vim.eval( f'popup_show( { state.popup_win_id } )' )
 
   syntax = utils.ToUnicode( vim.current.buffer.options[ 'syntax' ] )
   active_signature = int( signature_info.get( 'activeSignature', 0 ) )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -336,7 +336,9 @@ class YouCompleteMe:
         return False
 
       request_data = self._latest_completion_request.request_data.copy()
-      request_data[ 'signature_help_state' ] = self._signature_help_state.state
+      request_data[ 'signature_help_state' ] = (
+          self._signature_help_state.IsActive()
+      )
 
       self._AddExtraConfDataIfNeeded( request_data )
 
@@ -843,6 +845,10 @@ class YouCompleteMe:
       'max_num_candidates': max_items,
       'query': vimsupport.ToUnicode( query )
     }, 'filter_and_sort_candidates' )
+
+
+  def ToggleSignatureHelp( self ):
+    self._signature_help_state.ToggleVisibility()
 
 
   def _AddSyntaxDataIfNeeded( self, extra_data ):

--- a/test/lib/autoload/youcompleteme/test/popup.vim
+++ b/test/lib/autoload/youcompleteme/test/popup.vim
@@ -3,7 +3,8 @@ function! youcompleteme#test#popup#CheckPopupPosition( winid, pos )
   let actual_pos = popup_getpos( a:winid )
   let ret = 0
   if a:pos->empty()
-    return assert_true( actual_pos->empty(), 'popup pos empty' )
+    return assert_true( actual_pos->empty(),
+          \ 'popup pos empty, got: ' . string( actual_pos ) )
   endif
   for c in keys( a:pos )
     if !has_key( actual_pos, c )

--- a/test/signature_help.test.vim
+++ b/test/signature_help.test.vim
@@ -787,3 +787,108 @@ function! TearDown_Test_Semantic_Completion_Popup_With_Sig_Help_EmptyBuf()
   call youcompleteme#test#setup#PopGlobal( 'ycm_filetype_blacklist' )
   call youcompleteme#test#setup#PopGlobal( 'ycm_add_preview_to_completeopt' )
 endfunction
+
+function! SetUp_Test_Signature_Help_Manual_HideShow()
+  imap <silent> kjkj <Plug>(YCMToggleSignatureHelp)
+endfunction
+
+function! Test_Signature_Help_Manual_HideShow()
+  call youcompleteme#test#setup#OpenFile(
+        \ 'test/testdata/cpp/complete_with_sig_help.cc', {} )
+  call s:WaitForSigHelpAvailable( 'cpp' )
+
+  call setpos( '.', [ 0, 10, 1 ] )
+
+  call test_override( 'char_avail', 1 )
+
+  function! Check( ... )
+    call youcompleteme#test#popup#CheckPopupPosition(
+          \ s:_GetSigHelpWinID(),
+          \ { 'line': 9, 'col': 6, 'visible': 1 } )
+
+    call FeedAndCheckAgain( 'kjkj', funcref( 'Check2' ) )
+  endfunction
+
+  function! Check2( ... )
+    call youcompleteme#test#popup#CheckPopupPosition(
+          \ s:_GetSigHelpWinID(),
+          \ { 'line': 9, 'col': 6, 'visible': 0 } )
+
+    call FeedAndCheckAgain( 'kjkj', funcref( 'Check3' ) )
+  endfunction
+
+  function! Check3( ... )
+    call youcompleteme#test#popup#CheckPopupPosition(
+          \ s:_GetSigHelpWinID(),
+          \ { 'line': 9, 'col': 6, 'visible': 1 } )
+
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+
+  call FeedAndCheckMain( 'iprintf(', funcref( 'Check' ) )
+
+  call test_override( 'ALL', 0 )
+
+  delfunc! Check
+  delfunc! Check2
+  delfunc! Check3
+endfunction
+
+function! TearDown_Test_Signature_Help_Manual_HideShow()
+  silent! iunmap kjkj
+endfunction
+
+function! SetUp_Test_Signature_Help_Manual_NoSigs()
+  imap <silent> kjkj <Plug>(YCMToggleSignatureHelp)
+endfunction
+
+function! Test_Signature_Help_Manual_NoSigs()
+  call youcompleteme#test#setup#OpenFile(
+        \ 'test/testdata/cpp/complete_with_sig_help.cc', {} )
+  call s:WaitForSigHelpAvailable( 'cpp' )
+
+  call setpos( '.', [ 0, 10, 1 ] )
+
+  call test_override( 'char_avail', 1 )
+
+  let popup_id = 0
+
+  function! CheckSigs( ... ) closure
+    let popup_id = s:_GetSigHelpWinID()
+    call youcompleteme#test#popup#CheckPopupPosition(
+          \ s:_GetSigHelpWinID(),
+          \ { 'line': 9, 'col': 6, 'visible': 1 } )
+
+    call FeedAndCheckAgain( ')', funcref( 'CheckSigsClosed' ) )
+  endfunction
+
+  function! CheckSigsClosed( ... ) closure
+    call youcompleteme#test#popup#CheckPopupPosition(
+          \ popup_id,
+          \ {} )
+
+    call FeedAndCheckAgain( 'kjkj', funcref( 'CheckStillOK' ) )
+  endfunction
+
+  function! CheckStillOK( ... ) closure
+    call youcompleteme#test#popup#CheckPopupPosition(
+          \ popup_id,
+          \ {} )
+
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+
+  call FeedAndCheckMain( 'iprintf(', funcref( 'CheckSigs' ) )
+
+  call test_override( 'ALL', 0 )
+
+  delfunc! CheckSigs
+  delfunc! CheckSigsClosed
+  delfunc! CheckStillOK
+endfunction
+
+function! TearDown_Test_Signature_Help_Manual_NoSigs()
+  silent! iunmap kjkj
+endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The signature help is awesome when you need it, but can get in the way,
when one needs to see the line above cursor.

With this commit, and an additional binding, it is possible to
temporarily hide the popup.

One caveat is that, if there were no popup to begin with and user starts
to edit arguments somewhere between triggers, the user won't be able to
spawn a popup with this binding.

As for the tests... I don't think there's an API for "is this popup visible", akin to `pumvisible()`.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4008)
<!-- Reviewable:end -->
