### PR TITLE
Add new semantic token types

### DIFF
--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -50,10 +50,12 @@ HIGHLIGHT_GROUP = {
   'number': 'Number',
   'regexp': 'String',
   'operator': 'Operator',
+  'decorator': 'Special',
   'unknown': 'Normal',
 
   # These are not part of the spec, but are used by clangd
   'bracket': 'Normal',
+  'concept': 'Type',
   # These are not part of the spec, but are used by jdt.ls
   'annotation': 'Macro',
 }


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The `decorator` type was introduced in LSP 1.17.
The `concept` type is used by clangd.

Reported by @amosnier on gitter.
The mapped value is just the first thing that came to my mind. Feel free to suggest bette alternatives.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4232)
<!-- Reviewable:end -->
