### PR TITLE
More available arguments for commands

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -393,8 +393,10 @@ class YouCompleteMe:
         continue
       elif argument.startswith( '--line_num=' ):
         extra_data[ 'line_num' ] = int( argument[ len( '--line_num=' ): ] )
+        continue
       elif argument.startswith( '--column_num=' ):
         extra_data[ 'column_num' ] = int( argument[ len( '--column_num=' ): ] )
+        continue
 
       final_arguments.append( argument )
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -391,6 +391,10 @@ class YouCompleteMe:
       elif argument.startswith( '--bufnr=' ):
         extra_data[ 'bufnr' ] = int( argument[ len( '--bufnr=' ): ] )
         continue
+      elif argument.startswith( '--line_num=' ):
+        extra_data[ 'line_num' ] = int( argument[ len( '--line_num=' ): ] )
+      elif argument.startswith( '--column_num=' ):
+        extra_data[ 'column_num' ] = int( argument[ len( '--column_num=' ): ] )
 
       final_arguments.append( argument )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
This change provides more available arguments for commands like `YcmCompleter`. The new available arguments `--line_num=` and `--column_num=` enables the commands to be executed at any position. Without these two arguments, the commands can only be executed at cursor position.

The result of the command `YcmCompleter GetDoc --line_num=6 --column_num=2`:
![image](https://user-images.githubusercontent.com/110970449/209471083-b4778db1-a19b-4e7f-8a35-24739bc34f6f.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4105)
<!-- Reviewable:end -->
