### PR TITLE
fix: Add safety check for b:ycm_hover

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1664,7 +1664,7 @@ if exists( '*popup_atcursor' )
   function! s:ShowHoverResult( response )
     call popup_hide( s:cursorhold_popup )
 
-    if empty( a:response )
+    if empty( a:response ) || !exists( 'b:ycm_hover' )
       return
     endif
 


### PR DESCRIPTION
# PR Prelude
- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
The function s:ShowHoverResult() assumes b:ycm_hover always exists when processing hover responses. However, this assumption is unsafe, and leads to errors like this:
```shell
Error detected while processing function <SNR>151_PollCommands[30]..<SNR>151_ShowHoverResult:
line   36:
E121: Undefined variable: b:ycm_hover
Error detected while processing function <SNR>151_PollCommands[30]..<SNR>151_ShowHoverResult:
line   36:
E116: Invalid arguments for function has_key( b:ycm_hover, 'popup_params' )
Error detected while processing function <SNR>151_PollCommands[30]..<SNR>151_ShowHoverResult:
line   42:
E121: Undefined variable: b:ycm_hover
Error detected while processing function <SNR>151_PollCommands[30]..<SNR>151_ShowHoverResult:
line   42:
E116: Invalid arguments for function setbufvar
```
So I added a check for the existence of a variable.