### PR TITLE
Don't change the cursor position if GoTo doesnt have one

### DIFF
--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -138,6 +138,12 @@ class CommandRequest( BaseRequest ):
       vimsupport.SetQuickFixList(
         [ vimsupport.BuildQfListItem( x ) for x in self._response ] )
       vimsupport.OpenQuickFixList( focus = True, autoclose = True )
+    elif self._response.get( 'file_only' ):
+      vimsupport.JumpToLocation( self._response[ 'filepath' ],
+                                 None,
+                                 None,
+                                 modifiers,
+                                 buffer_command )
     else:
       vimsupport.JumpToLocation( self._response[ 'filepath' ],
                                  self._response[ 'line_num' ],

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1729,6 +1729,124 @@ class VimsupportTest( TestCase ):
 
 
   @patch( 'vim.command', new_callable = ExtendedMock )
+  def test_JumpToLocation_SameFile_NoLineCol( self, vim_command ):
+    current_buffer = VimBuffer( 'uni¢𐍈d€' )
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+      vim.current.window.cursor = ( 99, 99 )
+
+      target_name = os.path.realpath( 'uni¢𐍈d€' )
+      vimsupport.JumpToLocation( target_name,
+                                 None,
+                                 None,
+                                 'belowright',
+                                 'same-buffer' )
+
+      assert_that( vim.current.window.cursor, equal_to( ( 99, 99 ) ) )
+      vim_command.assert_has_exact_calls( [
+        call( 'normal! m\'' ),
+      ] )
+
+
+  @patch( 'vim.command', new_callable = ExtendedMock )
+  def test_JumpToLocation_SameFile_NoLine( self, vim_command ):
+    current_buffer = VimBuffer( 'uni¢𐍈d€' )
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+      vim.current.window.cursor = ( 99, 99 )
+
+      target_name = os.path.realpath( 'uni¢𐍈d€' )
+      vimsupport.JumpToLocation( target_name,
+                                 None,
+                                 1,
+                                 'belowright',
+                                 'same-buffer' )
+
+      assert_that( vim.current.window.cursor, equal_to( ( 99, 99 ) ) )
+      vim_command.assert_has_exact_calls( [
+        call( 'normal! m\'' ),
+      ] )
+
+
+  @patch( 'vim.command', new_callable = ExtendedMock )
+  def test_JumpToLocation_SameFile_NoCol( self, vim_command ):
+    current_buffer = VimBuffer( 'uni¢𐍈d€' )
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+      vim.current.window.cursor = ( 99, 99 )
+
+      target_name = os.path.realpath( 'uni¢𐍈d€' )
+      vimsupport.JumpToLocation( target_name,
+                                 1,
+                                 None,
+                                 'belowright',
+                                 'same-buffer' )
+
+      assert_that( vim.current.window.cursor, equal_to( ( 99, 99 ) ) )
+      vim_command.assert_has_exact_calls( [
+        call( 'normal! m\'' ),
+      ] )
+
+
+  @patch( 'vim.command', new_callable = ExtendedMock )
+  def test_JumpToLocation_DifferentFile_NoLineCol( self, vim_command ):
+    current_buffer = VimBuffer( 'uni¢𐍈d€' )
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+      vim.current.window.cursor = ( 99, 99 )
+
+      target_name = os.path.realpath( 'different_uni¢𐍈d€' )
+      vimsupport.JumpToLocation( target_name,
+                                 None,
+                                 None,
+                                 'belowright',
+                                 'same-buffer' )
+
+      assert_that( vim.current.window.cursor, equal_to( ( 99, 99 ) ) )
+      vim_command.assert_has_exact_calls( [
+        call( 'normal! m\'' ),
+        call( f'keepjumps belowright edit { target_name }' ),
+      ] )
+
+
+  @patch( 'vim.command', new_callable = ExtendedMock )
+  def test_JumpToLocation_DifferentFile_NoLine( self, vim_command ):
+    current_buffer = VimBuffer( 'uni¢𐍈d€' )
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+      vim.current.window.cursor = ( 99, 99 )
+
+      target_name = os.path.realpath( 'different_uni¢𐍈d€' )
+      vimsupport.JumpToLocation( target_name,
+                                 None,
+                                 1,
+                                 'belowright',
+                                 'same-buffer' )
+
+      assert_that( vim.current.window.cursor, equal_to( ( 99, 99 ) ) )
+      vim_command.assert_has_exact_calls( [
+        call( 'normal! m\'' ),
+        call( f'keepjumps belowright edit { target_name }' ),
+      ] )
+
+
+  @patch( 'vim.command', new_callable = ExtendedMock )
+  def test_JumpToLocation_DifferentFile_NoCol( self, vim_command ):
+    current_buffer = VimBuffer( 'uni¢𐍈d€' )
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+      vim.current.window.cursor = ( 99, 99 )
+
+      target_name = os.path.realpath( 'different_uni¢𐍈d€' )
+      vimsupport.JumpToLocation( target_name,
+                                 1,
+                                 None,
+                                 'belowright',
+                                 'same-buffer' )
+
+      assert_that( vim.current.window.cursor, equal_to( ( 99, 99 ) ) )
+      vim_command.assert_has_exact_calls( [
+        call( 'normal! m\'' ),
+        call( f'keepjumps belowright edit { target_name }' ),
+      ] )
+
+
+
+  @patch( 'vim.command', new_callable = ExtendedMock )
   def test_JumpToLocation_DifferentFile_SameBuffer_Modified_CannotHide(
       self, vim_command ):
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -631,12 +631,13 @@ def TryJumpLocationInTab( tab, filename, line, column ):
     if ComparePaths( GetBufferFilepath( win.buffer ), filename ):
       vim.current.tabpage = tab
       vim.current.window = win
-      vim.current.window.cursor = ( line, column - 1 )
+      if line is not None and column is not None:
+        vim.current.window.cursor = ( line, column - 1 )
+        # Open possible folding at location
+        vim.command( 'normal! zv' )
+        # Center the screen on the jumped-to location
+        vim.command( 'normal! zz' )
 
-      # Open possible folding at location
-      vim.command( 'normal! zv' )
-      # Center the screen on the jumped-to location
-      vim.command( 'normal! zz' )
       return True
   # 'filename' is not opened in this tab page
   return False
@@ -710,12 +711,13 @@ def JumpToLocation( filename, line, column, modifiers, command ):
     if not JumpToFile( filename, command, modifiers ):
       return
 
-  vim.current.window.cursor = ( line, column - 1 )
+  if line is not None and column is not None:
+    vim.current.window.cursor = ( line, column - 1 )
 
-  # Open possible folding at location
-  vim.command( 'normal! zv' )
-  # Center the screen on the jumped-to location
-  vim.command( 'normal! zz' )
+    # Open possible folding at location
+    vim.command( 'normal! zv' )
+    # Center the screen on the jumped-to location
+    vim.command( 'normal! zz' )
 
 
 def NumLinesInBuffer( buffer_object ):


### PR DESCRIPTION
This fixes the behavour of GoToAlternate file to keep the buffer's cursor position.

cc @klew

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4118)
<!-- Reviewable:end -->
