### PR TITLE
Update youcompleteme.vim

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -168,7 +168,7 @@ function! youcompleteme#Enable()
     " supported, enable it.
     let s:resolve_completions = s:RESOLVE_ON_DEMAND
   elseif require_resolve
-    " The preview window or info popup is enalbed - request the server
+    " The preview window or info popup is enabled - request the server
     " pre-resolves completion items
     let s:resolve_completions = s:RESOLVE_UP_FRONT
   else
@@ -1225,6 +1225,7 @@ function! s:ShowInfoPopup( completion_item )
   let id = popup_findinfo()
   if id
     call popup_settext( id, split( a:completion_item.info, '\n' ) )
+    call win_execute( id, 'set nonumber' )
     call popup_show( id )
   endif
 endfunction
@@ -1587,7 +1588,15 @@ if exists( '*popup_atcursor' )
   endfunction
 
 
+  let s:last_line = line(".")
+  let s:last_col = col(".")
   function! s:ShowHoverResult( response )
+    if line(".") == s:last_line && col(".") == s:last_col
+      return
+    endif
+    let s:last_line = line(".")
+    let s:last_col = col(".")
+    
     call popup_hide( s:cursorhold_popup )
 
     if empty( a:response )
@@ -1618,9 +1627,11 @@ if exists( '*popup_atcursor' )
           \   {
           \     'col': col,
           \     'wrap': wrap,
+          \     'border': [ 1, 1, 1, 1 ],
           \     'padding': [ 0, 1, 0, 1 ],
           \     'moved': 'word',
           \     'maxwidth': &columns,
+          \     'maxheight': max( [ winline() - 1, winheight( win_getid() ) - winline() ] ),
           \     'close': 'click',
           \     'fixed': 0,
           \   }


### PR DESCRIPTION
some optimization of the info popup and the hover

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
This change can make vim more user-friendly and more VSCode-like.
The reasons and effects of the changes are listed below:
line 171: correct the spelling of 'enabled'.
line 1228: avoid showing line numbers in the info popup beside the completion popup menu in insert mode since line numbers often take too much space.
line 1591-1599: Originally, if you scroll down the hover in normal mode, it will automatically scroll back to its top after &updatetime's CursorHold. This change fixes the problem.
line 1630: add a border to the hover in normal mode to make it more distinct.
line 1634: set the maxheight of the hover in normal mode to fit the window size (i.e. keep the hover from going out of the window's boundary). Originally, the hover cannot be scrolled because it always fits its contents (some of its contents that are out of the window's boundary will become invisible). This change fixes the problem.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4070)
<!-- Reviewable:end -->
