### PR TITLE
Stop auto hover timer if buffer changes or cursor moves

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -766,6 +766,10 @@ function! s:OnBufferEnter()
     return
   endif
 
+  if g:ycm_auto_hover ==# 'CursorHold' && s:enable_hover
+    call timer_stop( s:pollers.command.id )
+  endif
+
   call s:SetUpCompleteopt()
   call s:EnableCompletingInCurrentBuffer()
 
@@ -1594,6 +1598,7 @@ if exists( '*popup_atcursor' )
       return
     endif
 
+    call timer_stop( s:pollers.command.id )
     if !has_key( b:, 'ycm_hover' )
       let cmds = youcompleteme#GetDefinedSubcommands()
       if index( cmds, 'GetHover' ) >= 0


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Lack of tests is again just so I can preserve my sanity.
This was just reported on gitter. If the user changes buffer while we are running thte hover time, it causes a traceback.
[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
