### PR TITLE
tagfiles may already be abspath

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -867,8 +867,8 @@ class YouCompleteMe:
   def _AddTagsFilesIfNeeded( self, extra_data ):
     def GetTagFiles():
       tag_files = vim.eval( 'tagfiles()' )
-      return [ (os.path.join( utils.GetCurrentDirectory(), tag_file ) 
-                if not os.path.isabs(tag_file) else tag_file)
+      return [ ( os.path.join( utils.GetCurrentDirectory(), tag_file )
+                 if not os.path.isabs( tag_file ) else tag_file )
                for tag_file in tag_files ]
 
     if not self._user_options[ 'collect_identifiers_from_tags_files' ]:

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -867,7 +867,8 @@ class YouCompleteMe:
   def _AddTagsFilesIfNeeded( self, extra_data ):
     def GetTagFiles():
       tag_files = vim.eval( 'tagfiles()' )
-      return [ os.path.abspath(tag_file)
+      return [ (os.path.join( utils.GetCurrentDirectory(), tag_file ) 
+                if not os.path.isabs(tag_file) else tag_file)
                for tag_file in tag_files ]
 
     if not self._user_options[ 'collect_identifiers_from_tags_files' ]:

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -867,7 +867,7 @@ class YouCompleteMe:
   def _AddTagsFilesIfNeeded( self, extra_data ):
     def GetTagFiles():
       tag_files = vim.eval( 'tagfiles()' )
-      return [ os.path.join( utils.GetCurrentDirectory(), tag_file )
+      return [ os.path.abspath(tag_file)
                for tag_file in tag_files ]
 
     if not self._user_options[ 'collect_identifiers_from_tags_files' ]:


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
The tagfiles specified (loaded) in vim may already be abspath, join them directly will lead to tagfiles not loaded.
(In my own settings, I used abspath for tag files and ID from tagfiles were not shown by YCM) 

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4021)
<!-- Reviewable:end -->
