### PR TITLE
Add the ability to pass popup_params when creating a custom ycm_hover

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1650,18 +1650,21 @@ if exists( '*popup_atcursor' )
       let wrap = 1
     endif
 
-    let s:cursorhold_popup = popup_atcursor(
-          \   lines,
-          \   {
-          \     'col': col,
-          \     'wrap': wrap,
-          \     'padding': [ 0, 1, 0, 1 ],
-          \     'moved': 'word',
-          \     'maxwidth': &columns,
-          \     'close': 'click',
-          \     'fixed': 0,
-          \   }
-          \ )
+    let popup_params = {
+      \   'col': col,
+      \   'wrap': wrap,
+      \   'padding': [ 0, 1, 0, 1 ],
+      \   'moved': 'word',
+      \   'maxwidth': &columns,
+      \   'close': 'click',
+      \   'fixed': 0,
+      \   }
+
+    if has_key( b:ycm_hover, 'popup_params' )
+      let popup_params = extend( copy( popup_params ), b:ycm_hover.popup_params )
+    endif
+
+    let s:cursorhold_popup = popup_atcursor( lines, popup_params )
     call setbufvar( winbufnr( s:cursorhold_popup ),
                             \ '&syntax',
                             \ b:ycm_hover.syntax )

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3277,6 +3277,7 @@ This buffer-local variable can be set to a dictionary with the following keys:
 - 'command': The YCM completer subcommand which should be run on hover
 - 'syntax': The syntax to use (as in 'set syntax=') in the popup window for
   highlighting.
+- 'popup_params': The params passed to a popup window which gets opened.
 
 For example, to use C/C++ syntax highlighting in the popup for C-family
 languages, add something like this to your vimrc:
@@ -3289,6 +3290,25 @@ languages, add something like this to your vimrc:
       \ }
   augroup END
 <
+
+You can also modify the opened popup with 'popup_params' key.
+For example, you can limit the popup's maximum width and add a border to it:
+>
+  augroup MyYCMCustom
+    autocmd!
+    autocmd FileType c,cpp let b:ycm_hover = {
+      \ 'command': 'GetDoc',
+      \ 'syntax': &filetype
+      \ 'popup_params': {
+      \     'maxwidth': 80,
+      \     'border': [],
+      \     'borderchars': ['─', '│', '─', '│', '┌', '┐', '┘', '└'],
+      \   },
+      \ }
+  augroup END
+<
+See |popup_create-arguments| for the list of available popup window options.
+
 Default: "'CursorHold'"
 
 -------------------------------------------------------------------------------

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -387,6 +387,53 @@ function! TearDown_Test_Hover_Custom_Command()
   silent! au! MyYCMCustom
 endfunction
 
+function! SetUp_Test_Hover_Custom_Popup()
+  augroup MyYCMCustom
+    autocmd!
+    autocmd FileType cpp let b:ycm_hover = {
+      \ 'command': 'GetDoc',
+      \ 'syntax': 'cpp',
+      \ 'popup_params': {
+      \     'maxwidth': 10,
+      \   }
+      \ }
+  augroup END
+endfunction
+
+function! Test_Hover_Custom_Popup()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/completion.cc',
+                                        \ {} )
+  call assert_equal( 'cpp', &filetype )
+  call assert_equal( {
+                   \   'command': 'GetDoc',
+                   \   'syntax': 'cpp',
+                   \   'popup_params': { 'maxwidth': 10 }
+                   \ }, b:ycm_hover )
+
+  call setpos( '.', [ 0, 6, 8 ] )
+  doautocmd CursorHold
+  call assert_equal( {
+                   \   'command': 'GetDoc',
+                   \   'syntax': 'cpp',
+                   \   'popup_params': { 'maxwidth': 10 }
+                   \ }, b:ycm_hover )
+
+  call s:CheckPopupVisibleScreenPos( { 'row': 7, 'col': 9 },
+                                   \ s:cpp_lifetime.GetDoc,
+                                   \ 'cpp' )
+  " Check that popup's width is limited by maxwidth being passed
+  call s:CheckPopupNotVisibleScreenPos( { 'row': 7, 'col': 20 }, v:false )
+
+  normal \D
+  call s:CheckPopupNotVisibleScreenPos( { 'row': 7, 'col': 9 }, v:false )
+
+  call popup_clear()
+endfunction
+
+function! TearDown_Test_Hover_Custom_Popup()
+  silent! au! MyYCMCustom
+endfunction
+
 function! Test_Long_Single_Line()
   call youcompleteme#test#setup#OpenFile( '/test/testdata/python/doc.py', {} )
   call cursor( [ 37, 3 ] )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This PR adds the ability to pass `popup_params` to a custom `ycm_hover` like this:

```vimscript
autocmd FileType c,cpp let b:ycm_hover = {
  \ 'command': 'GetDoc',
  \ 'syntax': &filetype,
  \ 'popup_params': {
      \ 'drag': 1,
      \ 'maxwidth': 80,
      \ 'resize': 1,
      \ 'border': [],
      \ 'borderchars': ['─', '│', '─', '│', '┌', '┐', '┘', '└'],
  \   },
  \ }
augroup END
```

This allows users to customize the popup window by adding maximum width, borders and other behaviour:

https://user-images.githubusercontent.com/1285136/225943211-c6df7e74-9d0f-494b-9270-33a98b81e4fa.mp4

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
