### PR TITLE
fix: capitalization for Linux installation dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ apt install mono-complete golang nodejs openjdk-17-jdk openjdk-17-jre npm
 - Compile YCM
 
 ```
-cd ~/.vim/bundle/YouCompleteMe
+cd ~/.vim/bundle/youcompleteme
 python3 install.py --all
 ```
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fixed the installation directory name in the Linux installation section: `YouCompleteMe` -> `youcompleteme` as it was causing `No such file or directory` error and the directory created actually has all letters uncapitalized.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/4107)
<!-- Reviewable:end -->
