### PR TITLE
Make switching to semantic completer work after select ID completer candidate

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1196,6 +1196,7 @@ function! s:RequestSemanticCompletion() abort
 
   if get( b:, 'ycm_completing' )
     let s:force_semantic = 1
+    let s:current_cursor_position = getpos( '.' )
     call s:StopPoller( s:pollers.completion )
     py3 ycm_state.SendCompletionRequest( True )
 

--- a/test/completion_info.test.vim
+++ b/test/completion_info.test.vim
@@ -203,3 +203,47 @@ function! Test_DontResolveCompletion_AlreadyResolved()
 
   call test_override( 'ALL', 0 )
 endfunction
+
+function! Test_SwitchingToSemanticCompletionAfterSelectingIdentifierCandidate()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/identifier_semantic_switch.cpp', {} )
+  call setpos( '.', [ 0, 3, 0 ] )
+  call test_override( 'char_avail', 1 )
+
+  function! Check1( id )
+    call WaitForCompletion()
+    call CheckCompletionItemsContainsExactly( [ 'ZbCdE' ], 'word' )
+    let compl = complete_info()
+    call assert_equal( -1, compl.selected )
+    call assert_equal( 1, len( compl.items ) )
+    let ZbCdE = compl.items[ 0 ]
+    call assert_equal( 'ZbCdE', ZbCdE.word )
+    call assert_equal( '[ID]', ZbCdE.menu )
+    call assert_equal( '', ZbCdE.kind )
+    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check2' ) )
+  endfunction
+
+  function! Check2( id )
+    call WaitForCompletion()
+    call assert_match( 'ZbCdE', getline( '.' ) )
+    call FeedAndCheckAgain( "\<C-Space>", funcref( 'Check3' ) )
+  endfunction
+
+  function! Check3( id )
+    call WaitForCompletion()
+    call CheckCompletionItemsContainsExactly( [ 'ZbCdE' ], 'word' )
+    let compl = complete_info()
+    call assert_equal( -1, compl.selected )
+    call assert_match( 'ZbCdE', getline( '.' ) )
+    call assert_equal( 1, len( compl.items ) )
+    let ZbCdE = compl.items[ 0 ]
+    call assert_equal( 'ZbCdE', ZbCdE.word )
+    call assert_equal( 'void', ZbCdE.menu )
+    call assert_equal( 'f', ZbCdE.kind )
+    call feedkeys( "\<Esc>" )
+  endfunction
+
+
+  call FeedAndCheckMain( 'ZCE', funcref( 'Check1' ) )
+  call assert_false( pumvisible(), 'pumvisible()' )
+  call test_override( 'ALL', 0 )
+endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4208)
<!-- Reviewable:end -->
