### PR TITLE
Diagnostics fixes - hopefully only the non-controversial parts

### DIFF
--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -44,8 +44,7 @@ class DiagnosticInterface:
     if self._user_options[ 'echo_current_diagnostic' ]:
       line, _ = vimsupport.CurrentLineAndColumn()
       line += 1  # Convert to 1-based
-      if ( not self.ShouldUpdateDiagnosticsUINow() and
-           self._diag_message_needs_clearing ):
+      if not self.ShouldUpdateDiagnosticsUINow():
         # Clear any previously echo'd diagnostic in insert mode
         self._EchoDiagnosticText( line, None, None )
       elif line != self._previous_diag_line_number:

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -614,8 +614,10 @@ class YouCompleteMe:
 
 
   def OnInsertLeave( self ):
+    async_diags = any( self._message_poll_requests.get( filetype )
+                      for filetype in vimsupport.CurrentFiletypes() )
     if ( not self._user_options[ 'update_diagnostics_in_insert_mode' ] and
-         not self.CurrentBuffer().ParseRequestPending() ):
+         ( async_diags or not self.CurrentBuffer().ParseRequestPending() ) ):
       self.CurrentBuffer().RefreshDiagnosticsUI()
     SendEventNotificationAsync( 'InsertLeave' )
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This PR fixes two diagnostic bugs, makes one harder to solve and leaves one for later:

1. Diagnostic echo on enter if echoing virtual-text when asked not to. - Fixed
2. No diagnostic refresh if leaving insert mode after a semantic trigger. - Fixed
3. Echo flicker on insert leave. - Harder to fix. Previously caused only by `CursorMoved`, now by `InsertLeave` too.
4. Sign column bounce - still thinking about the best way to fix it.

I have tried fixing number 3, but all I could come up with were some heuristics which were always wrong in some case...

Are these changes still too controversial?

I will (try to) write the vim level tests when we agree about the way forward.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4187)
<!-- Reviewable:end -->
