### PR TITLE
Hide diags in insert mode

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1035,6 +1035,7 @@ endfunction
 
 function! s:OnInsertEnter() abort
   let s:current_cursor_position = getpos( '.' )
+  py3 ycm_state.OnInsertEnter()
   if s:ShouldUseInlayHintsNow( bufnr() ) &&
         \ get(g:, 'ycm_clear_inlay_hints_in_insert_mode' )
     py3 ycm_state.CurrentBuffer().inlay_hints.Clear()

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -43,8 +43,8 @@ class Buffer:
 
 
   def FileParseRequestReady( self, block = False ):
-    return bool( self._parse_request and
-                 ( block or self._parse_request.Done() ) )
+    return ( bool( self._parse_request ) and
+             ( block or self._parse_request.Done() ) )
 
 
   def SendParseRequest( self, extra_data ):
@@ -62,6 +62,10 @@ class Buffer:
     # reparse on buffer visit and changed tick remains the same.
     self._handled_tick -= 1
     self._parse_tick = self._ChangedTick()
+
+
+  def ParseRequestPending( self ):
+    return bool( self._parse_request ) and not self._parse_request.Done()
 
 
   def NeedsReparse( self ):
@@ -125,6 +129,10 @@ class Buffer:
 
   def RefreshDiagnosticsUI( self ):
     return self._diag_interface.RefreshDiagnosticsUI()
+
+
+  def ClearDiagnosticsUI( self ):
+    return self._diag_interface.ClearDiagnosticsUI()
 
 
   def DiagnosticsForLine( self, line_number ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -182,7 +182,7 @@ def GetCurrentBufferNumber():
 
 
 def GetBufferChangedTick( bufnr ):
-  return GetIntValue( f'getbufvar({ bufnr }, "changedtick")' ) or 0
+  return GetIntValue( f'getbufvar({ bufnr }, "changedtick")' or 0 )
 
 
 # Returns a range covering the earliest and latest lines visible in the current

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -608,9 +608,14 @@ class YouCompleteMe:
     return self._buffers[ bufnr ]
 
 
+  def OnInsertEnter( self ):
+    if not self._user_options[ 'update_diagnostics_in_insert_mode' ]:
+      self.CurrentBuffer().ClearDiagnosticsUI()
+
+
   def OnInsertLeave( self ):
     if ( not self._user_options[ 'update_diagnostics_in_insert_mode' ] and
-         not self.NeedsReparse() ):
+         not self.CurrentBuffer().ParseRequestPending() ):
       self.CurrentBuffer().RefreshDiagnosticsUI()
     SendEventNotificationAsync( 'InsertLeave' )
 


### PR DESCRIPTION
When g:ycm_update_diagnostics_in_insert_mode is disabled (i.e. `0`) clear the diagnostics when _entering_ insert mode.

This makes editing much smoother when there are a lot of diags and is much less annoying particularly when using things like virtual text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4117)
<!-- Reviewable:end -->
