### PR TITLE
Remove extra backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -2678,7 +2678,7 @@ number like `99`.
 When `g:ycm_auto_trigger` is `0`, YCM sets the `completefunc`, so that you can
 manually trigger normal completion using `C-x C-u`.
 
-If you want to map something else to trigger completion, such as `C-d``,
+If you want to map something else to trigger completion, such as `C-d`,
 then you can map it to `<plug>(YCMComplete)`. For example:
 
 ```viml


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fixes extra backtick in README.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4225)
<!-- Reviewable:end -->
