### PR TITLE
Fix display of special characters in finder popups

### DIFF
--- a/autoload/youcompleteme/finder.vim
+++ b/autoload/youcompleteme/finder.vim
@@ -499,7 +499,7 @@ function! s:RedrawFinderPopup() abort
                \ .. line_num
       let path_includes_line = 1
 
-      let spaces = available_width - len( desc ) - len( path )
+      let spaces = available_width - strdisplaywidth( desc ) - strdisplaywidth( path )
       let spacing = 4
       if spaces < spacing
         let spaces = spacing
@@ -524,16 +524,16 @@ function! s:RedrawFinderPopup() abort
       if len( path ) > 0
         if path_includes_line
           let props += [
-                \ { 'col': available_width - len( path ) + 1,
+                \ { 'col': len( desc ) + spaces + 1,
                 \   'length': len( path ) - len( line_num ),
                 \   'type': 'YCM-symbol-file' },
-                \ { 'col': available_width - len( line_num ) + 1,
+                \ { 'col': len( desc ) + spaces + 1 + len( path ) - len( line_num ),
                 \   'length': len( line_num ),
                 \   'type': 'YCM-symbol-line-num' },
                 \ ]
         else
           let props += [
-                \ { 'col': available_width - len( path ) + 1,
+                \ { 'col': len( desc ) + spaces + 1,
                 \   'length': len( path ),
                 \   'type': 'YCM-symbol-file' },
                 \ ]


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Previously len( desc ) and len( path ) counted bytes, which was wrong for non-ascii characters. A string like `čđš` should have the length of 3 when calculating the number of spaces between the identifier and the file path.

That brings us to choosing the right string length function. The choices are:

- strcharlen - counts characters. `čđš` is 3, `čđ\tš` is 4. Not sure what happens in the face of zero width joiners.
- strdisplaywidth - counts character width on screen. `čđš` is 3 and `čđ\tš` is 9 (assuming `tabstop` is 8).

Tabs do not appear in identifier names, but double width emojis might? Tabs *can* appear in file names though. If there's more than one tab in the file name, using `strcharlen` will push the file path text off screen.

I do not know if there's a performance penalty for using `strdisplaywidth` over `strcharlen`.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4215)
<!-- Reviewable:end -->
