### PR TITLE
remove usage of walrus operator

### DIFF
--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -28,7 +28,8 @@ class HierarchyNode:
 
 
   def ToRootLocation( self, subindex : int ):
-    if location := self._data.get( 'root_location' ):
+    location = self._data.get( 'root_location' )
+    if location:
       file = location[ 'filepath' ]
       line = location[ 'line_num' ]
       column = location[ 'column_num' ]


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

The usage of walrus operator makes ycm unavailable for Python version under 3.8, which is inconsistent with the requirements in install.py

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4244)
<!-- Reviewable:end -->
