### PR TITLE
Fix passing '+10' etc on command line in older vims.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -183,8 +183,7 @@ function! youcompleteme#Enable()
   call s:SetUpOptions()
 
   py3 ycm_semantic_highlighting.Initialise()
-  py3 vim.command( 'let s:enable_inlay_hints = ' +
-        \ '1' if ycm_inlay_hints.Initialise() else '0' )
+  let s:enable_inlay_hints = py3eval( 'ycm_inlay_hints.Initialise()' ) ? 1 : 0
 
   call youcompleteme#EnableCursorMovedAutocommands()
   augroup youcompleteme


### PR DESCRIPTION
For some reason, the (wierd) way we were initialising
s:enable_inlay_hints via vim.command was causing wierdness on older vims
and neovim (i.e. where it was returning 0). Unclear why this was
happening, but using less wierd syntax seems to fix it.

Fixes #4051
Fixes #4052

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4053)
<!-- Reviewable:end -->
