### PR TITLE
Use macOS 12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+        runs-on: [ ubuntu-20.04, macos-12, windows-2019 ]
         python-arch: [ 'x64' ]
         python-version: [ '3.8' ]
         include:


### PR DESCRIPTION
Our records indicate that some of your organization’s workflow files are still referencing the macos-10.15 runner image. This image has been fully unsupported since 2022-12-01 and will be completely removed by 2023-03-31.

What you need to do

Workflows using the macos-10.15 YAML workflow label should be updated to macos-latest, macos-12, or macos-11. You can always get up-to-date information on our tools by reading about the [software](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=20a1f0dfddfb4f279a143758449644bb&elq=80ef062d847e4addbbafffe8e5e487cb&elqaid=3113&elqat=1) in GitHub Actions runner images. Please contact [GitHub Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=109f1ab4edb9447baf91e5e0d5dcb9c1&elq=80ef062d847e4addbbafffe8e5e487cb&elqaid=3113&elqat=1) if you run into any problems or need help.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4132)
<!-- Reviewable:end -->
