### PR TITLE
Push jumps onto the tags stack

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -698,7 +698,7 @@ def JumpToLocation( filename, line, column, modifiers, command ):
       'tagname': vim.eval("expand('<cword>')")
   } ] }
   vim.eval(
-      f"settagstack( { vim.current.window.number }, { tags_stack }, 'a' )"
+      f"settagstack( { vim.current.window.number }, { tags_stack }, 't' )"
   )
 
   if filename != GetCurrentBufferFilepath():

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -695,7 +695,7 @@ def JumpToLocation( filename, line, column, modifiers, command ):
       # NOTE: Going back in the future with `:tag` works by reissuing the tag
       # command with the saved `tagname`. It obviously doesn't work currently
       # as we do not save the tag name.
-      'tagname': '???'
+      'tagname': vim.eval("expand('<cword>')")
   } ] }
   vim.eval(
       f"settagstack( { vim.current.window.number }, { tags_stack }, 'a' )"

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -685,6 +685,22 @@ def JumpToLocation( filename, line, column, modifiers, command ):
   # Add an entry to the jumplist
   vim.command( "normal! m'" )
 
+  # Add an entry to the tags stack
+  # TODO: Also modify newly created split window's tags stack.
+  lnum, col = vim.current.window.cursor
+  tags_stack = { 'items': [ {
+      'bufnr': vim.current.buffer.number,
+      'from': [ 0, lnum, col + 1, 0 ],
+      'matchnr': 1,
+      # NOTE: Going back in the future with `:tag` works by reissuing the tag
+      # command with the saved `tagname`. It obviously doesn't work currently
+      # as we do not save the tag name.
+      'tagname': '???'
+  } ] }
+  vim.eval(
+      f"settagstack( { vim.current.window.number }, { tags_stack }, 'a' )"
+  )
+
   if filename != GetCurrentBufferFilepath():
     # We prefix the command with 'keepjumps' so that opening the file is not
     # recorded in the jumplist. So when we open the file and move the cursor to


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Since LSP's GoTo* function often replace the native tags functionality it is convenient if they have feature parity. Currently there is no analogue in YCM to native `<c-t>` action. OK there is a jump list, but `<c-t>` is better (hence why it exists in Vim). The common scenario is this:

1. Go to a definiton of a function
2. *Jump* around and find another interesting function, go to this function's definition
3. Repeat ...

What happens then is using the jump list becomes a chore, whereas with `<c-t>` you can cleanly go back to where you were.


# Problems

1. [technicality, will be fixed probably] It is not immediately apparent to me how to figure out a tag name from this deep inside the call stack. This also breaks the "cleaning" of the stack, so to speak. When you're in the middle of the stack and jump to a new definition, current prototype can't figure out that it's a different "tag" and modifies the next entry instead of chopping the tail of the stack.
2. Native `:tag` command allows to traverse the stack in the opposite direction of `<c-t>` by reissuing the tag search for the saved token (see p. 1 above). It's impossible to cleanly hook into this.
3. When using both YCM and tags there *might* be problems.
4. It's probably not going to work with `GoToReferences`.

# Notes

1. This feature is implemented in [vim-lsp]. 
2. This is just a prototype, but already adds value for me personally. I didn't fix the tests yet, in case the approach changes.
3. I wanted to at least have this documented in the repo if we don't manage to merge. Maybe an issue is better for that?
4. Originally discussed with @puremourning on gitter.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
[vim-lsp]: https://github.com/prabirshrestha/vim-lsp/blob/296fb98d198cbbb5c5c937c09b84c8c7a9605a16/autoload/lsp/utils/tagstack.vim

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4078)
<!-- Reviewable:end -->
