### PR TITLE
Address #4165: provide a highlight group for the detailed diagnostic popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,6 +1770,10 @@ You can also style the line that has the warning/error with these groups:
 - `YcmWarningLine`, which falls back to group `SyntasticWarningLine` if it
   exists
 
+Finally, you can also style the popup for the detailed diagnostics (it is shown
+if `g:ycm_show_detailed_diag_in_popup` is set) using the group `YcmErrorPopup`,
+which falls back to `ErrorMsg`.
+
 Note that the line highlighting groups only work when the
 [`g:ycm_enable_diagnostic_signs`](#the-gycm_enable_diagnostic_signs-option)
 option is set. If you want highlighted lines but no signs in the Vim gutter,

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -512,6 +512,10 @@ function! s:SetUpSyntaxHighlighting()
           \ 'combine': 0,
           \ 'override': 1 } )
   endif
+
+  if !hlexists( 'YcmErrorPopup' )
+    highlight default link YcmErrorPopup ErrorMsg
+  endif
 endfunction
 
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2017,6 +2017,10 @@ You can also style the line that has the warning/error with these groups:
 - 'YcmWarningLine', which falls back to group 'SyntasticWarningLine' if it
   exists
 
+Finally, you can also style the popup for the detailed diagnostics (it is shown
+if |g:ycm_show_detailed_diag_in_popup| is set) using the group 'YcmErrorPopup',
+which falls back to |ErrorMsg|.
+
 Note that the line highlighting groups only work when the
 |g:ycm_enable_diagnostic_signs| option is set. If you want highlighted lines
 but no signs in the Vim gutter, set the 'signcolumn' option to 'no' in your

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -849,7 +849,7 @@ class YouCompleteMe:
           'maxwidth': available_columns,
           'close': 'click',
           'fixed': 0,
-          'highlight': 'ErrorMsg',
+          'highlight': 'YcmErrorPopup',
           'border': [ 1, 1, 1, 1 ],
           # Close when moving cursor
           'moved': 'expr',


### PR DESCRIPTION
This seems to work, but I have a few questions

  - What tests should I look at to understand how to write one for this change?
  - Are you happy with the name `YcmErrorPopup`?
  - What should I set as `'priority'`, `'combine'`, `'override'`?

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

See #4165 and [conversation on gitter](https://matrix.to/#/!wwhJRinEmBFNyyXmut:gitter.im/$g19MXPpDc-cOYFxt_27sZ-nigpQRuBYUa_DbJ0RlqBA?via=gitter.im&via=matrix.org&via=matrix.freyachat.eu).

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4166)
<!-- Reviewable:end -->
