### PR TITLE
    Provide a way to manually trigger YCM's completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2672,6 +2672,21 @@ If you want to just turn off the identifier completer but keep the semantic
 triggers, you should set `g:ycm_min_num_of_chars_for_completion` to a high
 number like `99`.
 
+When `g:ycm_auto_trigger` is `0`, YCM sets the `completefunc`, so that you can
+manually trigger normal completion using `C-x C-u`.
+
+If you want to map something else to trigger completion, such as `C-d``,
+then you can map it to `<plug>(YCMComplete)`. For example:
+
+```viml
+let g:ycm_auto_trigger = 0
+imap <c-d> <plug>(YCMComplete)
+```
+
+NOTE: It's not possible to map one of the keys in
+`g:ycm_key_list_select_completion` (or similar) to `<plug>(YCMComplete)`. In
+practice that means that you can't use `<Tab>` for this.
+
 Default: `1`
 
 ```viml
@@ -3386,9 +3401,10 @@ let g:ycm_key_list_stop_completion = ['<C-y>']
 
 This option controls the key mapping used to invoke the completion menu for
 semantic completion. By default, semantic completion is triggered automatically
-after typing `.`, `->` and `::` in insert mode (if semantic completion support
-has been compiled in). This key mapping can be used to trigger semantic
-completion anywhere. Useful for searching for top-level functions and classes.
+after typing characters appropriate for the language, such as `.`, `->`, `::`,
+etc. in insert mode (if semantic completion support has been compiled in). This
+key mapping can be used to trigger semantic completion anywhere. Useful for
+searching for top-level functions and classes.
 
 Console Vim (not Gvim or MacVim) passes `<Nul>` to Vim when the user types
 `<C-Space>` so YCM will make sure that `<Nul>` is used in the map command when

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -40,7 +40,7 @@ BUFWINNR_REGEX = re.compile( '^bufwinnr\\((?P<buffer_number>[0-9]+)\\)$' )
 BWIPEOUT_REGEX = re.compile(
   '^(?:silent! )bwipeout!? (?P<buffer_number>[0-9]+)$' )
 GETBUFVAR_REGEX = re.compile(
-  '^getbufvar\\((?P<buffer_number>[0-9]+), "(?P<option>.+)"\\)$' )
+  '^getbufvar\\((?P<buffer_number>[0-9]+), "(?P<option>.+)"\\)( \\?\\? 0)?$' )
 PROP_ADD_REGEX = re.compile(
         '^prop_add\\( '            # A literal at the start
         '(?P<start_line>\\d+), '   # First argument - number

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -182,7 +182,7 @@ def GetCurrentBufferNumber():
 
 
 def GetBufferChangedTick( bufnr ):
-  return GetIntValue( f'getbufvar({ bufnr }, "changedtick") ?? 0' )
+  return GetIntValue( f'getbufvar({ bufnr }, "changedtick")' ) or 0
 
 
 # Returns a range covering the earliest and latest lines visible in the current

--- a/test/completion.common.vim
+++ b/test/completion.common.vim
@@ -439,3 +439,98 @@ function! Test_Completion_WorksWithoutMovingCursor()
   call setpos( '.', [ 0, 3, 1 ] )
   call FeedAndCheckMain( "i\<C-Space>", funcref( 'Check' ) )
 endfunction
+
+function! SetUp_Test_Manual_Trigger()
+  call youcompleteme#test#setup#PushGlobal( 'ycm_auto_trigger', 0 )
+endfunction
+
+function! Test_Manual_Trigger()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp', {} )
+
+  call setpos( '.', [ 0, 11, 6 ] )
+
+  imap <C-d> <plug>(YCMComplete)
+
+  " Required to trigger TextChangedI
+  " https://github.com/vim/vim/issues/4665#event-2480928194
+  call test_override( 'char_avail', 1 )
+
+  function! Check( id )
+    call WaitForCompletion()
+
+    call CheckCurrentLine( '  tfthne' )
+    call CheckCompletionItemsContainsExactly( [
+          \ 'test_function_that_has_no_errors' ], 'word' )
+
+    call FeedAndCheckAgain( "\<BS>", funcref( 'Check2' ) )
+  endfunction
+
+  function! Check2( id )
+    call WaitForCompletion()
+
+    call CheckCurrentLine( '  tfthn' )
+    call CheckCompletionItemsContainsExactly( [
+          \ 'test_function_that_has_no_errors' ], 'word' )
+
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+  call FeedAndCheckMain( "Otfthne\<C-d>", funcref( 'Check' ) )
+  " Checks run in insert mode, then exit insert mode.
+  call assert_false( pumvisible(), 'pumvisible()' )
+
+  call test_override( 'ALL', 0 )
+  iunmap <C-d>
+endfunction
+
+function! TearDown_Test_Manual_Trigger()
+  call youcompleteme#test#setup#PopGlobal( 'ycm_auto_trigger' )
+endfunction
+
+function! SetUp_Test_Manual_Trigger_CompleteFunc()
+  call youcompleteme#test#setup#PushGlobal( 'ycm_auto_trigger', 0 )
+endfunction
+
+function! Test_Manual_Trigger_CompleteFunc()
+  call youcompleteme#test#setup#OpenFile(
+        \ '/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp', {} )
+
+  call setpos( '.', [ 0, 11, 6 ] )
+  set completefunc=youcompleteme#CompleteFunc
+
+  " Required to trigger TextChangedI
+  " https://github.com/vim/vim/issues/4665#event-2480928194
+  call test_override( 'char_avail', 1 )
+
+  function! Check( id )
+    call WaitForCompletion()
+
+    call CheckCurrentLine( '  tfthne' )
+    call CheckCompletionItemsContainsExactly( [
+          \ 'test_function_that_has_no_errors' ], 'word' )
+
+    call FeedAndCheckAgain( "\<BS>", funcref( 'Check2' ) )
+  endfunction
+
+  function! Check2( id )
+    call WaitForCompletion()
+
+    call CheckCurrentLine( '  tfthn' )
+    call CheckCompletionItemsContainsExactly( [
+          \ 'test_function_that_has_no_errors' ], 'word' )
+
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+  call FeedAndCheckMain( "Otfthne\<C-x>\<C-u>", funcref( 'Check' ) )
+  " Checks run in insert mode, then exit insert mode.
+  call assert_false( pumvisible(), 'pumvisible()' )
+
+  call test_override( 'ALL', 0 )
+  set completefunc=
+endfunction
+
+function! TearDown_Test_Manual_Trigger_CompleteFunc()
+  call youcompleteme#test#setup#PopGlobal( 'ycm_auto_trigger' )
+endfunction

--- a/vimrc_ycm_minimal
+++ b/vimrc_ycm_minimal
@@ -13,9 +13,6 @@ set encoding=utf-8
 let g:ycm_keep_logfiles = 1
 let g:ycm_log_level = 'debug'
 
-" If you're on an arm mac, uncomment the following line
-" let g:ycm_clangd_binary_path=trim(system('brew --prefix llvm')).'/bin/clangd'
-
 " If the base settings don't repro, paste your existing config for YCM only,
 " here:
 " let g:ycm_....
@@ -23,4 +20,4 @@ let g:ycm_log_level = 'debug'
 " Load YCM (only)
 let &rtp .= ',' . expand( '<sfile>:p:h' )
 filetype plugin indent on
-
+syn on


### PR DESCRIPTION
Fixes #3919

```
    Provide a way to manually trigger YCM's completions

    When automatic triggering is disabled, we now set the completefunc, so
    the user can use C-x C-u. We also provide a plug mapping that does the
    completion as users may not be comfortable with c-x c-u.

    As this is a very unusual use-case for YCM we sweep under the rug that
    most users probably want to use <Tab> for both completion and "next". Or
    perhaps want to use C-p in the same way. For now a unique mapping works.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4097)
<!-- Reviewable:end -->
