### PR TITLE
allow using not registered highlighting groups

### DIFF
--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -71,6 +71,14 @@ def Initialise():
                               highlight = group,
                               priority = 0 )
 
+  # add user defined properties
+  ycm_prop_suffix = f'YCM_HL_'
+  for prop in props:
+    if prop[0:len(ycm_prop_suffix)] == ycm_prop_suffix:
+      name = prop[len(ycm_prop_suffix):]
+      if name not in HIGHLIGHT_GROUP.keys():
+        HIGHLIGHT_GROUP[name] = ''
+
 
 # "arbitrary" base id
 NEXT_TEXT_PROP_ID = 70784
@@ -107,18 +115,13 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
     self._prop_id = NextPropID()
 
     for token in tokens:
-      prop_type = f"YCM_HL_{ token[ 'type' ] }"
-
       if token[ 'type' ] not in HIGHLIGHT_GROUP:
-        props = tp.GetTextPropertyTypes()
-        if prop_type in props:
-          HIGHLIGHT_GROUP[token['type']] = ''
-        else:
-          if token[ 'type' ] not in REPORTED_MISSING_TYPES:
-            REPORTED_MISSING_TYPES.add( token[ 'type' ] )
-            vimsupport.PostVimMessage(
-              f"Missing property type for { token[ 'type' ] }" )
-          continue
+        if token[ 'type' ] not in REPORTED_MISSING_TYPES:
+          REPORTED_MISSING_TYPES.add( token[ 'type' ] )
+          vimsupport.PostVimMessage(
+            f"Missing property type for { token[ 'type' ] }" )
+        continue
+      prop_type = f"YCM_HL_{ token[ 'type' ] }"
 
       rng = token[ 'range' ]
       self.GrowRangeIfNeeded( rng )

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -107,13 +107,18 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
     self._prop_id = NextPropID()
 
     for token in tokens:
-      if token[ 'type' ] not in HIGHLIGHT_GROUP:
-        if token[ 'type' ] not in REPORTED_MISSING_TYPES:
-          REPORTED_MISSING_TYPES.add( token[ 'type' ] )
-          vimsupport.PostVimMessage(
-            f"Missing property type for { token[ 'type' ] }" )
-        continue
       prop_type = f"YCM_HL_{ token[ 'type' ] }"
+
+      if token[ 'type' ] not in HIGHLIGHT_GROUP:
+        props = tp.GetTextPropertyTypes()
+        if prop_type in props:
+          HIGHLIGHT_GROUP[token['type']] = ''
+        else:
+          if token[ 'type' ] not in REPORTED_MISSING_TYPES:
+            REPORTED_MISSING_TYPES.add( token[ 'type' ] )
+            vimsupport.PostVimMessage(
+              f"Missing property type for { token[ 'type' ] }" )
+          continue
 
       rng = token[ 'range' ]
       self.GrowRangeIfNeeded( rng )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Clangd supports some non-standard highlighting groups, for example `label`, so currently we will see warning in vim when C/C++ code contains any labels. And even if we manually set text property for `label` (like `YCM_HL_label`) it will not fix that, because YCM will ignore any not registered groups. So, instead, I add checking the "new" group in text properties - if it is already there, then add it to the list of registered groups

PS unfortunately I am not a good at python and I didn't look deep in that repo, so I didn't provide test case for that, only checked it in editor with `label` group

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4161)
<!-- Reviewable:end -->
