### PR TITLE
[READY] Implement type/call hierarchy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Contents
     - [Diagnostic Display](#diagnostic-display)
         - [Diagnostic Highlighting Groups](#diagnostic-highlighting-groups)
     - [Symbol Search](#symbol-search)
+    - [Type/Call Hierarchy](#typecall-hierarchy)
 - [Commands](#commands)
     - [YcmCompleter subcommands](#ycmcompleter-subcommands)
         - [GoTo Commands](#goto-commands)
@@ -677,6 +678,8 @@ Quick Feature Summary
 * Code formatting (`Format`)
 * Semantic highlighting
 * Inlay hints
+* Type hierarchy
+* Call hierarchy
 
 ### C♯
 
@@ -720,6 +723,7 @@ Quick Feature Summary
 * Type information for identifiers (`GetType`)
 * Code formatting (`Format`)
 * Management of `gopls` server instance
+* Call hierarchy
 
 ### JavaScript and TypeScript
 
@@ -759,6 +763,7 @@ Quick Feature Summary
 * Management of `rust-analyzer` server instance
 * Semantic highlighting
 * Inlay hints
+* Call hierarchy
 
 ### Java
 
@@ -782,6 +787,8 @@ Quick Feature Summary
 * Execute custom server command (`ExecuteCommand <args>`)
 * Management of `jdt.ls` server instance
 * Semantic highlighting
+* Type hierarchy
+* Call hierarchy
 
 User Guide
 ----------
@@ -912,10 +919,6 @@ difficult to create without breaking or overriding some existing functionality.
 Ctrl-l is not a suggestion, just an example.
 
 ### Semantic highlighting
-
-**NOTE**: This feature is highly experimental and offered in the hope that it is
-useful. It shall not be considered stable; if you find issues with it, feel free
-to report them, however.
 
 Semantic highlighting is the process where the buffer text is coloured according
 to the underlying semantic type of the word, rather than classic syntax
@@ -1883,6 +1886,61 @@ so you can use window commands `<C-w>...` for example.
 for that, or use a window command (e.g. `<Ctrl-w>j`) or the mouse to leave the
 prompt buffer window.
 
+### Type/Call Hierarchy
+
+***This feature requires Vim and is not supported in Neovim***
+
+**NOTE**: This feature is highly experimental and offered in the hope that it is
+useful. Please help us by reporting issues and offering feedback.
+
+YCM provides a way to view and navigate hierarchies. The following hierarchies
+are supported:
+
+* Type hierachy `<Plug>(YCMTypeHierarchy)`: Display subtypes and supertypes
+  of the symbol under cursor. Expand down to subtypes and up to supertypes.
+* Call hierarchy `<Plug>(YCMCallHierarchy)`: Display callees and callers of
+  the symbol under cursor. Expand down to callers and up to callees.
+
+Take a look at this [![asciicast](https://asciinema.org/a/659925.svg)](https://asciinema.org/a/659925)
+for brief demo.
+
+Hierarchy UI can be initiated by mapping something to the indicated plug
+mappings, for example:
+
+```viml
+nmap <leader>yth <Plug>(YCMTypeHierarchy)
+nmap <leader>ych <Plug>(YCMCallHierarchy)
+```
+
+This opens a "modal" popup showing the current element in the hierarchy tree.
+The current tree root is aligned to the left and child and parent nodes are
+expanded to the right. Expand the tree "down" with `<Tab> and "up" with
+`<S-Tab>`.
+
+The "root" of the tree can be re-focused to the selected item with
+`<S-Tab>` and further `<S-Tab>` will show the parents of the selected item. This
+can take a little getting used to, but it's particularly important with multiple
+inheritance where a "child" of the current root may actually have other,
+invisible, parent links. `<S-Tab>` on that row will show these by setting the
+display root to the selected item.
+
+When the hierarchy is displayed, the following keys are intercepted:
+
+* `<Tab>`: Drill into the hierarchy at the selected item: expand and show
+  children of the selected item.
+* `<S-Tab>`: Show parents of the selected item. When applied to sub-types, this
+  will re-root the tree at that type, so that all parent types (are displayed).
+  Similar for callers.
+* `<CR>`: Jump to the symbol currently selected.
+* `<Down>`, `<C-n>`, `<C-j>`, `j`: Select the next item
+* `<Up>`, `<C-p>`, `<C-k>`, `k`; Select the previous item
+* Any other key: closes the popup without jumping to any location
+
+**Note:** you might think the call hierarchy tree is inverted, but we think
+this way round is more intuitive because this is the typical way that call
+stacks are displayed (with the current function at the top, and its callers
+below). 
+
 Commands
 --------
 
@@ -2101,6 +2159,9 @@ Provides a list of symbols in the current document, in the quickfix list. See al
 Supported in filetypes: `c, cpp, objc, objcpp, cuda, go, java, rust`
 
 #### The `GoToCallers` and `GoToCallees` subcommands
+
+Note: A much more powerful call and type hierarchy can be viewd interactively.
+See [interactive type and call hierarchy](#interactive-type-and-call-hierarchy).
 
 Populate the quickfix list with the callers, or callees respectively, of the
 function associated with the current cursor position. The semantics of this
@@ -3738,9 +3799,7 @@ let g:ycm_language_server = []
 ### The `g:ycm_disable_signature_help` option
 
 This option allows you to disable all signature help for all completion engines.
-There is no way to disable it per-completer. This option is _reserved_, meaning
-that while signature help support remains experimental, its values and meaning
-may change and it may be removed in a future version.
+There is no way to disable it per-completer.
 
 Default: `0`
 

--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ Quick Feature Summary
 * Type information for identifiers (`GetType`)
 * Code formatting (`Format`)
 * Management of `gopls` server instance
+* Inlay hints
 * Call hierarchy
 
 ### JavaScript and TypeScript
@@ -745,6 +746,7 @@ Quick Feature Summary
 * Organize imports (`OrganizeImports`)
 * Management of `TSServer` server instance
 * Inlay hints
+* Call hierarchy
 
 ### Rust
 
@@ -787,6 +789,7 @@ Quick Feature Summary
 * Execute custom server command (`ExecuteCommand <args>`)
 * Management of `jdt.ls` server instance
 * Semantic highlighting
+* Inlay hints
 * Type hierarchy
 * Call hierarchy
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1763,6 +1763,11 @@ endfunction
 silent! nnoremap <silent> <plug>(YCMToggleInlayHints)
       \ <cmd>call <SID>ToggleInlayHints()<CR>
 
+silent! nnoremap <silent> <plug>(YCMTypeHierarchy)
+      \ <cmd>call youcompleteme#hierarchy#StartRequest( 'type' )
+silent! nnoremap <silent> <plug>(YCMCallHierarchy)
+      \ <cmd>call youcompleteme#hierarchy#StartRequest( 'call' )
+
 " This is basic vim plugin boilerplate
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1764,9 +1764,9 @@ silent! nnoremap <silent> <plug>(YCMToggleInlayHints)
       \ <cmd>call <SID>ToggleInlayHints()<CR>
 
 silent! nnoremap <silent> <plug>(YCMTypeHierarchy)
-      \ <cmd>call youcompleteme#hierarchy#StartRequest( 'type' )
+      \ <cmd>call youcompleteme#hierarchy#StartRequest( 'type' )<cr>
 silent! nnoremap <silent> <plug>(YCMCallHierarchy)
-      \ <cmd>call youcompleteme#hierarchy#StartRequest( 'call' )
+      \ <cmd>call youcompleteme#hierarchy#StartRequest( 'call' )<cr>
 
 " This is basic vim plugin boilerplate
 let &cpo = s:save_cpo

--- a/autoload/youcompleteme/finder.vim
+++ b/autoload/youcompleteme/finder.vim
@@ -113,35 +113,6 @@ scriptencoding utf-8
 " The other functions are utility for the most part and handle things like
 " TextChangedI event, starting/stopping drawing the spinner and such.
 
-let s:highlight_group_for_symbol_kind = {
-      \ 'Array': 'Identifier',
-      \ 'Boolean': 'Boolean',
-      \ 'Class': 'Structure',
-      \ 'Constant': 'Constant',
-      \ 'Constructor': 'Function',
-      \ 'Enum': 'Structure',
-      \ 'EnumMember': 'Identifier',
-      \ 'Event': 'Identifier',
-      \ 'Field': 'Identifier',
-      \ 'Function': 'Function',
-      \ 'Interface': 'Structure',
-      \ 'Key': 'Identifier',
-      \ 'Method': 'Function',
-      \ 'Module': 'Include',
-      \ 'Namespace': 'Type',
-      \ 'Null': 'Keyword',
-      \ 'Number': 'Number',
-      \ 'Object': 'Structure',
-      \ 'Operator': 'Operator',
-      \ 'Package': 'Include',
-      \ 'Property': 'Identifier',
-      \ 'String': 'String',
-      \ 'Struct': 'Structure',
-      \ 'TypeParameter': 'Typedef',
-      \ 'Variable': 'Identifier',
-      \ }
-let s:initialized_text_properties = v:false
-
 let s:icon_spinner = [ '/', '-', '\', '|', '/', '-', '\', '|' ]
 let s:icon_done = 'X'
 let s:spinner_delay = 100
@@ -156,18 +127,7 @@ function! youcompleteme#finder#FindSymbol( scope ) abort
     return
   endif
 
-  if !s:initialized_text_properties
-    call prop_type_add( 'YCM-symbol-Normal', { 'highlight': 'Normal' } )
-    for k in keys( s:highlight_group_for_symbol_kind )
-      call prop_type_add(
-            \ 'YCM-symbol-' . k,
-            \ { 'highlight': s:highlight_group_for_symbol_kind[ k ] } )
-    endfor
-    call prop_type_add( 'YCM-symbol-file', { 'highlight': 'Comment' } )
-    call prop_type_add( 'YCM-symbol-filetype', { 'highlight': 'Special' } )
-    call prop_type_add( 'YCM-symbol-line-num', { 'highlight': 'Number' } )
-    let s:initialized_text_properties = v:true
-  endif
+  call youcompleteme#symbol#InitSymbolProperties()
 
   let s:find_symbol_status = {
         \ 'selected': -1,
@@ -470,11 +430,7 @@ function! s:RedrawFinderPopup() abort
         let kind = result[ 'extra_data' ][ 'kind' ]
         let name = result[ 'extra_data' ][ 'name' ]
         let desc = kind .. ': ' .. name
-        if s:highlight_group_for_symbol_kind->has_key( kind )
-          let prop = 'YCM-symbol-' . kind
-        else
-          let prop = 'YCM-symbol-Normal'
-        endif
+        let prop = youcompleteme#symbol#GetPropForSymbolKind( kind )
         let props = [
             \ { 'col': 1,
             \   'length': len( kind ) + 2,

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -144,7 +144,7 @@ function! s:SetUpMenu()
     \   border: [],
     \ }
   if &ambiwidth ==# 'single' && &encoding ==? 'utf-8'
-    let opts[ 'borderchars' ] = [ '─', '│', '─', '│', '╭', '╮', '┛', '╰' ]
+    let opts[ 'borderchars' ] = [ '─', '│', '─', '│', '╭', '╮', '╯', '╰' ]
   endif
 
   let s:popup_id = popup_create( [], opts )

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -64,7 +64,7 @@ endfunction
 function! s:MenuFilter( winid, key )
   if a:key == "\<S-Tab>"
     " Root changes if we're showing super-tree of a sub-tree of the root
-    " (indeicated by the handle being positive)
+    " (indicated by the handle being positive)
     let will_change_root = s:lines_and_handles[ s:select - 1 ][ 1 ] > 0
     call popup_close(
           \ s:popup_id,
@@ -73,7 +73,7 @@ function! s:MenuFilter( winid, key )
   endif
   if a:key == "\<Tab>"
     " Root changes if we're showing sub-tree of a super-tree of the root
-    " (indeicated by the handle being negative)
+    " (indicated by the handle being negative)
     let will_change_root = s:lines_and_handles[ s:select - 1 ][ 1 ] < 0
     call popup_close(
           \ s:popup_id,

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -157,6 +157,9 @@ function! s:SetUpMenu()
           \ .. item.icon
           \ .. item.kind
           \ .. ': ' .. item.symbol
+    " -2 because:
+    "   0-based index
+    "   1 for the tab character
     let trunc_name = name[ : tabstop - 2 ]
     let props = []
     let name_pfx_len = len( indent ) + len( item.icon ) + len( item.kind ) + 2
@@ -193,7 +196,6 @@ function! s:SetUpMenu()
 
     let trunc_desc = item.description[ : tabstop - 2 ]
 
-    " TODO: Explain (understand) why it's -2 not -1 for the space (padding?)
     let line = trunc_name
           \ . "\t"
           \ .. trunc_path

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -22,7 +22,7 @@ set cpoptions&vim
 scriptencoding utf-8
 
 let s:popup_id = -1
-let s:lines_and_handles = v:none
+let s:lines_and_handles = v:null
 " 1-based index of the selected item in the popup
 " -1 means none set
 "  0 means nothing, (Invalid)
@@ -35,6 +35,11 @@ let s:ingored_keys = [
       \ ]
 
 function! youcompleteme#hierarchy#StartRequest( kind )
+  if !py3eval( 'vimsupport.VimSupportsPopupWindows()' )
+    echo 'Sorry, this feature is not supported in your editor'
+    return
+  endif
+
   call youcompleteme#symbol#InitSymbolProperties()
   py3 ycm_state.ResetCurrentHierarchy()
   if a:kind == 'call'

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -1,0 +1,109 @@
+" Copyright (C) 2021 YouCompleteMe contributors
+"
+" This file is part of YouCompleteMe.
+"
+" YouCompleteMe is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" YouCompleteMe is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+" This is basic vim plugin boilerplate
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+scriptencoding utf-8
+
+let s:popup_id = -1
+let s:lines_and_handles = v:none
+let s:select = -1
+let s:kind = ''
+let s:direction = ''
+
+function! youcompleteme#hierarchy#StartRequest( kind, direction )
+  py3 ycm_state.ResetCurrentHierarchy()
+  if a:kind == 'call'
+    let lines_and_handles = py3eval( 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequest( [ "CallHierarchy", vim.eval( "a:direction" ) ], "", False, 0, 0 ), vim.eval( "a:kind" ), vim.eval( "a:direction" ) )' )
+  else
+    let lines_and_handles = py3eval( 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequest( [ "TypeHierarchy", vim.eval( "a:direction" ) ], "", False, 0, 0 ), vim.eval( "a:kind" ), vim.eval( "a:direction" ) )' )
+  endif
+  if len( lines_and_handles )
+    let s:lines_and_handles = lines_and_handles
+    let s:kind = a:kind
+    let s:direction = a:direction
+    let s:select = 1
+    call s:SetupMenu()
+  endif
+endfunction
+
+function! s:MenuFilter( winid, key )
+  if a:key == "\<Tab>"
+    call popup_close( s:popup_id, [ s:select - 1, 'resolve' ] )
+    return 1
+  endif
+  if a:key == "\<Esc>"
+    call popup_close( s:popup_id, [ s:select - 1, 'cancel' ] )
+    return 1
+  endif
+  if a:key == "\<CR>"
+    call popup_close( s:popup_id, [ s:select - 1, 'jump' ] )
+    return 1
+  endif
+  if a:key == "\<Up>"
+    let s:select -= 1
+    if s:select < 1
+      let s:select = 1
+    endif
+    call win_execute( s:popup_id, 'call cursor( [' . string( s:select ) . ', 1 ] )' )
+    return 1
+  endif
+  if a:key == "\<Down>"
+    let s:select += 1
+    if s:select > len( s:lines_and_handles )
+      let s:select = len( s:lines_and_handles )
+    endif
+    call win_execute( s:popup_id, 'call cursor( [' . string( s:select ) . ', 1 ] )' )
+    return 1
+  endif
+  return 0
+endfunction
+
+function! s:MenuCallback( winid, result )
+  let operation = result[ 1 ]
+  if operation == 'resolve'
+    call s:ResolveItem( a:result )
+  else
+    if operation == 'jump'
+      let handle = s:lines_and_handles[ a:result ][ 1 ]
+      py3 ycm_state.JumpToHierarchyItem( vimsupport.GetIntValue( "handle" ) )
+    endif
+    py3 ycm_state.ResetCurrentHierarchy()
+    let s:kind = ''
+    let s:direction = ''
+    let s:select = 1
+  endif
+endfunction
+
+function! s:SetupMenu()
+  let menu_lines = []
+  for line_and_item in s:lines_and_handles
+    call add( menu_lines, line_and_item[ 0 ] )
+  endfor
+  let s:popup_id = popup_menu( menu_lines, #{ filter: funcref( 's:MenuFilter' ), callback: funcref( 's:MenuCallback' ) } )
+  call win_execute( s:popup_id, 'call cursor( [' . string( s:select ) . ', 1 ] )' )
+endfunction
+
+function! s:ResolveItem( choice )
+  let handle = s:lines_and_handles[ a:choice ][ 1 ]
+  if py3eval( 'ycm_state.ItemNeedsResolving( vimsupport.GetIntValue( "handle" ) )' )
+    let s:lines_and_handles = py3eval( 'ycm_state.UpdateCurrentHierarchy( vimsupport.GetIntValue( "handle" ) )' )
+  endif
+  call s:SetupMenu()
+endfunction

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -233,8 +233,15 @@ function! s:ResolveItem( choice, direction, will_change_root )
       " where we _don't_ re-root the tree, so feels more natural than anything
       " else.
       " The new root is the element with indent of 0.
-      let s:select = 1 + indexof( s:lines_and_handles,
-            \                     { i, v -> v[0].indent == 0 } )
+      " let s:select = 1 + indexof( s:lines_and_handles,
+      "       \                     { i, v -> v[0].indent == 0 } )
+      let s:select = 1
+      for item in s:lines_and_handles
+        if item[0].indent == 0
+          break
+        endif
+        let s:select += 1
+      endfor
     else
       let s:select += lines_and_handles_with_offset[ 1 ]
     endif

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -26,6 +26,11 @@ let s:lines_and_handles = v:none
 let s:select = -1
 let s:kind = ''
 
+let s:ingored_keys = [
+      \ "\<CursorHold>",
+      \ "\<MouseMove>",
+      \ ]
+
 function! youcompleteme#hierarchy#StartRequest( kind )
   py3 ycm_state.ResetCurrentHierarchy()
   if a:kind == 'call'
@@ -43,30 +48,30 @@ function! youcompleteme#hierarchy#StartRequest( kind )
     let s:lines_and_handles = lines_and_handles
     let s:kind = a:kind
     let s:select = 1
-    call s:SetupMenu()
+    call s:SetUpMenu()
   endif
 endfunction
 
 function! s:MenuFilter( winid, key )
   if a:key == "\<S-Tab>"
     let will_change_root = s:lines_and_handles[ s:select - 1 ][ 1 ] > 0
-    call popup_close( s:popup_id, [ s:select - 1, 'resolve_up', will_change_root ] )
+    call popup_close(
+          \ s:popup_id,
+          \ [ s:select - 1, 'resolve_up', will_change_root ] )
     return 1
   endif
   if a:key == "\<Tab>"
     let will_change_root = s:lines_and_handles[ s:select - 1 ][ 1 ] < 0
-    call popup_close( s:popup_id, [ s:select - 1, 'resolve_down', will_change_root ] )
-    return 1
-  endif
-  if a:key == "\<Esc>"
-    call popup_close( s:popup_id, [ s:select - 1, 'cancel', v:none ] )
+    call popup_close(
+          \ s:popup_id,
+          \ [ s:select - 1, 'resolve_down', will_change_root ] )
     return 1
   endif
   if a:key == "\<CR>"
     call popup_close( s:popup_id, [ s:select - 1, 'jump', v:none ] )
     return 1
   endif
-  if a:key == "\<Up>"
+  if a:key == "\<Up>" || a:key == "\<C-p>" || a:key == "\<C-k>" || a:key == "k"
     let s:select -= 1
     if s:select < 1
       let s:select = 1
@@ -75,13 +80,21 @@ function! s:MenuFilter( winid, key )
                     \ 'call cursor( [' . string( s:select ) . ', 1 ] )' )
     return 1
   endif
-  if a:key == "\<Down>"
+  if a:key == "\<Down>" || a:key == "\<C-n>" || a:key == "\<C-j>" || a:key == "j"
     let s:select += 1
     if s:select > len( s:lines_and_handles )
       let s:select = len( s:lines_and_handles )
     endif
     call win_execute( s:popup_id,
                     \ 'call cursor( [' . string( s:select ) . ', 1 ] )' )
+    return 1
+  endif
+  if index( s:ingored_keys, a:key ) >= 0
+    return 0
+  endif
+  " Close the popup on any other key press
+  call popup_close( s:popup_id, [ s:select - 1, 'cancel', v:none ] )
+  if a:key == "\<Esc>" || a:key == "\<C-c>"
     return 1
   endif
   return 0
@@ -105,14 +118,15 @@ function! s:MenuCallback( winid, result )
   endif
 endfunction
 
-function! s:SetupMenu()
+function! s:SetUpMenu()
   let menu_lines = []
   for line_and_item in s:lines_and_handles
     call add( menu_lines, line_and_item[ 0 ] )
   endfor
   let s:popup_id = popup_menu( menu_lines, #{
-    \ filter: funcref( 's:MenuFilter' ),
-    \ callback: funcref( 's:MenuCallback' ) } )
+    \   filter: funcref( 's:MenuFilter' ),
+    \   callback: funcref( 's:MenuCallback' )
+    \ } )
   call win_execute( s:popup_id,
                   \ 'call cursor( [' . string( s:select ) . ', 1 ] )' )
 endfunction
@@ -127,10 +141,11 @@ function! s:ResolveItem( choice, direction, will_change_root )
         \ 'vim.eval( "a:direction" ) )' )
     let s:lines_and_handles = lines_and_handles_with_offset[ 0 ]
     if a:will_change_root
-      let s:select = 1 + indexof( s:lines_and_handles, { i, v -> v[0][0] =~ "[-+]" } )
+      let s:select = 1 + indexof( s:lines_and_handles,
+            \                     { i, v -> v[0][0] =~ "[-+]" } )
     else
       let s:select += lines_and_handles_with_offset[ 1 ]
     endif
   endif
-  call s:SetupMenu()
+  call s:SetUpMenu()
 endfunction

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -44,13 +44,13 @@ function! youcompleteme#hierarchy#StartRequest( kind )
   py3 ycm_state.ResetCurrentHierarchy()
   if a:kind == 'call'
     let lines_and_handles = py3eval(
-      \ 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequest( ' .
-      \ '[ "CallHierarchy" ], "", False, 0, 0 ), ' .
+      \ 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequestAsync( ' .
+      \ '[ "CallHierarchy" ] ), ' .
       \ 'vim.eval( "a:kind" ) )' )
   else
     let lines_and_handles = py3eval( 
-      \ 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequest( ' .
-      \ '[ "TypeHierarchy" ], "", False, 0, 0 ), ' .
+      \ 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequestAsync( ' .
+      \ '[ "TypeHierarchy" ] ), ' .
       \ 'vim.eval( "a:kind" ) )' )
   endif
   if len( lines_and_handles )
@@ -63,7 +63,7 @@ endfunction
 
 function! s:MenuFilter( winid, key )
   if a:key == "\<S-Tab>"
-    " ROot changes if we're showing super-tree of a sub-tree of the root
+    " Root changes if we're showing super-tree of a sub-tree of the root
     " (indeicated by the handle being positive)
     let will_change_root = s:lines_and_handles[ s:select - 1 ][ 1 ] > 0
     call popup_close(

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -42,15 +42,16 @@ function! youcompleteme#hierarchy#StartRequest( kind )
 
   call youcompleteme#symbol#InitSymbolProperties()
   py3 ycm_state.ResetCurrentHierarchy()
+  py3 from ycm.client.command_request import GetRawCommandResponse
   if a:kind == 'call'
     let lines_and_handles = py3eval(
-      \ 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequestAsync( ' .
-      \ '[ "CallHierarchy" ] ), ' .
+      \ 'ycm_state.InitializeCurrentHierarchy( GetRawCommandResponse( ' .
+      \ '[ "CallHierarchy" ], False ), ' .
       \ 'vim.eval( "a:kind" ) )' )
   else
     let lines_and_handles = py3eval( 
-      \ 'ycm_state.InitializeCurrentHierarchy( ycm_state.SendCommandRequestAsync( ' .
-      \ '[ "TypeHierarchy" ] ), ' .
+      \ 'ycm_state.InitializeCurrentHierarchy( GetRawCommandResponse( ' .
+      \ '[ "TypeHierarchy" ], False ), ' .
       \ 'vim.eval( "a:kind" ) )' )
   endif
   if len( lines_and_handles )

--- a/autoload/youcompleteme/symbol.vim
+++ b/autoload/youcompleteme/symbol.vim
@@ -1,0 +1,71 @@
+" Copyright (C) 2024 YouCompleteMe contributors
+"
+" This file is part of YouCompleteMe.
+"
+" YouCompleteMe is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" YouCompleteMe is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+
+let s:highlight_group_for_symbol_kind = {
+      \ 'Array': 'Identifier',
+      \ 'Boolean': 'Boolean',
+      \ 'Class': 'Structure',
+      \ 'Constant': 'Constant',
+      \ 'Constructor': 'Function',
+      \ 'Enum': 'Structure',
+      \ 'EnumMember': 'Identifier',
+      \ 'Event': 'Identifier',
+      \ 'Field': 'Identifier',
+      \ 'Function': 'Function',
+      \ 'Interface': 'Structure',
+      \ 'Key': 'Identifier',
+      \ 'Method': 'Function',
+      \ 'Module': 'Include',
+      \ 'Namespace': 'Type',
+      \ 'Null': 'Keyword',
+      \ 'Number': 'Number',
+      \ 'Object': 'Structure',
+      \ 'Operator': 'Operator',
+      \ 'Package': 'Include',
+      \ 'Property': 'Identifier',
+      \ 'String': 'String',
+      \ 'Struct': 'Structure',
+      \ 'TypeParameter': 'Typedef',
+      \ 'Variable': 'Identifier',
+      \ }
+let s:initialized_text_properties = v:false
+
+function! youcompleteme#symbol#InitSymbolProperties() abort
+  if !s:initialized_text_properties
+    call prop_type_add( 'YCM-symbol-Normal', { 'highlight': 'Normal' } )
+    for k in keys( s:highlight_group_for_symbol_kind )
+      call prop_type_add(
+            \ 'YCM-symbol-' . k,
+            \ { 'highlight': s:highlight_group_for_symbol_kind[ k ] } )
+    endfor
+    call prop_type_add( 'YCM-symbol-file', { 'highlight': 'Comment' } )
+    call prop_type_add( 'YCM-symbol-filetype', { 'highlight': 'Special' } )
+    call prop_type_add( 'YCM-symbol-line-num', { 'highlight': 'Number' } )
+    let s:initialized_text_properties = v:true
+  endif
+endfunction
+
+function! youcompleteme#symbol#GetPropForSymbolKind( kind ) abort
+  if s:highlight_group_for_symbol_kind->has_key( a:kind )
+    return 'YCM-symbol-' . a:kind
+  endif
+
+  return 'YCM-symbol-Normal'
+endfunction
+
+

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -308,6 +308,7 @@ def _BuildUri( handler ):
 
 
 def MakeServerException( data ):
+  _logger.debug( 'Server exception: %s', data )
   if data[ 'exception' ][ 'TYPE' ] == UnknownExtraConf.__name__:
     return UnknownExtraConf( data[ 'exception' ][ 'extra_conf_file' ] )
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -252,9 +252,11 @@ def BuildRequestData( buffer_number = None ):
 def BuildRequestDataForLocation( location ):
   file, line, column = location
   current_buffer = vim.current.buffer
-  current_filepath = vimsupport.GetBufferFilepath( current_buffer )
-  file_data = vimsupport.GetUnsavedAndSpecifiedBufferData( current_buffer,
-                                                           current_filepath )
+  vim.command( f'badd {file }' )
+  vim.eval( f'bufload( "{ file }" )' )
+  buffer_number = vimsupport.GetBufferNumberForFilename( file )
+  buffer = vim.buffers[ buffer_number ]
+  file_data = vimsupport.GetUnsavedAndSpecifiedBufferData( buffer, file )
   return {
     'filepath': file,
     'line_num': line,

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -249,16 +249,15 @@ def BuildRequestData( buffer_number = None ):
   }
 
 
-def BuildRequestDataForLocation( location ):
-  file, line, column = location
-  if file not in vim.buffers:
-    vim.command( f'badd { file }' )
+def BuildRequestDataForLocation( file : str, line : int, column : int ):
+  buffer_number = vimsupport.GetBufferNumberForFilename(
+      file,
+      create_buffer_if_needed = True )
   try:
     vim.eval( f'bufload( "{ file }" )' )
   except vim.error as e:
     if 'E325' not in str( e ):
       raise
-  buffer_number = vimsupport.GetBufferNumberForFilename( file )
   buffer = vim.buffers[ buffer_number ]
   file_data = vimsupport.GetUnsavedAndSpecifiedBufferData( buffer, file )
   return {

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -251,9 +251,13 @@ def BuildRequestData( buffer_number = None ):
 
 def BuildRequestDataForLocation( location ):
   file, line, column = location
-  current_buffer = vim.current.buffer
-  vim.command( f'badd {file }' )
-  vim.eval( f'bufload( "{ file }" )' )
+  if file not in vim.buffers:
+    vim.command( f'badd { file }' )
+  try:
+    vim.eval( f'bufload( "{ file }" )' )
+  except vim.error as e:
+    if 'E325' not in str( e ):
+      raise
   buffer_number = vimsupport.GetBufferNumberForFilename( file )
   buffer = vim.buffers[ buffer_number ]
   file_data = vimsupport.GetUnsavedAndSpecifiedBufferData( buffer, file )

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -167,7 +167,7 @@ class BaseRequest:
       else:
         headers = BaseRequest._ExtraHeaders( method, request_uri )
         if payload:
-          request_uri += ToBytes( f'?{urlencode( payload )}' )
+          request_uri += ToBytes( f'?{ urlencode( payload ) }' )
 
         _logger.debug( 'GET %s (%s)\n%s', request_uri, payload, headers )
       return urlopen(
@@ -246,6 +246,21 @@ def BuildRequestData( buffer_number = None ):
     'working_dir': working_dir,
     'file_data': vimsupport.GetUnsavedAndSpecifiedBufferData( current_buffer,
                                                               current_filepath )
+  }
+
+
+def BuildRequestDataForLocation( location ):
+  file, line, column = location
+  current_buffer = vim.current.buffer
+  current_filepath = vimsupport.GetBufferFilepath( current_buffer )
+  file_data = vimsupport.GetUnsavedAndSpecifiedBufferData( current_buffer,
+                                                           current_filepath )
+  return {
+    'filepath': file,
+    'line_num': line,
+    'column_num': column,
+    'working_dir': GetCurrentDirectory(),
+    'file_data': file_data
   }
 
 

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -49,7 +49,7 @@ class CommandRequest( BaseRequest ):
 
   def Start( self ):
     if self._location is not None:
-      self._request_data = BuildRequestDataForLocation( self._location )
+      self._request_data = BuildRequestDataForLocation( *self._location )
     elif self._bufnr is not None:
       self._request_data = BuildRequestData( self._bufnr )
     else:

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -248,3 +248,11 @@ def GetCommandResponse( arguments, extra_data = None ):
                                      silent = True )
   # Block here to get the response
   return request.StringResponse()
+
+
+def GetRawCommandResponse( arguments, silent, location = None ):
+  request = SendCommandRequestAsync( arguments,
+                                     extra_data = None,
+                                     silent = silent,
+                                     location = location )
+  return request.Response()

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -218,12 +218,14 @@ def SendCommandRequestAsync( arguments, extra_data = None, silent = True ):
 def SendCommandRequest( arguments,
                         modifiers,
                         buffer_command = DEFAULT_BUFFER_COMMAND,
-                        extra_data = None ):
+                        extra_data = None,
+                        skip_post_command_action = False ):
   request = SendCommandRequestAsync( arguments,
                                      extra_data = extra_data,
                                      silent = False )
   # Block here to get the response
-  request.RunPostCommandActionsIfNeeded( modifiers, buffer_command )
+  if not skip_post_command_action:
+    request.RunPostCommandActionsIfNeeded( modifiers, buffer_command )
   return request.Response()
 
 

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -15,7 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-from ycm.client.base_request import BaseRequest, BuildRequestData
+from ycm.client.base_request import ( BaseRequest,
+                                      BuildRequestData,
+                                      BuildRequestDataForLocation )
 from ycm import vimsupport
 
 DEFAULT_BUFFER_COMMAND = 'same-buffer'
@@ -28,7 +30,11 @@ def _EnsureBackwardsCompatibility( arguments ):
 
 
 class CommandRequest( BaseRequest ):
-  def __init__( self, arguments, extra_data = None, silent = False ):
+  def __init__( self,
+                arguments,
+                extra_data = None,
+                silent = False,
+                location = None ):
     super( CommandRequest, self ).__init__()
     self._arguments = _EnsureBackwardsCompatibility( arguments )
     self._command = arguments and arguments[ 0 ]
@@ -38,10 +44,13 @@ class CommandRequest( BaseRequest ):
     self._response_future = None
     self._silent = silent
     self._bufnr = extra_data.pop( 'bufnr', None ) if extra_data else None
+    self._location = location
 
 
   def Start( self ):
-    if self._bufnr is not None:
+    if self._location is not None:
+      self._request_data = BuildRequestDataForLocation( self._location )
+    elif self._bufnr is not None:
       self._request_data = BuildRequestData( self._bufnr )
     else:
       self._request_data = BuildRequestData()
@@ -206,10 +215,14 @@ class CommandRequest( BaseRequest ):
                                      modifiers )
 
 
-def SendCommandRequestAsync( arguments, extra_data = None, silent = True ):
+def SendCommandRequestAsync( arguments,
+                             extra_data = None,
+                             silent = True,
+                             location = None ):
   request = CommandRequest( arguments,
                             extra_data = extra_data,
-                            silent = silent )
+                            silent = silent,
+                            location = location )
   request.Start()
   # Don't block
   return request

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -22,7 +22,7 @@ import os
 
 class HierarchyNode:
   def __init__( self, data, distance : int ):
-    self._references : Optional[List[int]] = None
+    self._references : Optional[ List[ int ] ] = None
     self._data = data
     self._distance_from_root = distance
 
@@ -38,8 +38,8 @@ class HierarchyNode:
 
 class HierarchyTree:
   def __init__( self ):
-    self._up_nodes : List[HierarchyNode] = []
-    self._down_nodes : List[HierarchyNode] = []
+    self._up_nodes : List[ HierarchyNode ] = []
+    self._down_nodes : List[ HierarchyNode ] = []
     self._kind : str = ''
 
   def SetRootNode( self, items, kind : str ):

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -69,27 +69,16 @@ class HierarchyTree:
 
   def UpdateHierarchy( self, handle : int, items, direction : str ):
     current_index = handle_to_index( handle )
-    if ( ( handle >= 0 and direction == 'down' ) or
-         ( handle <= 0 and direction == 'up' ) ):
-      nodes = self._down_nodes if direction == 'down' else self._up_nodes
-      if items:
-        nodes.extend( [
-          HierarchyNode( item,
-                         nodes[ current_index ]._distance_from_root + 1 )
-          for item in items ] )
-        nodes[ current_index ]._references = list(
-            range( len( nodes ) - len( items ), len( nodes ) ) )
-      else:
-        nodes[ current_index ]._references = []
+    nodes = self._down_nodes if direction == 'down' else self._up_nodes
+    if items:
+      nodes.extend( [
+        HierarchyNode( item,
+                       nodes[ current_index ]._distance_from_root + 1 )
+        for item in items ] )
+      nodes[ current_index ]._references = list(
+          range( len( nodes ) - len( items ), len( nodes ) ) )
     else:
-      if direction == 'up':
-        current_node = self._down_nodes[ current_index ]
-      else:
-        current_node = self._up_nodes[ current_index ]
-      old_kind = self._kind
-      self.Reset()
-      self.SetRootNode( [ current_node._data ], old_kind )
-      self.UpdateHierarchy( 0, items, direction )
+      nodes[ current_index ]._references = []
 
 
   def Reset( self ):
@@ -195,3 +184,20 @@ class HierarchyTree:
       node._data,
       direction
     ]
+
+
+  def HandleToLocation( self, handle : int ):
+    node_index = handle_to_index( handle )
+
+    if handle >= 0:
+      node = self._down_nodes[ node_index ]
+    else:
+      node = self._up_nodes[ node_index ]
+
+    location_index = handle_to_location_index( handle )
+    return node.ToLocation( location_index )
+
+
+  def UpdateChangesRoot( self, handle : int, direction : str ):
+    return ( ( handle < 0 and direction == 'down' ) or
+             ( handle > 0 and direction == 'up'   ) )

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -37,14 +37,18 @@ class HierarchyNode:
 
 MAX_HANDLES_PER_INDEX = 1000000
 
+
 def handle_to_index( handle : int ):
   return abs( handle ) // MAX_HANDLES_PER_INDEX
+
 
 def handle_to_location_index( handle : int ):
   return abs( handle ) % MAX_HANDLES_PER_INDEX
 
+
 def make_handle( index : int, location_index : int ):
   return index * MAX_HANDLES_PER_INDEX + location_index
+
 
 class HierarchyTree:
   def __init__( self ):

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -114,8 +114,10 @@ class HierarchyTree:
             {
               'indent': indent,
               'icon': symbol,
-              'symbol': kind + ': ' + name,
-              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'symbol': name,
+              'kind': kind,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
+              'line_num': str( l[ 'line_num' ] ),
               'description': l.get( 'description', '' ),
             },
             make_handle( index, location_index )
@@ -128,8 +130,10 @@ class HierarchyTree:
             {
               'indent': indent,
               'icon': symbol,
-              'symbol': kind + ': ' + name,
-              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'symbol': name,
+              'kind': kind,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
+              'line_num': str( l[ 'line_num' ] ),
               'description': l.get( 'description', '' ),
             },
             make_handle( index, location_index ) * -1

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -27,6 +27,16 @@ class HierarchyNode:
     self._distance_from_root = distance
 
 
+  def ToRootLocation( self, subindex : int ):
+    if location := self._data.get( 'root_location' ):
+      file = location[ 'filepath' ]
+      line = location[ 'line_num' ]
+      column = location[ 'column_num' ]
+      return file, line, column
+    else:
+      return self.ToLocation( subindex )
+
+
   def ToLocation( self, subindex : int ):
     location = self._data[ 'locations' ][ subindex ]
     line = location[ 'line_num' ]
@@ -186,7 +196,7 @@ class HierarchyTree:
     ]
 
 
-  def HandleToLocation( self, handle : int ):
+  def HandleToRootLocation( self, handle : int ):
     node_index = handle_to_index( handle )
 
     if handle >= 0:
@@ -195,7 +205,7 @@ class HierarchyTree:
       node = self._up_nodes[ node_index ]
 
     location_index = handle_to_location_index( handle )
-    return node.ToLocation( location_index )
+    return node.ToRootLocation( location_index )
 
 
   def UpdateChangesRoot( self, handle : int, direction : str ):

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -102,14 +102,14 @@ class HierarchyTree:
         partial_result.extend( [
           ( ' ' * indent + symbol + kind + ': ' + name + 3 * '\t' +
               os.path.split( l[ 'filepath' ] )[ 1 ] + ':' +
-              str( l[ 'line_num' ] ) + 3 * '\t' + l[ 'description' ],
+              str( l[ 'line_num' ] ) + 3 * '\t' + l.get( 'description', '' ),
             ( i * 1000000 + j ) )
           for j, l in enumerate( next_node._data[ 'locations' ] ) ] )
       else:
         partial_result.extend( [
           ( ' ' * indent + symbol + kind + ': ' + name + 3 * '\t' +
               os.path.split( l[ 'filepath' ] )[ 1 ] + ':' +
-              str( l[ 'line_num' ] ) + 3 * '\t' + l[ 'description' ],
+              str( l[ 'line_num' ] ) + 3 * '\t' + l.get( 'description', '' ),
             ( i * 1000000 + j ) * -1 )
           for j, l in enumerate( next_node._data[ 'locations' ] ) ] )
       if next_node._references:

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -118,7 +118,7 @@ class HierarchyTree:
               'kind': kind,
               'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
               'line_num': str( l[ 'line_num' ] ),
-              'description': l.get( 'description', '' ),
+              'description': l.get( 'description', '' ).strip(),
             },
             make_handle( index, location_index )
           )
@@ -134,7 +134,7 @@ class HierarchyTree:
               'kind': kind,
               'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
               'line_num': str( l[ 'line_num' ] ),
-              'description': l.get( 'description', '' ),
+              'description': l.get( 'description', '' ).strip(),
             },
             make_handle( index, location_index ) * -1
           )

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -210,4 +210,4 @@ class HierarchyTree:
 
   def UpdateChangesRoot( self, handle : int, direction : str ):
     return ( ( handle < 0 and direction == 'down' ) or
-             ( handle > 0 and direction == 'up'   ) )
+             ( handle > 0 and direction == 'up' ) )

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -100,18 +100,32 @@ class HierarchyTree:
       kind = next_node._data[ 'kind' ]
       if use_down_nodes:
         partial_result.extend( [
-          ( ' ' * indent + symbol + kind + ': ' + name + 3 * '\t' +
-              os.path.split( l[ 'filepath' ] )[ 1 ] + ':' +
-              str( l[ 'line_num' ] ) + 3 * '\t' + l.get( 'description', '' ),
-            ( i * 1000000 + j ) )
-          for j, l in enumerate( next_node._data[ 'locations' ] ) ] )
+          (
+            {
+              'indent': indent,
+              'icon': symbol,
+              'symbol': kind + ': ' + name,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'description': l.get( 'description', '' ),
+            },
+            i * 1000000 + j
+          )
+          for j, l in enumerate( next_node._data[ 'locations' ] )
+        ] )
       else:
         partial_result.extend( [
-          ( ' ' * indent + symbol + kind + ': ' + name + 3 * '\t' +
-              os.path.split( l[ 'filepath' ] )[ 1 ] + ':' +
-              str( l[ 'line_num' ] ) + 3 * '\t' + l.get( 'description', '' ),
-            ( i * 1000000 + j ) * -1 )
-          for j, l in enumerate( next_node._data[ 'locations' ] ) ] )
+          (
+            {
+              'indent': indent,
+              'icon': symbol,
+              'symbol': kind + ': ' + name,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'description': l.get( 'description', '' ),
+            },
+            ( i * 1000000 + j ) * -1
+          )
+          for j, l in enumerate( next_node._data[ 'locations' ] )
+        ] )
       if next_node._references:
         partial_result.extend(
           self._HierarchyToLinesHelper(

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2011-2024 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional, List
+from ycm import vimsupport
+import os
+
+
+class HierarchyNode:
+  def __init__( self, data, distance : int ):
+    self._references : Optional[List[int]] = None
+    self._data = data
+    self._distance_from_root = distance
+
+
+  def ToLocation( self, subindex : int ):
+    location = self._data[ 'locations' ][ subindex ]
+    line = location[ 'line_num' ]
+    column = location[ 'column_num' ]
+    file = location[ 'filepath' ]
+    return file, line, column
+
+
+
+class HierarchyTree:
+  def __init__( self ):
+    self._nodes : List[HierarchyNode] = []
+    self._kind : str = ''
+    self._direction : str = ''
+
+  def SetRootNode( self, items, kind : str, direction : str ):
+    if items:
+      self._root_node_indices = list( range( 0, len( items ) ) )
+      self._nodes.append( HierarchyNode( items[ 0 ], 0 ) )
+      self._kind = kind
+      self._direction = direction
+      return self.HierarchyToLines( is_root_node = True )
+    return []
+
+
+  def UpdateHierarchy( self, handle : int, items ):
+    current_index = handle // 1000000
+    if items:
+      self._nodes.extend( [
+        HierarchyNode( item,
+                       self._nodes[ current_index ]._distance_from_root + 1 )
+        for item in items ] )
+      self._nodes[ current_index ]._references = list(
+          range( len( self._nodes ) - len( items ),
+                 len( self._nodes ) ) )
+    else:
+      self._nodes[ current_index ]._references = []
+
+
+  def Reset( self ):
+    self._nodes = []
+
+
+  def _HierarchyToLinesHelper( self, refs, is_root_node = False ):
+    partial_result = []
+    for i in refs:
+      next_node = self._nodes[ i ]
+      indent = 2 * next_node._distance_from_root
+      can_expand = next_node._references is None
+      symbol = '+' if can_expand else '-'
+      name = next_node._data[ 'name' ]
+      kind = next_node._data[ 'kind' ]
+      partial_result.extend( [
+        ( ' ' * indent + symbol + kind + ': ' + name + '\t' +
+            os.path.split( l[ 'filepath' ] )[ 1 ] + ':' +
+            str( l[ 'line_num' ] ) + '\t' + l[ 'description' ],
+          i * 1000000 + j )
+        for j, l in enumerate( next_node._data[ 'locations' ] ) ] )
+      if next_node._references:
+        partial_result.extend(
+          self._HierarchyToLinesHelper( next_node._references, is_root_node ) )
+    return partial_result
+
+  def HierarchyToLines( self, is_root_node = False ):
+    lines = []
+    for i in self._root_node_indices:
+      lines.extend( self._HierarchyToLinesHelper( [ i ], is_root_node ) )
+    return lines
+
+
+  def JumpToItem( self, handle : int, command ):
+    node_index = handle // 1000000
+    location_index = handle % 1000000
+    node = self._nodes[ node_index ]
+    file, line, column = node.ToLocation( location_index )
+    vimsupport.JumpToLocation( file, line, column, '', command )
+
+
+  def ShouldResolveItem( self, handle : int ):
+    node_index = handle // 1000000
+    return self._nodes[ node_index ]._references is None
+
+
+  def ResolveArguments( self, handle : int ):
+    node_index = handle // 1000000
+    return [
+      f'Resolve{ self._kind.title() }HierarchyItem',
+      self._nodes[ node_index ]._data,
+      self._direction
+    ]

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -47,7 +47,8 @@ class CommandTest( TestCase ):
               'extra_conf_data': has_entries( {
                 'tempname()': '_TEMP_FILE_'
               } ),
-            } )
+            } ),
+            False
           )
         )
 
@@ -71,7 +72,8 @@ class CommandTest( TestCase ):
                 'tab_size': 2,
                 'insert_spaces': True,
               } )
-            } )
+            } ),
+            False
           )
         )
 
@@ -102,7 +104,8 @@ class CommandTest( TestCase ):
                 'column_num': 12
               }
             }
-          }
+          },
+          False
         )
 
 
@@ -135,7 +138,8 @@ class CommandTest( TestCase ):
                 'column_num': 9
               }
             }
-          }
+          },
+          False
         )
 
 
@@ -153,7 +157,8 @@ class CommandTest( TestCase ):
             'tab_size': 2,
             'insert_spaces': True
           },
-        }
+        },
+        False
       )
 
       with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -48,7 +48,6 @@ class CommandTest( TestCase ):
                 'tempname()': '_TEMP_FILE_'
               } ),
             } ),
-            False
           )
         )
 
@@ -73,7 +72,6 @@ class CommandTest( TestCase ):
                 'insert_spaces': True,
               } )
             } ),
-            False
           )
         )
 
@@ -105,7 +103,6 @@ class CommandTest( TestCase ):
               }
             }
           },
-          False
         )
 
 
@@ -139,7 +136,6 @@ class CommandTest( TestCase ):
               }
             }
           },
-          False
         )
 
 
@@ -158,7 +154,6 @@ class CommandTest( TestCase ):
             'insert_spaces': True
           },
         },
-        False
       )
 
       with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -35,8 +35,8 @@ from ycmd.utils import GetCurrentDirectory, OnMac, OnWindows, ToUnicode
 
 
 BUFNR_REGEX = re.compile(
-  '^bufnr\\(\'(?P<buffer_filename>.+)\'(, ([01]))?\\)$' )
-BUFWINNR_REGEX = re.compile( '^bufwinnr\\((?P<buffer_number>[0-9]+)\\)$' )
+  '^bufnr\\( \'(?P<buffer_filename>.+)\'(, ([01]))? \\)$' )
+BUFWINNR_REGEX = re.compile( '^bufwinnr\\( (?P<buffer_number>[0-9]+) \\)$' )
 BWIPEOUT_REGEX = re.compile(
   '^(?:silent! )bwipeout!? (?P<buffer_number>[0-9]+)$' )
 GETBUFVAR_REGEX = re.compile(

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -152,8 +152,8 @@ def GetUnsavedAndSpecifiedBufferData( included_buffer, included_filepath ):
 def GetBufferNumberForFilename( filename, create_buffer_if_needed = False ):
   realpath = os.path.realpath( filename )
   return MADEUP_FILENAME_TO_BUFFER_NUMBER.get( realpath, GetIntValue(
-      f"bufnr('{ EscapeForVim( realpath ) }', "
-             f"{ int( create_buffer_if_needed ) })" ) )
+      f"bufnr( '{ EscapeForVim( realpath ) }', "
+             f"{ int( create_buffer_if_needed ) } )" ) )
 
 
 def GetCurrentBufferFilepath():
@@ -163,7 +163,7 @@ def GetCurrentBufferFilepath():
 def BufferIsVisible( buffer_number ):
   if buffer_number < 0:
     return False
-  window_number = GetIntValue( f"bufwinnr({ buffer_number })" )
+  window_number = GetIntValue( f"bufwinnr( { buffer_number } )" )
   return window_number != -1
 
 
@@ -259,7 +259,7 @@ def VisibleRangeOfBufferOverlaps( bufnr, expanded_range ):
 
 
 def CaptureVimCommand( command ):
-  return vim.eval( f"execute( '{EscapeForVim(command)}', 'silent!' )" )
+  return vim.eval( f"execute( '{ EscapeForVim( command ) }', 'silent!' )" )
 
 
 def GetSignsInBuffer( buffer_number ):
@@ -345,7 +345,7 @@ def GetTextProperties( buffer_number ):
     else:
       properties = []
       for line_number in range( len( vim.buffers[ buffer_number ] ) ):
-        vim_props =  vim.eval( f'prop_list( {line_number + 1}, '
+        vim_props =  vim.eval( f'prop_list( { line_number + 1 }, '
                                f'{{ "bufnr": { buffer_number } }} )' )
         properties.extend(
           DiagnosticProperty(
@@ -818,9 +818,9 @@ def PresentDialog( message, choices, default_choice_index = 0 ):
       [Y]es, (N)o, May(b)e:"""
   message = EscapeForVim( ToUnicode( message ) )
   choices = EscapeForVim( ToUnicode( '\n'.join( choices ) ) )
-  to_eval = ( f"confirm('{ message }', "
-                      f"'{ choices }', "
-                      f"{ default_choice_index + 1 })" )
+  to_eval = ( f"confirm( '{ message }', "
+                       f"'{ choices }', "
+                       f"{ default_choice_index + 1 } )" )
   try:
     return GetIntValue( to_eval ) - 1
   except KeyboardInterrupt:
@@ -1258,7 +1258,7 @@ def OpenFileInPreviewWindow( filename, modifiers ):
   """ Open the supplied filename in the preview window """
   if modifiers:
     modifiers = ' ' + modifiers
-  vim.command( f'silent!{modifiers} pedit! { filename }' )
+  vim.command( f'silent!{ modifiers } pedit! { filename }' )
 
 
 def WriteToPreviewWindow( message, modifiers ):
@@ -1353,7 +1353,7 @@ def OpenFilename( filename, options = {} ):
 
   # Open the file.
   try:
-    vim.command( f'{ options.get( "mods", "") }'
+    vim.command( f'{ options.get( "mods", "" ) }'
                  f'{ size }'
                  f'{ command } '
                  f'{ filename }' )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -116,26 +116,15 @@ class YouCompleteMe:
     return self._current_hierarchy.SetRootNode( items, kind, direction )
 
 
-  def UpdateCurrentHierarchy( self, handle : int ):
-    items = self.ResolveHierarchyItem( handle )
+  def UpdateCurrentHierarchy( self, handle ):
+    items = self._ResolveHierarchyItem( handle )
     self._current_hierarchy.UpdateHierarchy( handle, items )
     return self._current_hierarchy.HierarchyToLines()
 
 
-  def ResolveHierarchyItem( self, handle : int ):
-    node_data = self._current_hierarchy._nodes[ handle ]._data
-    kind = self._current_hierarchy._kind
-    direction = self._current_hierarchy._direction
-    try:
-      item = node_data[ 'from' ]
-    except KeyError:
-      try:
-        item = node_data[ 'to' ]
-      except KeyError:
-        item = node_data
-
+  def _ResolveHierarchyItem( self, handle ):
     return SendCommandRequest(
-      [ f'Resolve{ kind.title() }HierarchyItem', item, direction ],
+      self._current_hierarchy.ResolveArguments( handle ),
       '',
       self._user_options[ 'goto_buffer_command' ],
       extra_data = None,
@@ -143,21 +132,18 @@ class YouCompleteMe:
     )
 
 
-  def ItemNeedsResolving( self, handle : int ):
-    item = self._current_hierarchy._nodes[ handle ]
-    return item._references is None
+  def ShouldResolveItem( self, handle ):
+    return self._current_hierarchy.ShouldResolveItem( handle )
 
 
   def ResetCurrentHierarchy( self ):
     self._current_hierarchy.Reset()
 
 
-  def JumpToHierarchyItem( self, handle : int ):
-    item = self._current_hierarchy._nodes[ handle ]
-    file, line, column = item.ToLocation()
-    line += 1
-    column += 1
-    vimsupport.JumpToLocation( file, line, column, '', self._user_options[ 'goto_buffer_command' ] )
+  def JumpToHierarchyItem( self, handle ):
+    self._current_hierarchy.JumpToItem(
+        handle,
+        self._user_options[ 'goto_buffer_command' ] )
 
 
   def _SetUpServer( self ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -123,7 +123,7 @@ class YouCompleteMe:
       self._current_hierarchy.UpdateHierarchy( handle, items, direction )
 
       if items is not None and direction == 'up':
-        offset = sum( map( lambda item: len( item[ 'locations' ] ), items ) )
+        offset = sum( len( item[ 'locations' ] ) for item in items )
       else:
         offset = 0
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -436,13 +436,12 @@ class YouCompleteMe:
 
     final_arguments = []
     for argument in arguments:
-      if isinstance( argument, str ):
-        if argument.startswith( 'ft=' ):
-          extra_data[ 'completer_target' ] = argument[ 3: ]
-          continue
-        elif argument.startswith( '--bufnr=' ):
-          extra_data[ 'bufnr' ] = int( argument[ len( '--bufnr=' ): ] )
-          continue
+      if argument.startswith( 'ft=' ):
+        extra_data[ 'completer_target' ] = argument[ 3: ]
+        continue
+      elif argument.startswith( '--bufnr=' ):
+        extra_data[ 'bufnr' ] = int( argument[ len( '--bufnr=' ): ] )
+        continue
 
       final_arguments.append( argument )
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -112,19 +112,20 @@ class YouCompleteMe:
     self._current_hierarchy = HierarchyTree()
 
 
-  def InitializeCurrentHierarchy( self, items, kind, direction ):
-    return self._current_hierarchy.SetRootNode( items, kind, direction )
+  def InitializeCurrentHierarchy( self, items, kind ):
+    return self._current_hierarchy.SetRootNode( items, kind )
 
 
-  def UpdateCurrentHierarchy( self, handle ):
-    items = self._ResolveHierarchyItem( handle )
-    self._current_hierarchy.UpdateHierarchy( handle, items )
-    return self._current_hierarchy.HierarchyToLines()
+  def UpdateCurrentHierarchy( self, handle : int, direction : str ):
+    items = self._ResolveHierarchyItem( handle, direction )
+    self._current_hierarchy.UpdateHierarchy( handle, items, direction )
+    offset = len( items ) if items is not None and direction == 'up' else 0
+    return self._current_hierarchy.HierarchyToLines(), offset
 
 
-  def _ResolveHierarchyItem( self, handle ):
+  def _ResolveHierarchyItem( self, handle : int, direction : str ):
     return SendCommandRequest(
-      self._current_hierarchy.ResolveArguments( handle ),
+      self._current_hierarchy.ResolveArguments( handle, direction ),
       '',
       self._user_options[ 'goto_buffer_command' ],
       extra_data = None,
@@ -132,8 +133,8 @@ class YouCompleteMe:
     )
 
 
-  def ShouldResolveItem( self, handle ):
-    return self._current_hierarchy.ShouldResolveItem( handle )
+  def ShouldResolveItem( self, handle : int, direction : str ):
+    return self._current_hierarchy.ShouldResolveItem( handle, direction )
 
 
   def ResetCurrentHierarchy( self ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -124,7 +124,7 @@ class YouCompleteMe:
       offset = len( items ) if items is not None and direction == 'up' else 0
       return self._current_hierarchy.HierarchyToLines(), offset
     else:
-      location = self._current_hierarchy.HandleToLocation( handle )
+      location = self._current_hierarchy.HandleToRootLocation( handle )
       kind = self._current_hierarchy._kind
       self._current_hierarchy.Reset()
       items = GetRawCommandResponse(
@@ -132,6 +132,8 @@ class YouCompleteMe:
         silent = False,
         location = location
       )
+      # [ 0 ] chooses the data for the 1st (and only) line.
+      # [ 1 ] chooses only the handle
       handle = self.InitializeCurrentHierarchy( items, kind )[ 0 ][ 1 ]
       return self.UpdateCurrentHierarchy( handle, direction )
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -35,7 +35,8 @@ from ycm.client.base_request import BaseRequest, BuildRequestData
 from ycm.client.completer_available_request import SendCompleterAvailableRequest
 from ycm.client.command_request import ( SendCommandRequest,
                                          SendCommandRequestAsync,
-                                         GetCommandResponse )
+                                         GetCommandResponse,
+                                         GetRawCommandResponse )
 from ycm.client.completion_request import CompletionRequest
 from ycm.client.resolve_completion_request import ResolveCompletionItem
 from ycm.client.signature_help_request import ( SignatureHelpRequest,
@@ -112,9 +113,7 @@ class YouCompleteMe:
     self._current_hierarchy = HierarchyTree()
 
 
-  def InitializeCurrentHierarchy( self, request_id, kind ):
-    items = self.GetCommandRequest( request_id ).Response()
-    self.FlushCommandRequest( request_id )
+  def InitializeCurrentHierarchy( self, items, kind ):
     return self._current_hierarchy.SetRootNode( items, kind )
 
 
@@ -128,23 +127,20 @@ class YouCompleteMe:
       location = self._current_hierarchy.HandleToLocation( handle )
       kind = self._current_hierarchy._kind
       self._current_hierarchy.Reset()
-      request_id = self.SendCommandRequestAsync(
+      items = GetRawCommandResponse(
         [ f'{ kind.title() }Hierarchy' ],
         silent = False,
         location = location
       )
-      handle = self.InitializeCurrentHierarchy( request_id, kind )[ 0 ][ 1 ]
+      handle = self.InitializeCurrentHierarchy( items, kind )[ 0 ][ 1 ]
       return self.UpdateCurrentHierarchy( handle, direction )
 
 
   def _ResolveHierarchyItem( self, handle : int, direction : str ):
-    request_id = self.SendCommandRequestAsync(
+    return GetRawCommandResponse(
       self._current_hierarchy.ResolveArguments( handle, direction ),
       silent = False
     )
-    response = self.GetCommandRequest( request_id ).Response()
-    self.FlushCommandRequest( request_id )
-    return response
 
 
   def ShouldResolveItem( self, handle : int, direction : str ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -121,7 +121,12 @@ class YouCompleteMe:
     if not self._current_hierarchy.UpdateChangesRoot( handle, direction ):
       items = self._ResolveHierarchyItem( handle, direction )
       self._current_hierarchy.UpdateHierarchy( handle, items, direction )
-      offset = len( items ) if items is not None and direction == 'up' else 0
+
+      if items is not None and direction == 'up':
+        offset = sum( map( lambda item: len( item[ 'locations' ] ), items ) )
+      else:
+        offset = 0
+
       return self._current_hierarchy.HierarchyToLines(), offset
     else:
       location = self._current_hierarchy.HandleToRootLocation( handle )

--- a/test/hierarchies.test.vim
+++ b/test/hierarchies.test.vim
@@ -17,67 +17,72 @@ function! Test_Call_Hierarchy()
 
   call youcompleteme#hierarchy#StartRequest( 'call' )
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
-  " Check that `+Function f` is at the start of the only line in the popup
+  " Check that `+Function f` is at the start of the only line in the popup.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-  call WaitForAssert( { -> assert_match( '^+Function: f', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call assert_match( '^+Function: f', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
 
-  silent call feedkeys( "\<Tab>", "xt" )
-  " Check that f's callers are present
+  call feedkeys( "\<Tab>", "xt" )
+  " Check that f's callers are present.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
-  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
+  call assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] )
 
-  silent call feedkeys( "\<Down>\<Tab>", "xt" )
-  " Check that g's callers are present
+  call feedkeys( "\<Down>\<Tab>", "xt" )
+  " Check that g's callers are present.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^    +Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+  call assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
+  call assert_match( '^    +Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] )
+  call assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] )
 
+  " silent, because h has no incoming calls.
   silent call feedkeys( "\<Down>\<Down>\<Tab>", "xt" )
-  " Check that 1st h's callers are present
+  " Check that 1st h's callers are present.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+  call assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
+  call assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] )
+  call assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] )
 
+  " silent, because h has no incoming calls.
   silent call feedkeys( "\<Down>\<Tab>", "xt" )
-  " Check that 2nd h's callers are present
+  " Check that 2nd h's callers are present.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+  call assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
+  call assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] )
+  call assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] )
 
+  " silent, because clangd does not support outgoing calls.
   silent call feedkeys( "\<Up>\<Up>\<Up>\<Up>\<S-Tab>", "xt" )
-  " Try to access callees of f
+  " Try to access callees of f.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-  call WaitForAssert( { -> assert_match( '^-Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+  call assert_match( '^-Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
+  call assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] )
+  call assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] )
 
+  " silent, because clangd does not support outgoing calls.
   silent call feedkeys( "\<Down>\<Down>\<Down>\<Down>\<S-Tab>", "xt" )
-  " Re-root at h
+  " Re-root at h.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-  call WaitForAssert( { -> assert_match( '^+Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[0] ) } )
+  call assert_match( '^+Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[0] )
 
+  " silent, because clangd does not support outgoing calls.
   silent call feedkeys( "\<S-Tab>\<Tab>", "xt" )
   " Expansion after re-rooting works.
   " NOTE: Clangd does not support outgoing calls, hence, we are stuck at just h.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-  call WaitForAssert( { -> assert_match( '^-Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call assert_match( '^-Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
 
   call feedkeys( "\<C-c>", "xt" )
-  " Make sure it is closed
+  " Make sure it is closed.
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
 
   %bwipe!
@@ -89,61 +94,64 @@ function! Test_Type_Hierarchy()
 
   call youcompleteme#hierarchy#StartRequest( 'type' )
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
-  " Check that `+Function f` is at the start of the only line in the popup
+  " Check that `+Struct: B1` is at the start of the only line in the popup.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-  call WaitForAssert( { -> assert_match( '^+Struct: B1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call assert_match( '^+Struct: B1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
 
-  silent call feedkeys( "\<Tab>", "xt" )
-  " Check that B1's subtypes are present
+  call feedkeys( "\<Tab>", "xt" )
+  " Check that B1's subtypes are present.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
-  call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
 
+  " silent, because D1 has no subtypes.
   silent call feedkeys( "\<Down>\<Tab>", "xt" )
-  " Try to access D1's subtypes
+  " Try to access D1's subtypes.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
-  call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
 
-  silent call feedkeys( "\<Up>\<S-Tab>", "xt" )
-  " Check that 1st h's callers are present
+  call feedkeys( "\<Up>\<S-Tab>", "xt" )
+  " Check that B1's supertypes are present.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
 
+  " silent, because there are no supertypes of B0.
   silent call feedkeys( "\<Up>\<S-Tab>", "xt" )
-  " Check that 2nd h's callers are present
+  " Try to access B0's supertypes.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-  call WaitForAssert( { -> assert_match( '^  -Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call assert_match( '^  -Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
 
-  silent call feedkeys( "\<Tab>", "xt" )
-  " Re-root at B0: supertypes->subtypes
+  call feedkeys( "\<Tab>", "xt" )
+  " Re-root at B0: supertypes->subtypes.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
-  call WaitForAssert( { -> assert_match( '^+Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: D0.*:15', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call assert_match( '^+Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  +Struct: D0.*:15', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
+  call assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] )
 
-  silent call feedkeys( "\<Down>\<Down>\<Down>\<S-Tab>", "xt" )
-  " Re-root at D1: subtypes->supertypes
+  call feedkeys( "\<Down>\<Down>\<Down>\<S-Tab>", "xt" )
+  " Re-root at D1: subtypes->supertypes.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^+Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^+Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
 
+  " silent, because there are no subtypes of D1.
   silent call feedkeys( "\<Tab>\<Up>\<S-Tab>", "xt" )
   " Expansion after re-rooting works.
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
-  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^    +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^  -Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-  call WaitForAssert( { -> assert_match( '^-Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] )
+  call assert_match( '^    +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] )
+  call assert_match( '^  -Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] )
+  call assert_match( '^-Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] )
 
   call feedkeys( "\<C-c>", "xt" )
-  " Make sure it is closed
+  " Make sure it is closed.
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
 
   %bwipe!

--- a/test/hierarchies.test.vim
+++ b/test/hierarchies.test.vim
@@ -1,0 +1,178 @@
+function! SetUp()
+  let g:ycm_auto_hover = 1
+  let g:ycm_auto_trigger = 1
+  let g:ycm_keep_logfiles = 1
+  let g:ycm_log_level = 'DEBUG'
+
+  call youcompleteme#test#setup#SetUp()
+endfunction
+
+function! TearDown()
+  call youcompleteme#test#setup#CleanUp()
+endfunction
+
+function! Test_Call_Hierarchy()
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
+  call cursor( [ 1, 5 ] )
+
+  " Check that f's callers are present
+  function! Check1( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check2' ) )
+  endfunction
+
+  " Check that g's callers are present
+  function! Check2( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^    +Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Down>\<Down>\<Tab>", funcref( 'Check8' ) )
+  endfunction
+
+  " Check that 1st h's callers are present
+  function! Check3( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check4' ) )
+  endfunction
+
+  " Check that 2nd h's callers are present
+  function! Check4( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Up>\<Up>\<Up>\<Up>\<S-Tab>", funcref( 'Check5' ) )
+  endfunction
+
+  " Try to access callees of f
+  function! Check5( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+    call WaitForAssert( { -> assert_match( '^-Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Down>\<Down>\<Down>\<Down>\<S-Tab>", funcref( 'Check6' ) )
+  endfunction
+
+  " Re-root at h
+  function! Check6( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+    call WaitForAssert( { -> assert_match( '^+Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 ) ) } )
+    call FeedAndCheckAgain( "\<S-Tab>\<Tab>", funcref( 'Check7' ) )
+  endfunction
+
+  " Expansion after re-rooting works.
+  " NOTE: Clangd does not support outgoing calls, hence, we are stuck at just h.
+  function! Check7( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+    call WaitForAssert( { -> assert_match( '^-Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 ) ) } )
+    call FeedAndCheckAgain( "\<C-c>", funcref( 'Check8' ) )
+  endfunction
+
+  " Make sure it is closed
+  function! Check8( id )
+    call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
+  endfunction
+
+  call youcompleteme#hierarchy#StartRequest( 'call' )
+  call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
+  " Check that `+Function f` is at the start of the only line in the popup
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call FeedAndCheckMain( "\<Tab>", funcref( 'Check1' ) )
+endfunction
+
+function! Test_Type_Hierarchy()
+  "call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
+  call cursor( [ 13, 8 ] )
+
+  " Check that B1's subtypes are present
+  function! Check1( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
+    call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check2' ) )
+  endfunction
+
+  " Try to access D1's subtypes
+  function! Check2( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
+    call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Up>\<S-Tab>", funcref( 'Check3' ) )
+  endfunction
+
+  " Check that 1st h's callers are present
+  function! Check3( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Up>\<S-Tab>", funcref( 'Check4' ) )
+  endfunction
+
+  " Check that 2nd h's callers are present
+  function! Check4( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+    call WaitForAssert( { -> assert_match( '^  -Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check5' ) )
+  endfunction
+
+  " Re-root at B0: supertypes->subtypes
+  function! Check5( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+    call WaitForAssert( { -> assert_match( '^+Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: D0.*:15', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Down>\<Down>\<Down>\<S-Tab>", funcref( 'Check6' ) )
+  endfunction
+
+  " Re-root at D1: subtypes->supertypes
+  function! Check6( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^+Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<Tab>\<Up>\<S-Tab>", funcref( 'Check7' ) )
+  endfunction
+
+  " Expansion after re-rooting works.
+  function! Check7( id )
+    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^    +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^  -Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+    call WaitForAssert( { -> assert_match( '^-Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+    call FeedAndCheckAgain( "\<C-c>", funcref( 'Check7' ) )
+  endfunction
+
+  " Make sure it is closed
+  function! Check8( id )
+    call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
+  endfunction
+
+  call youcompleteme#hierarchy#StartRequest( 'type' )
+  call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
+  " Check that `+Function f` is at the start of the only line in the popup
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: B1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call FeedAndCheckMain( "\<Tab>", funcref( 'Check1' ) )
+endfunction

--- a/test/hierarchies.test.vim
+++ b/test/hierarchies.test.vim
@@ -15,164 +15,136 @@ function! Test_Call_Hierarchy()
   call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
   call cursor( [ 1, 5 ] )
 
-  " Check that f's callers are present
-  function! Check1( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check2' ) )
-  endfunction
-
-  " Check that g's callers are present
-  function! Check2( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    +Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Down>\<Tab>", funcref( 'Check8' ) )
-  endfunction
-
-  " Check that 1st h's callers are present
-  function! Check3( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check4' ) )
-  endfunction
-
-  " Check that 2nd h's callers are present
-  function! Check4( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Up>\<Up>\<Up>\<Up>\<S-Tab>", funcref( 'Check5' ) )
-  endfunction
-
-  " Try to access callees of f
-  function! Check5( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^-Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Down>\<Down>\<Down>\<S-Tab>", funcref( 'Check6' ) )
-  endfunction
-
-  " Re-root at h
-  function! Check6( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 ) ) } )
-    call FeedAndCheckAgain( "\<S-Tab>\<Tab>", funcref( 'Check7' ) )
-  endfunction
-
-  " Expansion after re-rooting works.
-  " NOTE: Clangd does not support outgoing calls, hence, we are stuck at just h.
-  function! Check7( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-    call WaitForAssert( { -> assert_match( '^-Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 ) ) } )
-    call FeedAndCheckAgain( "\<C-c>", funcref( 'Check8' ) )
-  endfunction
-
-  " Make sure it is closed
-  function! Check8( id )
-    call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
-  endfunction
-
   call youcompleteme#hierarchy#StartRequest( 'call' )
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
   " Check that `+Function f` is at the start of the only line in the popup
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
   call WaitForAssert( { -> assert_match( '^+Function: f', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call FeedAndCheckMain( "\<Tab>", funcref( 'Check1' ) )
+
+  silent call feedkeys( "\<Tab>", "xt" )
+  " Check that f's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Tab>", "xt" )
+  " Check that g's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    +Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Down>\<Tab>", "xt" )
+  " Check that 1st h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Tab>", "xt" )
+  " Check that 2nd h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Up>\<Up>\<Up>\<Up>\<S-Tab>", "xt" )
+  " Try to access callees of f
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^-Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Down>\<Down>\<Down>\<S-Tab>", "xt" )
+  " Re-root at h
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[0] ) } )
+
+  silent call feedkeys( "\<S-Tab>\<Tab>", "xt" )
+  " Expansion after re-rooting works.
+  " NOTE: Clangd does not support outgoing calls, hence, we are stuck at just h.
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+  call WaitForAssert( { -> assert_match( '^-Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+
+  call feedkeys( "\<C-c>", "xt" )
+  " Make sure it is closed
+  call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
+
+  %bwipe!
 endfunction
 
 function! Test_Type_Hierarchy()
-  "call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
   call cursor( [ 13, 8 ] )
-
-  " Check that B1's subtypes are present
-  function! Check1( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check2' ) )
-  endfunction
-
-  " Try to access D1's subtypes
-  function! Check2( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Up>\<S-Tab>", funcref( 'Check3' ) )
-  endfunction
-
-  " Check that 1st h's callers are present
-  function! Check3( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Up>\<S-Tab>", funcref( 'Check4' ) )
-  endfunction
-
-  " Check that 2nd h's callers are present
-  function! Check4( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check5' ) )
-  endfunction
-
-  " Re-root at B0: supertypes->subtypes
-  function! Check5( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: D0.*:15', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Down>\<Down>\<S-Tab>", funcref( 'Check6' ) )
-  endfunction
-
-  " Re-root at D1: subtypes->supertypes
-  function! Check6( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Tab>\<Up>\<S-Tab>", funcref( 'Check7' ) )
-  endfunction
-
-  " Expansion after re-rooting works.
-  function! Check7( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^-Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<C-c>", funcref( 'Check7' ) )
-  endfunction
-
-  " Make sure it is closed
-  function! Check8( id )
-    call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
-  endfunction
 
   call youcompleteme#hierarchy#StartRequest( 'type' )
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
   " Check that `+Function f` is at the start of the only line in the popup
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
   call WaitForAssert( { -> assert_match( '^+Struct: B1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call FeedAndCheckMain( "\<Tab>", funcref( 'Check1' ) )
+
+  silent call feedkeys( "\<Tab>", "xt" )
+  " Check that B1's subtypes are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Tab>", "xt" )
+  " Try to access D1's subtypes
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Up>\<S-Tab>", "xt" )
+  " Check that 1st h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Up>\<S-Tab>", "xt" )
+  " Check that 2nd h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Tab>", "xt" )
+  " Re-root at B0: supertypes->subtypes
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: D0.*:15', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Down>\<Down>\<S-Tab>", "xt" )
+  " Re-root at D1: subtypes->supertypes
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Tab>\<Up>\<S-Tab>", "xt" )
+  " Expansion after re-rooting works.
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^-Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+
+  call feedkeys( "\<C-c>", "xt" )
+  " Make sure it is closed
+  call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
+
+  %bwipe!
 endfunction

--- a/test/hover.test.vim
+++ b/test/hover.test.vim
@@ -71,7 +71,7 @@ let s:cpp_lifetime = {
       \             '',
       \             'Type: char',
       \             'Offset: 16 bytes',
-      \             'Size: 1 byte (+7 bytes padding)',
+      \             'Size: 1 byte (+7 bytes padding), alignment 1 byte',
       \             'nobody will live > 128 years',
       \             '',
       \             '// In PointInTime',

--- a/test/testdata/cpp/hierarchies.cc
+++ b/test/testdata/cpp/hierarchies.cc
@@ -1,0 +1,16 @@
+int f();
+
+int g() {
+    return f() + f();
+}
+
+int h() {
+    int x = g();
+    return f() + x;
+}
+
+struct B0 {};
+struct B1 : B0 {};
+
+struct D0 : B0 {};
+struct D1 : B0, B1 {};


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This is the client side pull request related to ycm-core/ycmd#1733

Again, tests and documentations are missing.  Documentation is the easy part, but tests would be dreadful...


#### popup look

I have not paid much attention to the look of the popup.
The look is slightly off - for deep hierarchies  the location of references in the file (`foo.cpp:8` for example) becomes misaligned.
The context is is not right aligned either.

Basically, it's functional but ugly. If someone would be up for it, please send patches my way.

#### How to use this thing?

The only publicly available function here is `youcompleteme#hierarchy#StartRequest( kind )`. It takes `'call'` or `'type'` as the argyment. From there, YCM will fire a "prepare hierarchy" request and then open a popup with the results.

While the popup is open, the following keys are used:

- `<Tab>` to resolve a hierarchy item in the "subtypes" / "incoming" direction.
-  `<S-Tab>` to resolve a hierarchy item in the "supertypes"/"outgoing" direction.
- `<Up>`/`<Down>` to select items in the popup.
- `<CR>` to jump to the selected item and close the popup.
- `<Esc>` to close the popup without jumping.

Maybe we want more key bindings here? `<C-n>`/`<C-p>` and `j`/`k` come to mind...

Oh yes, there's also `<plug>(YCMCallHierarchy)` and `<plug>(YCMTypeHierarchy)` that just call `youcompletem#hierarchy#StartRequest()`. Users should be using these, instead of directly calling the function.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4221)
<!-- Reviewable:end -->
