### PR TITLE
[READY] Handle multiple identical diagnostics in YcmShowDetailedDiagnostic popup

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -868,6 +868,7 @@ class YouCompleteMe:
               'textprop': prop[ 'type' ],
             } )
             options.pop( 'col' )
+            break
         vim.eval( f'{ popup_func }( { json.dumps( lines ) }, '
                                   f'{ json.dumps( options ) } )' )
       else:

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -446,3 +446,21 @@ function! Test_ShowDetailedDiagnostic_Popup_MultilineDiagFromStartOfLine()
 
   %bwipe!
 endfunction
+
+function! Test_ShowDetailedDiagnostic_Popup_MultipleDiagsPerLine_SameMessage()
+  let f = tempname() . '.cc'
+  execut 'edit' f
+  call setline( 1, [ 'void f(){a;a;}', ] )
+  call youcompleteme#test#setup#WaitForInitialParse( {} )
+
+  call WaitForAssert( {->
+    \ assert_true(
+      \ py3eval(
+        \ 'len( ycm_state.CurrentBuffer()._diag_interface._diagnostics )'
+    \ ) ) } )
+
+  YcmShowDetailedDiagnostic popup
+  let popup_list = popup_list()
+  call assert_equal( 1, len( popup_list ) )
+  call popup_close( popup_list[ 0 ] )
+endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

If a line for which detailed diagnostics are requested contains more than a single diagnostic with the same message, YCM will try `options.pop( 'col' )` more than once.

We do not need to really iterate through the diagnostics once we have found the first one that is a match. If there's only one diag with the matching message, looping beyond that diagnostic is just a waste of time. If there's multiple diagnostics with the same message, it does not matter which one we display in the popup.

Hence, the added break at the end of the loop.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4219)
<!-- Reviewable:end -->
