### PR TITLE
Fix traceback with invalid diagnostic ranges

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
   "configurations": {
+    "Python: Attach To Vim": {
+      "variables": {
+        "port": "5678",
+        "host": "localhost"
+      },
+      "adapter": "multi-session",
+      "configuration": {
+        "request": "attach"
+      }
+    },
     "python - launch pytest": {
       "adapter": "debugpy",
       "variables": [

--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -260,6 +260,10 @@ def _ConvertDiagnosticToTextProperties( bufnr, diagnostic ):
       diagnostic_range[ 'end' ][ 'line_num' ],
       diagnostic_range[ 'end' ][ 'column_num' ]
     )
+
+    if not _IsValidRange( start_line, start_column, end_line, end_column ):
+      continue
+
     properties.append( (
       start_line,
       start_column,
@@ -268,3 +272,20 @@ def _ConvertDiagnosticToTextProperties( bufnr, diagnostic ):
         'end_col': end_column } ) )
 
   return properties
+
+
+def _IsValidRange( start_line, start_column, end_line, end_column ):
+  # End line before start line - invalid
+  if start_line > end_line:
+    return False
+
+  # End line after start line - valid
+  if start_line < end_line:
+    return True
+
+  # Same line, start colum after end column - invalid
+  if start_column > end_column:
+    return False
+
+  # Same line, start column before or equal to end column - valid
+  return True

--- a/python/ycm/tests/diagnostic_interface_test.py
+++ b/python/ycm/tests/diagnostic_interface_test.py
@@ -16,7 +16,11 @@
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 from ycm import diagnostic_interface
 from ycm.tests.test_utils import VimBuffer, MockVimModule, MockVimBuffers
-from hamcrest import assert_that, contains_exactly, has_entries, has_item
+from hamcrest import ( assert_that,
+                       contains_exactly,
+                       equal_to,
+                       has_entries,
+                       has_item )
 from unittest import TestCase
 MockVimModule()
 
@@ -101,3 +105,21 @@ class DiagnosticInterfaceTest( TestCase ):
               diag )
           print( actual )
           assert_that( actual, result )
+
+  def test_IsValidRange( self ):
+    for start_line, start_col, end_line, end_col, expect in (
+      ( 1, 1, 1, 1, True ),
+      ( 1, 1, 0, 0, False ),
+      ( 1, 1, 2, 1, True ),
+      ( 1, 2, 2, 1, True ),
+      ( 2, 1, 1, 1, False ),
+      ( 2, 2, 2, 1, False ),
+    ):
+      with self.subTest( start=( start_line, start_col ),
+                         end=( end_line, end_col ),
+                         expect = expect ):
+        assert_that( diagnostic_interface._IsValidRange( start_line,
+                                                         start_col,
+                                                         end_line,
+                                                         end_col ),
+                     equal_to( expect ) )


### PR DESCRIPTION
SOmetimes, for some reason, the legacy libclang completer returns ranges
where the end of the diagnostic range is 0,0 (or otherwise invalid).
It's not clear why that is, but it's coming from libclang and there's
not much we can do about it.

ANyway in the past we would have just crated a diagnostic "match" that
would have never matched anything. Now, we're trying to create a text
property spanning that range, which causes a vim error and ugly
traceback.

Solution is to simply validate ranges and drop invalid ones.

Fixes #4013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4014)
<!-- Reviewable:end -->
