### PR TITLE
Fix wrong script_path under MINGW environment

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -266,11 +266,23 @@ endfunction
 function! s:SetUpPython() abort
   py3 << EOF
 import os.path as p
+import os
+import re
 import sys
 import traceback
 import vim
+IS_MSYS = 'MSYS' == os.environ.get( 'MSYSTEM' )
+IS_WINDOWS = sys.platform == 'win32'
 
 root_folder = p.normpath( p.join( vim.eval( 's:script_folder_path' ), '..' ) )
+# convert posix-based mingw path to windows path
+# such as \c\path\to\directory to C:\path\to\directory
+if IS_WINDOWS and not IS_MSYS:
+  root_paths = root_folder.split( os.sep )
+  if len(root_paths) > 1 and root_paths[0] == '' and re.match( '^[a-zA-Z]$', root_paths[ 1 ] ):
+    root_paths = root_paths[ 1: ]
+    root_paths[ 0 ] = root_paths[ 0 ] + ':'
+  root_folder = os.sep.join( root_paths )
 third_party_folder = p.join( root_folder, 'third_party' )
 
 # Add dependencies to Python path.


### PR DESCRIPTION
Under MINGW environment, the vim script path is passed as "\c\path\to\directory" when it is passed to python in autoload\youcompleteme.vim it will be interpreted as %PWD%\c\path\to\directory instead of the correct path.

This patch fixes it.

Tested with the vim shipped with 'Git bash' from Git application.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4089)
<!-- Reviewable:end -->
