### PR TITLE
[READY] Handle scrolling when hover popup is open

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -717,6 +717,12 @@ function! s:EnableAutoHover()
     augroup YcmBufHover
       autocmd! * <buffer>
       autocmd CursorHold <buffer> call s:Hover()
+      if exists( '##WinResized' )
+        autocmd WinResized <buffer> call popup_close( s:cursorhold_popup )
+      endif
+      if exists( '##WinScrolled' )
+        autocmd WinScrolled <buffer> call popup_close( s:cursorhold_popup )
+      endif
     augroup END
   endif
 endfunction
@@ -1646,10 +1652,12 @@ if exists( '*popup_atcursor' )
       return
     endif
 
-    call s:GetCommandResponseAsyncImpl(
-          \ function( 's:ShowHoverResult' ),
-          \ 'autohover',
-          \ b:ycm_hover.command )
+    if empty( popup_getpos( s:cursorhold_popup ) )
+      call s:GetCommandResponseAsyncImpl(
+            \ function( 's:ShowHoverResult' ),
+            \ 'autohover',
+            \ b:ycm_hover.command )
+    endif
   endfunction
 
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

There are two kinds of scrolling that need to be handled:
1. Scrolling the buffer in a window shifts the buffer, but popups stay in place. Instead, we close the popup whenever we receive a WinScrolled event.
2. Scrolling the popup contents themselves resets the `updatetime` timer and can trigger a second `CursorHold` event, which leads to YCM resetting the hover popup. Instead, only re-display the hover popup if it is not already visible.

Open questions:
- Should we close other popups after `WinScrolled`?
- Tests... How do we even test "do X if mouse pointer at (x, y) position"? The behaviour differs when mouse pointer is inside or outside the popup area. 

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4209)
<!-- Reviewable:end -->
