### PR TITLE
Fix traceback when a long identifier is displayed in finder

### DIFF
--- a/autoload/youcompleteme/finder.vim
+++ b/autoload/youcompleteme/finder.vim
@@ -522,16 +522,20 @@ function! s:RedrawFinderPopup() abort
              \ .. result[ 'filetype' ]
 
       if len( path ) > 0
-        let props += [
-              \ { 'col': available_width - len( path ) + 1,
-              \   'length': len( path ) - len( line_num ),
-              \   'type': 'YCM-symbol-file' },
-              \ ]
         if path_includes_line
           let props += [
+                \ { 'col': available_width - len( path ) + 1,
+                \   'length': len( path ) - len( line_num ),
+                \   'type': 'YCM-symbol-file' },
                 \ { 'col': available_width - len( line_num ) + 1,
                 \   'length': len( line_num ),
                 \   'type': 'YCM-symbol-line-num' },
+                \ ]
+        else
+          let props += [
+                \ { 'col': available_width - len( path ) + 1,
+                \   'length': len( path ),
+                \   'type': 'YCM-symbol-file' },
                 \ ]
         endif
       endif
@@ -773,7 +777,7 @@ function! s:HandleWorkspaceSymbols( filetype, results ) abort
     "
     let results = py3eval(
           \ 'ycm_state.FilterAndSortItems( vim.eval( "results" ),'
-          \ .                              ' "description",'
+          \ .                              ' "key",'
           \ .                              ' vim.eval( "query" ) )' )
   endif
 
@@ -804,7 +808,7 @@ function! s:SearchDocument( query, new_query ) abort
   let response = py3eval(
         \ 'ycm_state.FilterAndSortItems( '
         \ . ' vim.eval( "s:find_symbol_status.raw_results" ),'
-        \ . ' "description",'
+        \ . ' "key",'
         \ . ' vim.eval( "a:query" ) )' )
 
   eval s:HandleSymbolSearchResults( response )


### PR DESCRIPTION
If a candidate shown in the symbol finder is too long to display the
path and line number, we would incorrectly calculate the length of the
path text property. Calculate it correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4054)
<!-- Reviewable:end -->
