### PR TITLE
Support for semantic highlighting (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@ Quick Feature Summary
 * Reference finding (`GoToReferences`)
 * Renaming symbols (`RefactorRename <new name>`)
 * Code formatting (`Format`)
+* Semantic highlighting
 
 ### C♯
 
@@ -808,6 +809,7 @@ Quick Feature Summary
 * Renaming symbols (`RefactorRename <new name>`)
 * Code formatting (`Format`)
 * Management of `rust-analyzer` server instance
+* Semantic highlighting
 
 ### Java
 
@@ -830,6 +832,7 @@ Quick Feature Summary
 * Detection of java projects
 * Execute custom server command (`ExecuteCommand <args>`)
 * Management of `jdt.ls` server instance
+* Semantic highlighting
 
 User Guide
 ----------
@@ -957,6 +960,74 @@ mode: `imap <silent> <C-l> <Plug>(YCMToggleSignatureHelp)`.
 _NOTE_: No default mapping is provided because insert mappings are very
 difficult to create without breaking or overriding some existing functionality.
 Ctrl-l is not a suggestion, just an example.
+
+### Semantic highlighting
+
+**NOTE**: This feature is highly experimental and offered in the hope that it is
+useful. It shall not be considered stable; if you find issues with it, feel free
+to report them however.
+
+Semantic highlighting is the process where the buffer text is coloured according
+to the underlying semantic type of the word, rather than classic syntax
+highlighting based on regular expressions. This can be powerful additional data
+that we can process very quickly.
+
+This feature is only supported in Vim.
+
+For example, here is a function with classic highlighting:
+
+![highliting-classic](https://user-images.githubusercontent.com/10584846/173137003-a265e8b0-84db-4993-98f0-03ee81b9de94.png)
+
+And here is the same function with semantic highlighting:
+
+![highliting-semantic](https://user-images.githubusercontent.com/10584846/173137012-7547de0b-145f-45fa-ace3-18943acd2141.png)
+
+As you can see, the function calls, macros, etc. are correctly identified. 
+
+This can be enabled globally with `let g:ycm_enable_semantic_highlighting=1` or
+per buffer, by setting `b:ycn_enable_semantic_highlighting`.
+
+#### Customising the highlight groups
+
+YCM uses text properties (see `:help text-prop-intro`) for semantic
+highlighting. In order to customise the coloring, you can define the text
+properties that are used.
+
+If you define a text property named `YCM_HL_<token type>`, then it will be used
+in place of the defaults. The `<token type>` is defined as the Language Server
+Protocol semantic token type, defined in the [LSP Spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens).
+
+Some servers also use custom values. In this case, YCM prints a warning
+including the token type name that you can customise.
+
+For example, to render `parameter` tokens using the `Nomral` highlight group,
+you can do this:
+
+```viml
+call prop_type_add( 'YCM_HL_parameter', { 'highlight': 'Normal' } )
+```
+
+More generally, this pattern can be useful for customising the groups:
+
+```viml
+let MY_YCM_HIGHLIGHT_GROUP = {
+      \   'typeParameter': 'PreProc',
+      \   'parameter': 'Normal',
+      \   'variable': 'Normal',
+      \   'property': 'Normal',
+      \   'enumMember': 'Normal',
+      \   'event': 'Special',
+      \   'member': 'Normal',
+      \   'method': 'Normal',
+      \   'class': 'Special',
+      \   'namespace': 'Special',
+      \ }
+
+for tokenType in keys( MY_YCM_HIGHLIGHT_GROUP )
+  call prop_type_add( 'YCM_HL_' . tokenType,
+                    \ { 'highlight': MY_YCM_HIGHLIGHT_GROUP[ tokenType ] } )
+endfor
+```
 
 ### General Semantic Completion
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -762,8 +762,8 @@ function! s:OnFileReadyToParse( ... )
           \ s:pollers.file_parse_response.wait_milliseconds,
           \ function( 's:PollFileParseResponse' ) )
 
-    if get( g:, 'ycm_enable_semantic_highlightng', 0 ) ||
-          \ get( b:, 'ycm_enable_semantic_highlightng', 0 )
+    if get( g:, 'ycm_enable_semantic_highlighting', 0 ) ||
+          \ get( b:, 'ycm_enable_semantic_highlighting', 0 )
 
       call s:StopPoller( s:pollers.semantic_highlighting )
       py3 ycm_state.CurrentBuffer().SendSemanticTokensRequest()

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -764,11 +764,13 @@ function! s:OnFileReadyToParse( ... )
 
     if get( g:, 'ycm_enable_semantic_highlightng', 0 ) ||
           \ get( b:, 'ycm_enable_semantic_highlightng', 0 )
-      py3 ycm_state.CurrentBuffer().SendSemanticTokensRequest()
+
       call s:StopPoller( s:pollers.semantic_highlighting )
+      py3 ycm_state.CurrentBuffer().SendSemanticTokensRequest()
       let s:pollers.semantic_highlighting.id = timer_start(
             \ s:pollers.semantic_highlighting.wait_milliseconds,
             \ function( 's:PollSemanticHighlighting' ) )
+
     endif
   endif
 endfunction
@@ -794,9 +796,7 @@ function! s:PollSemanticHighlighting( ... )
     let s:pollers.semantic_highlighting.id = timer_start(
           \ s:pollers.semantic_highlighting.wait_milliseconds,
           \ function( 's:PollSemanticHighlighting' ) )
-  endif
-
-  if py3eval( 'ycm_state.CurrentBuffer().UpdateSemanticTokens()' )
+  elseif ! py3eval( 'ycm_state.CurrentBuffer().UpdateSemanticTokens()' )
     let s:pollers.semantic_highlighting.id = timer_start(
           \ s:pollers.semantic_highlighting.wait_milliseconds,
           \ function( 's:PollSemanticHighlighting' ) )

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -762,10 +762,11 @@ function! s:OnFileReadyToParse( ... )
           \ s:pollers.file_parse_response.wait_milliseconds,
           \ function( 's:PollFileParseResponse' ) )
 
-    if get( g:, 'ycm_enable_semantic_highlighting', 0 ) ||
-          \ get( b:, 'ycm_enable_semantic_highlighting', 0 )
+    call s:StopPoller( s:pollers.semantic_highlighting )
+    if !s:is_neovim &&
+          \ ( get( g:, 'ycm_enable_semantic_highlighting', 0 ) ||
+          \   get( b:, 'ycm_enable_semantic_highlighting', 0 ) )
 
-      call s:StopPoller( s:pollers.semantic_highlighting )
       py3 ycm_state.CurrentBuffer().SendSemanticTokensRequest()
       let s:pollers.semantic_highlighting.id = timer_start(
             \ s:pollers.semantic_highlighting.wait_milliseconds,

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -764,8 +764,8 @@ function! s:OnFileReadyToParse( ... )
 
     call s:StopPoller( s:pollers.semantic_highlighting )
     if !s:is_neovim &&
-          \ ( get( g:, 'ycm_enable_semantic_highlighting', 0 ) ||
-          \   get( b:, 'ycm_enable_semantic_highlighting', 0 ) )
+          \ get( b:, 'ycm_enable_semantic_highlighting',
+          \   get( g:, 'ycm_enable_semantic_highlighting', 0 ) )
 
       py3 ycm_state.CurrentBuffer().SendSemanticTokensRequest()
       let s:pollers.semantic_highlighting.id = timer_start(

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -18,6 +18,7 @@
 from ycm import vimsupport
 from ycm.client.event_notification import EventNotification
 from ycm.diagnostic_interface import DiagnosticInterface
+from ycm.semantic_highlighting import SemanticHighlighting
 
 
 # Emulates Vim buffer
@@ -35,6 +36,8 @@ class Buffer:
     self._diag_interface = DiagnosticInterface( bufnr, user_options )
     self._open_loclist_on_ycm_diags = user_options[
                                         'open_loclist_on_ycm_diags' ]
+    self._semantic_highlighting = SemanticHighlighting( bufnr,
+                                                        user_options )
     self.UpdateFromFileTypes( filetypes )
 
 
@@ -131,6 +134,18 @@ class Buffer:
     self._filetypes = filetypes
     # We will set this to true if we ever receive any diagnostics asyncronously.
     self._async_diags = False
+
+
+  def SendSemanticTokensRequest( self ):
+    self._semantic_highlighting.SendRequest()
+
+
+  def SemanticTokensRequestReady( self ):
+    return self._semantic_highlighting.IsResponseReady()
+
+
+  def UpdateSemanticTokens( self ):
+    return self._semantic_highlighting.Update()
 
 
   def _ChangedTick( self ):

--- a/python/ycm/client/semantic_tokens_request.py
+++ b/python/ycm/client/semantic_tokens_request.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2020, YouCompleteMe Contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import logging
+from ycm.client.base_request import ( BaseRequest, DisplayServerException,
+                                      MakeServerException )
+
+_logger = logging.getLogger( __name__ )
+
+
+# FIXME: This is copy/pasta from SignatureHelpRequest - abstract a
+# SimpleAsyncRequest base that does all of this generically
+class SemanticTokensRequest( BaseRequest ):
+  def __init__( self, request_data ):
+    super().__init__()
+    self.request_data = request_data
+    self._response_future = None
+
+
+  def Start( self ):
+    self._response_future = self.PostDataToHandlerAsync( self.request_data,
+                                                         'semantic_tokens' )
+
+  def Done( self ):
+    return bool( self._response_future ) and self._response_future.done()
+
+
+  def Reset( self ):
+    self._response_future = None
+
+  def Response( self ):
+    if not self._response_future:
+      return {}
+
+    response = self.HandleFuture( self._response_future,
+                                  truncate_message = True )
+
+    if not response:
+      return {}
+
+    # Vim may not be able to convert the 'errors' entry to its internal format
+    # so we remove it from the response.
+    errors = response.pop( 'errors', [] )
+    for e in errors:
+      exception = MakeServerException( e )
+      _logger.error( exception )
+      DisplayServerException( exception, truncate_message = True )
+
+    return response.get( 'semantic_tokens' ) or {}

--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -143,6 +143,9 @@ class DiagnosticInterface:
             diag ):
           global YCM_VIM_PROPERTY_ID
 
+          # FIXME: This remove() gambit probably never works because the IDs are
+          # almost certain to not match
+          # Perhaps we should have AddTextProperty return the ID?
           diag_prop = vimsupport.DiagnosticProperty(
               YCM_VIM_PROPERTY_ID,
               name,

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -59,7 +59,8 @@ def Initialise():
 
   for token_type, group in HIGHLIGHT_GROUP.items():
     prop = f'YCM_HL_{ token_type }'
-    if prop not in props:
+    if prop not in props and vimsupport.GetIntValue(
+        f"hlexists( '{ vimsupport.EscapeForVim( group ) }' )" ):
       AddTextPropertyType( prop, highlight = group )
 
 

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -42,6 +42,7 @@ HIGHLIGHT_GROUP = {
   'function': 'Function',
   'member': 'Identifier',
   'macro': 'Macro',
+  'method': 'Function',
   'keyword': 'Keyword',
   'modifier': 'Keyword',
   'comment': 'Comment',
@@ -49,7 +50,9 @@ HIGHLIGHT_GROUP = {
   'number': 'Number',
   'regexp': 'String',
   'operator': 'Operator',
+  'unknown': 'Normal',
 }
+REPORTED_MISSING_TYPES = set()
 
 
 def Initialise():
@@ -92,6 +95,7 @@ class SemanticHighlighting:
       return
 
     self.tick = vimsupport.GetBufferChangedTick( self._bufnr )
+
     self._request = SemanticTokensRequest( BuildRequestData() )
     self._request.Start()
 
@@ -99,19 +103,23 @@ class SemanticHighlighting:
     return self._request is not None and self._request.Done()
 
   def Update( self ):
-    if not self.IsResponseReady():
-      # Not ready - poll
-      return False
+    if not self._request:
+      # Nothing to update
+      return True
 
-    if self.tick != vimsupport.GetBufferChangedTick( self._bufnr ):
-      # Buffer has changed, we should ignore the data and retry
-      # self.SendRequest()
-      return False
+    assert self.IsResponseReady()
 
-    # We requested a snapshot
+    # We're ready to use this response. Clear it (to avoid repeatedly
+    # re-polling).
     response = self._request.Response()
     self._request = None
 
+    if self.tick != vimsupport.GetBufferChangedTick( self._bufnr ):
+      # Buffer has changed, we should ignore the data and retry
+      self.SendRequest()
+      return False # poll again
+
+    # We requested a snapshot
     tokens = response.get( 'tokens', [] )
 
     prev_prop_id = self._prop_id
@@ -119,6 +127,10 @@ class SemanticHighlighting:
 
     for token in tokens:
       if token[ 'type' ] not in HIGHLIGHT_GROUP:
+        if token[ 'type' ] not in REPORTED_MISSING_TYPES:
+          REPORTED_MISSING_TYPES.add( token[ 'type' ] )
+          vimsupport.PostVimMessage(
+            f"Missing property type for { token[ 'type' ] }" )
         continue
       prop_type = f"YCM_HL_{ token[ 'type' ] }"
       AddTextProperty( self._bufnr, self._prop_id, prop_type, token[ 'range' ] )
@@ -126,7 +138,7 @@ class SemanticHighlighting:
     ClearTextProperties( self._bufnr, prev_prop_id )
 
     # No need to re-poll
-    return False
+    return True
 
 
 # FIXME/TODO: Merge this with vimsupport funcitons, added after these were

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2020, YouCompleteMe Contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from ycm.client.semantic_tokens_request import SemanticTokensRequest
+from ycm.client.base_request import BuildRequestData
+from ycm import vimsupport
+from ycmd import utils
+
+import vim
+import json
+
+
+HIGHLIGHT_GROUP = {
+  'namespace': 'Type',
+  'type': 'Type',
+  'class': 'Structure',
+  'enum': 'Structure',
+  'interface': 'Structure',
+  'struct': 'Structure',
+  'typeParameter': 'Identifier',
+  'parameter': 'Identifier',
+  'variable': 'Identifier',
+  'property': 'Identifier',
+  'enumMember': 'Identifier',
+  'enumConstant': 'Constant',
+  'event': 'Identifier',
+  'function': 'Function',
+  'member': 'Identifier',
+  'macro': 'Macro',
+  'keyword': 'Keyword',
+  'modifier': 'Keyword',
+  'comment': 'Comment',
+  'string': 'String',
+  'number': 'Number',
+  'regexp': 'String',
+  'operator': 'Operator',
+}
+
+
+def Initialise():
+  props = GetTextPropertyTypes()
+  if 'YCM_HL_UNKNOWN' not in props:
+    AddTextPropertyType( 'YCM_HL_UNKNOWN', highlight = 'WarningMsg' )
+
+  for token_type, group in HIGHLIGHT_GROUP.items():
+    prop = f'YCM_HL_{ token_type }'
+    if prop not in props:
+      AddTextPropertyType( prop, highlight = group )
+
+
+# "arbitrary" base id
+NEXT_TEXT_PROP_ID = 70784
+
+
+def NextPropID():
+  global NEXT_TEXT_PROP_ID
+  try:
+    return NEXT_TEXT_PROP_ID
+  finally:
+    NEXT_TEXT_PROP_ID += 1
+
+
+
+class SemanticHighlighting:
+  """Stores the semantic highlighting state for a Vim buffer"""
+
+  def __init__( self, bufnr, user_options ):
+    self._request = None
+    self._bufnr = bufnr
+    self._prop_id = NextPropID()
+    self.tick = -1
+
+
+  def SendRequest( self ):
+    if self._request and not self.IsResponseReady():
+      return
+
+    self.tick = vimsupport.GetBufferChangedTick( self._bufnr )
+    self._request = SemanticTokensRequest( BuildRequestData() )
+    self._request.Start()
+
+  def IsResponseReady( self ):
+    return self._request is not None and self._request.Done()
+
+  def Update( self ):
+    if not self.IsResponseReady():
+      # Not ready - poll
+      return False
+
+    if self.tick != vimsupport.GetBufferChangedTick( self._bufnr ):
+      # Buffer has changed, we should ignore the data and retry
+      # self.SendRequest()
+      return False
+
+    # We requested a snapshot
+    response = self._request.Response()
+    self._request = None
+
+    tokens = response.get( 'tokens', [] )
+
+    prev_prop_id = self._prop_id
+    self._prop_id = NextPropID()
+
+    for token in tokens:
+      if token[ 'type' ] not in HIGHLIGHT_GROUP:
+        continue
+      prop_type = f"YCM_HL_{ token[ 'type' ] }"
+      AddTextProperty( self._bufnr, self._prop_id, prop_type, token[ 'range' ] )
+
+    ClearTextProperties( self._bufnr, prev_prop_id )
+
+    # No need to re-poll
+    return False
+
+
+# FIXME/TODO: Merge this with vimsupport funcitons, added after these were
+# writted for Diagnostics
+
+if not vimsupport.VimSupportsTextProperties():
+  def AddTextPropertyType( *args, **kwargs ):
+    pass
+  def GetTextPropertyTypes( *args, **kwargs ):
+    return []
+  def AddTextProperty( *args, **kwargs ):
+    pass
+  def ClearTextProperties( *args, **kwargs ):
+    pass
+
+else:
+  def AddTextPropertyType( name, **kwargs ):
+    props = {
+      'highlight': 'Ignore',
+      'combine': False,
+      'start_incl': False,
+      'end_incl': False,
+      'priority': 10
+    }
+    props.update( kwargs )
+
+    vim.eval( f"prop_type_add( '{ vimsupport.EscapeForVim( name ) }', "
+              f"               { json.dumps( kwargs ) } )" )
+
+
+  def GetTextPropertyTypes( *args, **kwargs ):
+    return [ utils.ToUnicode( p ) for p in vim.eval( 'prop_type_list()' ) ]
+
+
+  def AddTextProperty( bufnr, prop_id, prop_type, range ):
+    props = {
+      'end_lnum': range[ 'end' ][ 'line_num' ],
+      'end_col': range[ 'end' ][ 'column_num' ],
+      'bufnr': bufnr,
+      'id': prop_id,
+      'type': prop_type
+    }
+    vim.eval( f"prop_add( { range[ 'start' ][ 'line_num' ] },"
+              f"          { range[ 'start' ][ 'column_num' ] },"
+              f"          { json.dumps( props ) } )" )
+
+  def ClearTextProperties( bufnr, prop_id ):
+    props = {
+      'id': prop_id,
+      'bufnr': bufnr,
+      'all': 1,
+    }
+    vim.eval( f"prop_remove( { json.dumps( props ) } )" )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1353,6 +1353,11 @@ def HasFastPropList():
 
 
 @memoize()
+def VimSupportsTextProperties():
+  return VimHasFunctions( 'prop_add', 'prop_type_add' )
+
+
+@memoize()
 def VimSupportsPopupWindows():
   return VimHasFunctions( 'popup_create',
                           'popup_atcursor',
@@ -1360,9 +1365,7 @@ def VimSupportsPopupWindows():
                           'popup_hide',
                           'popup_settext',
                           'popup_show',
-                          'popup_close',
-                          'prop_add',
-                          'prop_type_add' )
+                          'popup_close' ) and VimSupportsTextProperties()
 
 
 @memoize()

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1353,11 +1353,6 @@ def HasFastPropList():
 
 
 @memoize()
-def VimSupportsTextProperties():
-  return VimHasFunctions( 'prop_add', 'prop_type_add' )
-
-
-@memoize()
 def VimSupportsPopupWindows():
   return VimHasFunctions( 'popup_create',
                           'popup_atcursor',
@@ -1365,7 +1360,7 @@ def VimSupportsPopupWindows():
                           'popup_hide',
                           'popup_settext',
                           'popup_show',
-                          'popup_close' ) and VimSupportsTextProperties()
+                          'popup_close' )
 
 
 @memoize()


### PR DESCRIPTION
There's a `g:ycm_enable_semantic_highlighting` and `b:ycm_enable_semantic_highlighting` that can be set to 1.

Vim only, no neovim.

experimental, unsupported and undocumented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4033)
<!-- Reviewable:end -->
