### PR TITLE
[READY] Use setlocal for temporary completeopt adjustment

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1357,7 +1357,7 @@ function! s:Complete()
   endif
   if len( s:completion.completions )
     let old_completeopt = &completeopt
-    set completeopt+=noselect
+    setlocal completeopt+=noselect
     call complete( s:completion.completion_start_column,
                  \ s:completion.completions )
     let &completeopt = old_completeopt


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Since vim 9.1.0469, completeopt is a global-local option. 
When adding `noselect`, we need to treat `completeopt` as local and use `setlocal`.
This works for 9.1.0016 as well and allows users to freely mess with buffer-local `completeopt`
without messing up YCM completions.

Fixes #4261 

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4264)
<!-- Reviewable:end -->
