### PR TITLE
Handle possible errors from RangeVisibleInBuffer()

### DIFF
--- a/python/ycm/scrolling_range.py
+++ b/python/ycm/scrolling_range.py
@@ -55,6 +55,13 @@ class ScrollingBufferRange( object ):
     #  - look up the actual visible range, then call this function
     #  - if not overlapping, do the factor expansion and request
     self._last_requested_range = vimsupport.RangeVisibleInBuffer( self._bufnr )
+    # If this is false, either the self._bufnr is not a valid buffer number or
+    # the buffer is not visible in any window.
+    # Since this is called asynchronously, a user may bwipeout a buffer with
+    # self._bufnr number between polls.
+    if self._last_requested_range is None:
+      return False
+
     self._tick = vimsupport.GetBufferChangedTick( self._bufnr )
 
     # We'll never use the last response again, so clear it

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -206,7 +206,10 @@ def RangeVisibleInBuffer( bufnr, grow_factor=0.5 ):
     start: Location = Location()
     end: Location = Location()
 
-  buffer = vim.buffers[ bufnr ]
+  try:
+    buffer = vim.buffers[ bufnr ]
+  except KeyError:
+    return None
 
   if not windows:
     return None


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
First and more common error is that by the time we execute

    buffer = vim.buffers[ bufnr ]

the buffer might not be there any more. This is because `RangeVisibleInBuffer()` is called asynchronously and the user may bwipeout a buffer in between polls.
This regularly happens in our vim tests. In such a case, we get a nasty traceback from `vimsupport` module.
The solution is to catch the KeyError and return None.

However, `ScrollingBufferRange()` also was not ready to handle None values from `RangeVisibleInBuffer()`, even though `RangeVisibleInBuffer()` could return None even before, if a visible window for `bufnr` can not be found.

As for the missing tests... showing that an inherently racy scenario does not cause a stacktrace in vim level test... I think I prefer to keep what is left of my sanity.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4192)
<!-- Reviewable:end -->
